### PR TITLE
Add obvious properties of thin categories

### DIFF
--- a/database/data/005_implications/004_morphism-behavior-implications.sql
+++ b/database/data/005_implications/004_morphism-behavior-implications.sql
@@ -133,10 +133,10 @@ VALUES
 	FALSE
 ),
 (
-	'thin_implies_one-way',
+	'thin_consequences',
 	'["thin"]',
-	'["one-way"]',
-	'This is trivial.',
+	'["one-way", "locally essentially small", "generating set"]',
+	'This is trivial. The empty set is generating.',
 	FALSE
 ),
 (


### PR DESCRIPTION
This is a continuation of https://github.com/ScriptRaccoon/CatDat/pull/78 in some sense. Thin categories have a generating set (the empty set), hence a cogenerating set as well, and are locally essentially small (not necessarily locally small). These properties have been added. This brings the current number of **465** missing combinations down to **458**.