### PR TITLE
Improve functor navigation

### DIFF
--- a/src/components/StructureSelector.svelte
+++ b/src/components/StructureSelector.svelte
@@ -10,10 +10,8 @@
 	let { structure }: Props = $props()
 
 	function handle_change() {
-		goto(`/${value}`)
+		goto(`/${structure}`)
 	}
-
-	let value = $derived(structure)
 </script>
 
 <label for="structure_selector">Structure</label>

--- a/src/components/StructureSelector.svelte
+++ b/src/components/StructureSelector.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
+	import { page } from '$app/state'
 	import { STRUCTURES } from '$lib/client/config'
 	import type { Structure } from '$lib/commons/types'
 
@@ -10,7 +11,18 @@
 	let { structure }: Props = $props()
 
 	function handle_change() {
-		goto(`/${structure}`)
+		const path = page.url.pathname
+		const singular = structure === 'categories' ? 'category' : 'functor'
+
+		if (path.endsWith('-implications')) {
+			goto(`/${singular}-implications`)
+		} else if (path.endsWith('-properties')) {
+			goto(`/${singular}-properties`)
+		} else if (path.endsWith('-search')) {
+			goto(`/${singular}-search`)
+		} else {
+			goto(`/${structure}`)
+		}
 	}
 </script>
 

--- a/src/routes/categories/+page.svelte
+++ b/src/routes/categories/+page.svelte
@@ -20,7 +20,7 @@
 	)
 </script>
 
-<MetaData title="List of categories" description="All available categories" />
+<MetaData title="List of categories" />
 
 <section>
 	<h2>List of categories</h2>

--- a/src/routes/categories/[tag]/+page.svelte
+++ b/src/routes/categories/[tag]/+page.svelte
@@ -6,10 +6,7 @@
 	let { data } = $props()
 </script>
 
-<MetaData
-	title="List of categories tagged with '{data.tag}'"
-	description="Categories tagged with '{data.tag}'"
-/>
+<MetaData title="List of categories tagged with '{data.tag}'" />
 
 <h2>List of categories tagged with '{data.tag}'</h2>
 

--- a/src/routes/category-comparison/[...ids]/+page.svelte
+++ b/src/routes/category-comparison/[...ids]/+page.svelte
@@ -37,10 +37,7 @@
 	})
 </script>
 
-<MetaData
-	title="Comparison of categories"
-	description={compared_categories.map((c) => c.name).join(', ')}
-/>
+<MetaData title="Comparison of categories" />
 
 <h2>Comparison of categories</h2>
 

--- a/src/routes/category-implications/+page.svelte
+++ b/src/routes/category-implications/+page.svelte
@@ -38,12 +38,9 @@
 	)
 </script>
 
-<MetaData
-	title="List of implications"
-	description="Implications of categorical properties"
-/>
+<MetaData title="Implications of categories" />
 
-<h2>List of implications</h2>
+<h2>Implications of categories</h2>
 
 <SearchFilter bind:search />
 

--- a/src/routes/category-properties/+page.svelte
+++ b/src/routes/category-properties/+page.svelte
@@ -18,12 +18,9 @@
 	)
 </script>
 
-<MetaData
-	title="List of properties of categories"
-	description="All categorical properties"
-/>
+<MetaData title="Properties of categories" />
 
-<h2>List of properties of categories</h2>
+<h2>Properties of categories</h2>
 
 <SearchFilter bind:search />
 

--- a/src/routes/contribute/+page.svelte
+++ b/src/routes/contribute/+page.svelte
@@ -3,7 +3,7 @@
 	import SuggestionForm from '$components/SuggestionForm.svelte'
 </script>
 
-<MetaData title="How to contribute" description="Options to contribute to CatDat" />
+<MetaData title="How to contribute to CatDat" />
 
 <h2>How to contribute</h2>
 

--- a/src/routes/functor-implications/+page.svelte
+++ b/src/routes/functor-implications/+page.svelte
@@ -7,12 +7,9 @@
 	let { data } = $props()
 </script>
 
-<MetaData
-	title="List of implications of functors"
-	description="Implications of functorial properties"
-/>
+<MetaData title="Implications of functors" />
 
-<h2>List of implications of functors</h2>
+<h2>Implications of functors</h2>
 
 <!-- TODO: add search feature if the list grows in the future -->
 <!-- TODO: add dualized-toggle if the list grows in the future -->

--- a/src/routes/functor-properties/+page.svelte
+++ b/src/routes/functor-properties/+page.svelte
@@ -7,10 +7,7 @@
 	let { data } = $props()
 </script>
 
-<MetaData
-	title="List of properties of functors"
-	description="All functorial properties"
-/>
+<MetaData title="Properties of functors" />
 
 <h2>Properties of Functors</h2>
 

--- a/src/routes/functors/+page.svelte
+++ b/src/routes/functors/+page.svelte
@@ -9,7 +9,7 @@
 	let { data } = $props()
 </script>
 
-<MetaData title="List of functors" description="All available functors" />
+<MetaData title="List of functors" />
 
 <h2>List of functors</h2>
 

--- a/src/routes/missing/+page.svelte
+++ b/src/routes/missing/+page.svelte
@@ -10,7 +10,7 @@
 
 <MetaData
 	title="Missing data in CatDat"
-	description="Missing properties, missing special morphisms, and more."
+	description="Missing properties, missing special morphisms, missing combinations, and more."
 />
 
 <h2>Missing data</h2>

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -2,9 +2,9 @@
 	import MetaData from '$components/MetaData.svelte'
 </script>
 
-<MetaData title="Resources" description="Resources on category theory" />
+<MetaData title="Resources on Category Theory" />
 
-<h2>Resources</h2>
+<h2>Resources on Category Theory</h2>
 
 <p>This is an (incomplete) list of resources on category theory.</p>
 


### PR DESCRIPTION
This PR fixes https://github.com/ScriptRaccoon/CatDat/issues/86.

When a user is on `/category-properties` and changes the structure to functors, they are now redirected to `/functor-properties`, and vice versa.

Same with `/category-search` (which redirects to `/functor-search`) and `/category-implications` (which redirects to `/functor-implications`).

When the user is on a different page, say the detail page of a category, and then changes the structure to functors, they are redirected to `/functors` (the list page) exactly as before: there is no corresponding functor page.