### PR TITLE
Enforce that the trivial category has no unsatisfied properties

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ When contributing new data (categories, functors, properties, implications), ple
 
 - **Counterexamples**: Ensure that at least one category does not satisfy any new property of categories that is added. If no existing category fits, add a new category that does not have the new property. The same remarks apply to properties of functors.
 
-- **Positive Properties**: Do not add negated properties to the database. For example, do not add "large" as the negation of "small". Instead, add "small" to the list of unsatisfied properties for a category. As a rule of thumb, every registered property of categories should be satisfied at least by the trivial category. Similarly, every property of functors should be satisfied at least by the identity functor.
+- **Positive Properties**: Do not add negated properties to the database. For example, do not add "large" as the negation of "small". Instead, add "small" to the list of unsatisfied properties for a category. Every registered property of categories should be satisfied at least by the trivial category. Similarly, every property of functors should be satisfied at least by the identity functor.
 
 - **Proofs for Claims**: Provide proofs for all new claims (satisfied properties, unsatisfied properties, implications, special morphisms). (We are currently working on filling in the existing ones.)
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -21,6 +21,7 @@ async function execute_tests() {
 	await test_mutual_category_duals()
 	await test_mutual_property_duals()
 	await test_decided_categories()
+	await test_properties_of_trivial_category()
 	await test_properties_of_core_categories()
 }
 
@@ -112,6 +113,24 @@ async function test_decided_category(category_id: string) {
 	}
 
 	console.info(`✅ All properties have been decided for ${category_id}`)
+}
+
+/**
+ * Tests that the trivial category has no unsatisfied property.
+ * This enforces that all properties in the database are "positive".
+ */
+async function test_properties_of_trivial_category() {
+	const res = await db.execute(`
+		SELECT property_id FROM category_property_assignments
+		WHERE category_id = '1' AND is_satisfied = FALSE
+	`)
+	if (res.rows.length > 0) {
+		throw new Error(
+			`❌ The trivial category has ${res.rows.length} unsatisfied properties, but it should have 0.`,
+		)
+	}
+
+	console.info(`✅ The trivial category has no unsatisfied properties`)
 }
 
 /**


### PR DESCRIPTION
This small PR adds a test (included in `pnpm db:test`) that confirms that the trivial category has no unsatisfied properties. Together with the existing test that all properties are decided for it, this means that every property is satisfied for the trivial category. This enforces that all properties in the database are "positive". For example, it prevents that "infinite" is added (we use "finite" instead). This was already documented in the contribution guidelines, but now it's properly enforced.

There is a small chance that I regret this decision at some point, but then the easy fix is to add the trivial category to the core categories (currently: Set, Top, Ab) for which every property is checked (satisfied or not).