### PR TITLE
Improve reason generation

### DIFF
--- a/databases/catdat/data/003_properties/001_relations.sql
+++ b/databases/catdat/data/003_properties/001_relations.sql
@@ -1,8 +1,8 @@
-INSERT INTO relations (relation, negation) VALUES
-('is', 'is not'),
-('is a', 'is not a'),
-('is an', 'is not an'),
-('has', 'does not have'),
-('has a', 'does not have a'),
-('has an', 'does not have an'),
-('satisfies', 'does not satisfy');
+INSERT INTO relations (relation, negation, conditional) VALUES
+('is', 'is not', 'would be'),
+('is a', 'is not a', 'would be a'),
+('is an', 'is not an', 'would be an'),
+('has', 'does not have', 'would have'),
+('has a', 'does not have a', 'would have a'),
+('has an', 'does not have an', 'would have an'),
+('satisfies', 'does not satisfy', 'would satisfy');

--- a/databases/catdat/migrations/019_conditional-relation.sql
+++ b/databases/catdat/migrations/019_conditional-relation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE relations ADD COLUMN conditional TEXT NOT NULL DEFAULT 'would be'; 

--- a/databases/catdat/scripts/deduce-category-properties.ts
+++ b/databases/catdat/scripts/deduce-category-properties.ts
@@ -362,14 +362,26 @@ async function deduce_unsatisfied_category_properties(
 		unsatisfied_properties.add(property)
 		deduced_unsatisfied_props.push(property)
 
-		const assumption_string = get_assumption_string(implication, properties_dict)
-		const conclusion_string = get_conclusion_string(implication, properties_dict)
+		const assumption_string = get_assumption_string(
+			implication,
+			properties_dict,
+			true,
+		)
+		const conclusion_string = get_conclusion_string(
+			implication,
+			properties_dict,
+			true,
+		)
+
+		const has_multiple_assumptions = implication.assumptions.size > 1
 
 		const ref = `(see <a href="/category-implication/${implication_id}">here</a>)`
 
-		const reason =
-			`Assume that it ${properties_dict[property].relation} ${property}. ` +
-			`But since it ${assumption_string}, it ${conclusion_string} ${ref} – contradiction.`
+		const contra = `Assume for contradiction that it ${properties_dict[property].relation} ${property}`
+
+		const reason = has_multiple_assumptions
+			? `${contra}. Then it ${assumption_string}, so it ${conclusion_string} ${ref} – contradiction.`
+			: `${contra}. Then it ${conclusion_string} ${ref} – contradiction.`
 
 		reasons[property] = reason
 	}

--- a/databases/catdat/scripts/deduce-category-properties.ts
+++ b/databases/catdat/scripts/deduce-category-properties.ts
@@ -271,8 +271,8 @@ async function deduce_satisfied_category_properties(
 		const assumption_string = get_assumption_string(implication, properties_dict)
 		const conclusion_string = get_conclusion_string(implication, properties_dict)
 
-		const ref = `(see <a href="/category-implication/${implication_id}">here</a>)`
-		const reason = `Since it ${assumption_string}, it ${conclusion_string} ${ref}.`
+		const ref = `by <a href="/category-implication/${implication_id}">this result</a>`
+		const reason = `Since it ${assumption_string}, it ${conclusion_string} (${ref}).`
 
 		reasons[conclusion] = reason
 	}
@@ -375,13 +375,13 @@ async function deduce_unsatisfied_category_properties(
 
 		const has_multiple_assumptions = implication.assumptions.size > 1
 
-		const ref = `(see <a href="/category-implication/${implication_id}">here</a>)`
+		const ref = `by <a href="/category-implication/${implication_id}">this result</a>`
 
 		const contra = `Assume for contradiction that it ${properties_dict[property].relation} ${property}`
 
 		const reason = has_multiple_assumptions
-			? `${contra}. Then it ${assumption_string}, so it ${conclusion_string} ${ref} – contradiction.`
-			: `${contra}. Then it ${conclusion_string} ${ref} – contradiction.`
+			? `${contra}. Then it ${assumption_string}, so it ${conclusion_string} (${ref}) – contradiction.`
+			: `${contra}. Then it ${conclusion_string} (${ref}) – contradiction.`
 
 		reasons[property] = reason
 	}

--- a/databases/catdat/scripts/deduce-category-properties.ts
+++ b/databases/catdat/scripts/deduce-category-properties.ts
@@ -12,9 +12,12 @@ type CategoryMeta = {
 	dual_category_id: string | null
 }
 
-type PropertyMeta = {
+type CategoryPropertyMeta = {
 	id: string
 	dual_property_id: string | null
+	relation: string
+	negation: string
+	conditional: string
 }
 
 /**
@@ -41,6 +44,7 @@ export async function deduce_category_properties(db: Client) {
 				category.id,
 				implications,
 				decided_properties[category.id].satisfied,
+				properties_dict,
 			)
 			await deduce_unsatisfied_category_properties(
 				tx,
@@ -48,6 +52,7 @@ export async function deduce_category_properties(db: Client) {
 				implications,
 				decided_properties[category.id].satisfied,
 				decided_properties[category.id].unsatisfied,
+				properties_dict,
 			)
 		}
 
@@ -74,6 +79,7 @@ export async function deduce_category_properties(db: Client) {
 				category.id,
 				implications,
 				decided_properties[category.id].satisfied,
+				properties_dict,
 				{ check_conflicts: false },
 			)
 			await deduce_unsatisfied_category_properties(
@@ -82,6 +88,7 @@ export async function deduce_category_properties(db: Client) {
 				implications,
 				decided_properties[category.id].satisfied,
 				decided_properties[category.id].unsatisfied,
+				properties_dict,
 				{ check_conflicts: false },
 			)
 		}
@@ -116,16 +123,7 @@ async function get_normalized_category_implications(
 			v.id,
             v.assumptions,
             v.conclusions,
-            v.is_equivalence,
-            (
-                SELECT json_group_object(p.id, p.relation)
-                FROM properties p
-                WHERE p.id IN (
-                    SELECT value FROM json_each(v.assumptions)
-                    UNION
-                    SELECT value FROM json_each(v.conclusions)
-                )
-            ) AS relations
+            v.is_equivalence
         FROM implications_view v
     `)
 
@@ -134,7 +132,6 @@ async function get_normalized_category_implications(
 		assumptions: string
 		conclusions: string
 		is_equivalence: number
-		relations: string
 	}[]
 
 	const implications: NormalizedCategoryImplication[] = []
@@ -142,14 +139,12 @@ async function get_normalized_category_implications(
 	for (const impl of all_implications_db) {
 		const assumptions: string[] = JSON.parse(impl.assumptions)
 		const conclusions: string[] = JSON.parse(impl.conclusions)
-		const relations: Record<string, string> = JSON.parse(impl.relations)
 
 		for (const conclusion of conclusions) {
 			implications.push({
 				id: impl.id,
 				assumptions: new Set(assumptions),
 				conclusion,
-				relations,
 			})
 		}
 
@@ -159,7 +154,6 @@ async function get_normalized_category_implications(
 					id: impl.id,
 					assumptions: new Set(conclusions),
 					conclusion: assumption,
-					relations,
 				})
 			}
 		}
@@ -184,17 +178,18 @@ async function get_categories(tx: Transaction) {
  */
 async function get_properties_dict(tx: Transaction) {
 	const res = await tx.execute(`
-		SELECT p.id, p.dual_property_id
+		SELECT
+			p.id, p.dual_property_id, p.relation,
+			r.negation, r.conditional
 		FROM properties p
+		INNER JOIN relations r ON r.relation = p.relation
 		ORDER BY lower(p.id)
 	`)
-	const rows = res.rows as unknown as PropertyMeta[]
+	const rows = res.rows as unknown as CategoryPropertyMeta[]
 
-	const dict: Record<string, PropertyMeta> = {}
+	const dict: Record<string, CategoryPropertyMeta> = {}
 
-	for (const p of rows) {
-		dict[p.id] = p
-	}
+	for (const p of rows) dict[p.id] = p
 
 	return dict
 }
@@ -254,6 +249,7 @@ async function deduce_satisfied_category_properties(
 	category_id: string,
 	implications: NormalizedCategoryImplication[],
 	satisfied_properties: Set<string>,
+	properties_dict: Record<string, CategoryPropertyMeta>,
 	options: { check_conflicts: boolean } = { check_conflicts: true },
 ) {
 	const deduced_satisfied_props: string[] = []
@@ -272,8 +268,8 @@ async function deduce_satisfied_category_properties(
 		satisfied_properties.add(conclusion)
 		deduced_satisfied_props.push(conclusion)
 
-		const assumption_string = get_assumption_string(implication)
-		const conclusion_string = get_conclusion_string(implication)
+		const assumption_string = get_assumption_string(implication, properties_dict)
+		const conclusion_string = get_conclusion_string(implication, properties_dict)
 
 		const ref = `(see <a href="/category-implication/${implication_id}">here</a>)`
 		const reason = `Since it ${assumption_string}, it ${conclusion_string} ${ref}.`
@@ -332,6 +328,7 @@ async function deduce_unsatisfied_category_properties(
 	implications: NormalizedCategoryImplication[],
 	satisfied_properties: Set<string>,
 	unsatisfied_properties: Set<string>,
+	properties_dict: Record<string, CategoryPropertyMeta>,
 	options: { check_conflicts: boolean } = { check_conflicts: true },
 ) {
 	const deduced_unsatisfied_props: string[] = []
@@ -356,7 +353,7 @@ async function deduce_unsatisfied_category_properties(
 		if (!next) break
 
 		const { implication, property } = next
-		const { id: implication_id, relations } = implication
+		const { id: implication_id } = implication
 
 		if (satisfied_properties.has(property)) {
 			throw new Error(`Contradiction has been found for: ${property}`)
@@ -365,13 +362,13 @@ async function deduce_unsatisfied_category_properties(
 		unsatisfied_properties.add(property)
 		deduced_unsatisfied_props.push(property)
 
-		const assumption_string = get_assumption_string(implication)
-		const conclusion_string = get_conclusion_string(implication)
+		const assumption_string = get_assumption_string(implication, properties_dict)
+		const conclusion_string = get_conclusion_string(implication, properties_dict)
 
 		const ref = `(see <a href="/category-implication/${implication_id}">here</a>)`
 
 		const reason =
-			`Assume that it ${relations[property]} ${property}. ` +
+			`Assume that it ${properties_dict[property].relation} ${property}. ` +
 			`But since it ${assumption_string}, it ${conclusion_string} ${ref} – contradiction.`
 
 		reasons[property] = reason
@@ -429,7 +426,7 @@ async function deduce_dual_category_properties(
 	unsatisfied: Set<string>,
 	dual_satisfied: Set<string>,
 	dual_unsatisfied: Set<string>,
-	properties_dict: Record<string, PropertyMeta>,
+	properties_dict: Record<string, CategoryPropertyMeta>,
 ) {
 	const new_satisfied = new Set<string>()
 

--- a/databases/catdat/scripts/deduce-functor-properties.ts
+++ b/databases/catdat/scripts/deduce-functor-properties.ts
@@ -345,11 +345,15 @@ async function deduce_unsatisfied_functor_properties(
 		const assumption_string = get_assumption_string(implication, properties_dict)
 		const conclusion_string = get_conclusion_string(implication, properties_dict)
 
+		const has_multiple_assumptions = implication.assumptions.size > 1
+
 		const ref = `(see <a href="/functor-implication/${implication_id}">here</a>)`
 
-		const reason =
-			`Assume that it ${properties_dict[property].relation} ${property}. ` +
-			`But since it ${assumption_string}, it ${conclusion_string} ${ref} – contradiction.`
+		const contra = `Assume for contradiction that it ${properties_dict[property].relation} ${property}`
+
+		const reason = has_multiple_assumptions
+			? `${contra}. Then it ${assumption_string}, so it ${conclusion_string} ${ref} – contradiction.`
+			: `${contra}. Then it ${conclusion_string} ${ref} – contradiction.`
 
 		reasons[property] = reason
 	}

--- a/databases/catdat/scripts/deduce-functor-properties.ts
+++ b/databases/catdat/scripts/deduce-functor-properties.ts
@@ -26,8 +26,10 @@ type FunctorPropertyMeta = {
 // TODO: remove code duplication with category deduction script
 // (not quite the same because we need source and target assumptions)
 
+// TODO: apply the same refactoring here that has been done for categories
+
 /**
- * Deduce properties of functor from given ones
+ * Deduce properties of functors from given ones
  * by using the list of functor implications.
  */
 export async function deduce_functor_properties(db: Client) {
@@ -40,8 +42,9 @@ export async function deduce_functor_properties(db: Client) {
 		const functors = await get_functors(tx)
 		const properties_dict = await get_functor_properties_dict(tx)
 
+		await delete_deduced_functor_properties(tx)
+
 		for (const functor of functors) {
-			await delete_deduced_functor_properties(tx, functor) // TODO: do this at once for all
 			await deduce_satisfied_functor_properties(
 				tx,
 				functor,
@@ -199,14 +202,8 @@ async function get_functor_properties_dict(tx: Transaction) {
  * Clears all the deduced functor properties.
  * This runs before the deduction starts.
  */
-async function delete_deduced_functor_properties(tx: Transaction, functor: FunctorMeta) {
-	await tx.execute({
-		sql: `
-			DELETE FROM functor_property_assignments
-			WHERE functor_id = ? AND is_deduced = TRUE
-		`,
-		args: [functor.id],
-	})
+async function delete_deduced_functor_properties(tx: Transaction) {
+	await tx.execute('DELETE FROM functor_property_assignments WHERE is_deduced = TRUE')
 }
 
 /**

--- a/databases/catdat/scripts/deduce-functor-properties.ts
+++ b/databases/catdat/scripts/deduce-functor-properties.ts
@@ -15,6 +15,14 @@ type FunctorMeta = {
 	target_props: Set<string>
 }
 
+type FunctorPropertyMeta = {
+	id: string
+	dual_property_id: string | null
+	relation: string
+	negation: string
+	conditional: string
+}
+
 // TODO: remove code duplication with category deduction script
 // (not quite the same because we need source and target assumptions)
 
@@ -30,11 +38,22 @@ export async function deduce_functor_properties(db: Client) {
 		const implications = await get_normalized_functor_implications(tx)
 
 		const functors = await get_functors(tx)
+		const properties_dict = await get_functor_properties_dict(tx)
 
 		for (const functor of functors) {
-			await delete_deduced_functor_properties(tx, functor)
-			await deduce_satisfied_functor_properties(tx, functor, implications)
-			await deduce_unsatisfied_functor_properties(tx, functor, implications)
+			await delete_deduced_functor_properties(tx, functor) // TODO: do this at once for all
+			await deduce_satisfied_functor_properties(
+				tx,
+				functor,
+				implications,
+				properties_dict,
+			)
+			await deduce_unsatisfied_functor_properties(
+				tx,
+				functor,
+				implications,
+				properties_dict,
+			)
 		}
 
 		await tx.commit()
@@ -69,16 +88,7 @@ async function get_normalized_functor_implications(
 			v.source_assumptions,
 			v.target_assumptions,
             v.conclusions,
-            v.is_equivalence,
-            (
-                SELECT json_group_object(p.id, p.relation)
-                FROM functor_properties p
-                WHERE p.id IN (
-                    SELECT value FROM json_each(v.assumptions)
-                    UNION
-                    SELECT value FROM json_each(v.conclusions)
-                )
-            ) AS relations
+            v.is_equivalence
         FROM functor_implications_view v
     `)
 
@@ -89,7 +99,6 @@ async function get_normalized_functor_implications(
 		target_assumptions: string
 		conclusions: string
 		is_equivalence: number
-		relations: string
 	}[]
 
 	const implications: NormalizedFunctorImplication[] = []
@@ -99,7 +108,6 @@ async function get_normalized_functor_implications(
 		const conclusions: string[] = JSON.parse(impl.conclusions)
 		const source_assumptions: string[] = JSON.parse(impl.source_assumptions)
 		const target_assumptions: string[] = JSON.parse(impl.target_assumptions)
-		const relations: Record<string, string> = JSON.parse(impl.relations)
 
 		for (const conclusion of conclusions) {
 			implications.push({
@@ -108,7 +116,6 @@ async function get_normalized_functor_implications(
 				source_assumptions: new Set(source_assumptions),
 				target_assumptions: new Set(target_assumptions),
 				conclusion,
-				relations,
 			})
 		}
 
@@ -120,7 +127,6 @@ async function get_normalized_functor_implications(
 					source_assumptions: new Set(source_assumptions),
 					target_assumptions: new Set(target_assumptions),
 					conclusion: assumption,
-					relations,
 				})
 			}
 		}
@@ -169,6 +175,27 @@ async function get_functors(tx: Transaction) {
 }
 
 /**
+ * Returns a dictionary of functor properties saved in the database.
+ */
+async function get_functor_properties_dict(tx: Transaction) {
+	const res = await tx.execute(`
+		SELECT
+			p.id, p.dual_property_id, p.relation,
+			r.negation, r.conditional
+		FROM functor_properties p
+		INNER JOIN relations r ON r.relation = p.relation
+		ORDER BY lower(p.id)
+	`)
+	const rows = res.rows as unknown as FunctorPropertyMeta[]
+
+	const dict: Record<string, FunctorPropertyMeta> = {}
+
+	for (const p of rows) dict[p.id] = p
+
+	return dict
+}
+
+/**
  * Clears all the deduced functor properties.
  * This runs before the deduction starts.
  */
@@ -211,6 +238,7 @@ async function deduce_satisfied_functor_properties(
 	tx: Transaction,
 	functor: FunctorMeta,
 	implications: NormalizedFunctorImplication[],
+	properties_dict: Record<string, FunctorPropertyMeta>,
 ) {
 	const satisfied_props = await get_decided_functor_properties(tx, functor.id, true)
 
@@ -232,8 +260,8 @@ async function deduce_satisfied_functor_properties(
 		satisfied_props.add(conclusion)
 		deduced_satisfied_props.push(conclusion)
 
-		const assumption_string = get_assumption_string(implication)
-		const conclusion_string = get_conclusion_string(implication)
+		const assumption_string = get_assumption_string(implication, properties_dict)
+		const conclusion_string = get_conclusion_string(implication, properties_dict)
 
 		const ref = `(see <a href="/functor-implication/${implication_id}">here</a>)`
 		const reason = `Since it ${assumption_string}, it ${conclusion_string} ${ref}.`
@@ -275,6 +303,7 @@ async function deduce_unsatisfied_functor_properties(
 	tx: Transaction,
 	functor: FunctorMeta,
 	implications: NormalizedFunctorImplication[],
+	properties_dict: Record<string, FunctorPropertyMeta>,
 ) {
 	const satisfied_props = await get_decided_functor_properties(tx, functor.id, true)
 	const unsatisfied_props = await get_decided_functor_properties(tx, functor.id, false)
@@ -304,7 +333,7 @@ async function deduce_unsatisfied_functor_properties(
 		if (!next) break
 
 		const { implication, property } = next
-		const { id: implication_id, relations } = implication
+		const { id: implication_id } = implication
 
 		if (satisfied_props.has(property)) {
 			throw new Error(`Contradiction has been found for: ${property}`)
@@ -313,13 +342,13 @@ async function deduce_unsatisfied_functor_properties(
 		unsatisfied_props.add(property)
 		deduced_unsatisfied_props.push(property)
 
-		const assumption_string = get_assumption_string(implication)
-		const conclusion_string = get_conclusion_string(implication)
+		const assumption_string = get_assumption_string(implication, properties_dict)
+		const conclusion_string = get_conclusion_string(implication, properties_dict)
 
 		const ref = `(see <a href="/functor-implication/${implication_id}">here</a>)`
 
 		const reason =
-			`Assume that it ${relations[property]} ${property}. ` +
+			`Assume that it ${properties_dict[property].relation} ${property}. ` +
 			`But since it ${assumption_string}, it ${conclusion_string} ${ref} – contradiction.`
 
 		reasons[property] = reason

--- a/databases/catdat/scripts/deduce-functor-properties.ts
+++ b/databases/catdat/scripts/deduce-functor-properties.ts
@@ -263,8 +263,8 @@ async function deduce_satisfied_functor_properties(
 		const assumption_string = get_assumption_string(implication, properties_dict)
 		const conclusion_string = get_conclusion_string(implication, properties_dict)
 
-		const ref = `(see <a href="/functor-implication/${implication_id}">here</a>)`
-		const reason = `Since it ${assumption_string}, it ${conclusion_string} ${ref}.`
+		const ref = `by <a href="/functor-implication/${implication_id}">this result</a>`
+		const reason = `Since it ${assumption_string}, it ${conclusion_string} (${ref}).`
 
 		reasons[conclusion] = reason
 	}
@@ -347,13 +347,13 @@ async function deduce_unsatisfied_functor_properties(
 
 		const has_multiple_assumptions = implication.assumptions.size > 1
 
-		const ref = `(see <a href="/functor-implication/${implication_id}">here</a>)`
+		const ref = `by <a href="/functor-implication/${implication_id}">this result</a>`
 
 		const contra = `Assume for contradiction that it ${properties_dict[property].relation} ${property}`
 
 		const reason = has_multiple_assumptions
-			? `${contra}. Then it ${assumption_string}, so it ${conclusion_string} ${ref} – contradiction.`
-			: `${contra}. Then it ${conclusion_string} ${ref} – contradiction.`
+			? `${contra}. Then it ${assumption_string}, so it ${conclusion_string} (${ref}) – contradiction.`
+			: `${contra}. Then it ${conclusion_string} (${ref}) – contradiction.`
 
 		reasons[property] = reason
 	}

--- a/databases/catdat/scripts/shared.ts
+++ b/databases/catdat/scripts/shared.ts
@@ -47,19 +47,24 @@ export type NormalizedFunctorImplication = NormalizedImplication & {
 export function get_assumption_string(
 	implication: NormalizedImplication,
 	properties_dict: Record<string, PropertyMeta>,
+	conditional = false,
 ): string {
 	const { assumptions } = implication
 
 	return Array.from(assumptions)
-		.map((assumption) => `${properties_dict[assumption].relation} ${assumption}`)
+		.map(
+			(assumption) =>
+				`${properties_dict[assumption][conditional ? 'conditional' : 'relation']} ${assumption}`,
+		)
 		.join(' and ')
 }
 
 export function get_conclusion_string(
 	implication: NormalizedImplication,
 	properties_dict: Record<string, PropertyMeta>,
+	conditional = false,
 ): string {
 	const { conclusion } = implication
 
-	return `${properties_dict[conclusion].relation} ${conclusion}`
+	return `${properties_dict[conclusion][conditional ? 'conditional' : 'relation']} ${conclusion}`
 }

--- a/databases/catdat/scripts/shared.ts
+++ b/databases/catdat/scripts/shared.ts
@@ -27,7 +27,14 @@ type NormalizedImplication = {
 	id: string
 	assumptions: Set<string>
 	conclusion: string
-	relations: Record<string, string>
+}
+
+type PropertyMeta = {
+	id: string
+	dual_property_id: string | null
+	relation: string
+	negation: string
+	conditional: string
 }
 
 export type NormalizedCategoryImplication = NormalizedImplication
@@ -37,14 +44,22 @@ export type NormalizedFunctorImplication = NormalizedImplication & {
 	target_assumptions: Set<string>
 }
 
-export function get_assumption_string(implication: NormalizedImplication): string {
-	const { assumptions, relations } = implication
+export function get_assumption_string(
+	implication: NormalizedImplication,
+	properties_dict: Record<string, PropertyMeta>,
+): string {
+	const { assumptions } = implication
+
 	return Array.from(assumptions)
-		.map((assumption) => `${relations[assumption]} ${assumption}`)
+		.map((assumption) => `${properties_dict[assumption].relation} ${assumption}`)
 		.join(' and ')
 }
 
-export function get_conclusion_string(implication: NormalizedImplication): string {
-	const { conclusion, relations } = implication
-	return `${relations[conclusion]} ${conclusion}`
+export function get_conclusion_string(
+	implication: NormalizedImplication,
+	properties_dict: Record<string, PropertyMeta>,
+): string {
+	const { conclusion } = implication
+
+	return `${properties_dict[conclusion].relation} ${conclusion}`
 }


### PR DESCRIPTION
The deduction system not only deduces properties (satisfied + unsatisfied) from given ones, it also generates human-readable reasons for these, including a reference to the implication being used. This PR improves the wording of these reasons.

<img width="600"  alt="screenshot with expanded reason" src="https://github.com/user-attachments/assets/2ff5ce3b-5c9b-4c61-920e-5cbdff64ea8a" />


### Reference

**Before**

_Since it is finitary algebraic, it has a generator (see [here](https://catdat.app/category-implication/free-algebra-generates))._

**After**

_Since it is finitary algebraic, it has a generator (by [this result](https://catdat.app/category-implication/free-algebra-generates))._

### Proofs by contradiction (1)

**Before**

_Assume that it is a groupoid. But since it is a groupoid, it is mono-regular (see [here](https://catdat.app/category-implication/groupoid_consequence)) – contradiction._

**After**

_Assume for contradiction that it is a groupoid. Then it would be mono-regular (by [this result](https://catdat.app/category-implication/groupoid_consequence)) – contradiction._

### Proofs by contradiction (2)

**Before**

_Assume that it is distributive. But since it has cartesian filtered colimits and has coproducts and is distributive, it is infinitary distributive (see [here](https://catdat.app/category-implication/infinite_distributive_filtered_criterion)) – contradiction._

**After**

_Assume for contradiction that it is distributive. Then it would have cartesian filtered colimits and would have coproducts and would be distributive, so it would be infinitary distributive (by [this result](https://catdat.app/category-implication/infinite_distributive_filtered_criterion)) – contradiction._

### What also has been done

- The reason generation has been refactored.
- To support the wording of "would have", "would be", etc. the relations table has been altered. It now looks like this:

```sql
INSERT INTO relations (relation, negation, conditional) VALUES
('is', 'is not', 'would be'),
('is a', 'is not a', 'would be a'),
('is an', 'is not an', 'would be an'),
('has', 'does not have', 'would have'),
('has a', 'does not have a', 'would have a'),
('has an', 'does not have an', 'would have an'),
('satisfies', 'does not satisfy', 'would satisfy');
```