### PR TITLE
Support display mode and commutative diagrams

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -239,5 +239,5 @@
 		".netlify",
 		"build"
 	],
-	"cSpell.ignoreRegExpList": ["\\$[^$]*\\$"]
+	"cSpell.ignoreRegExpList": ["\\$[^$]*\\$", "\\$\\$[^$]*\\$\\$"]
 }

--- a/databases/catdat/data/001_categories/007_tiny.sql
+++ b/databases/catdat/data/001_categories/007_tiny.sql
@@ -96,7 +96,7 @@ VALUES
 	'four objects $a,b,c,d$',
 	'morphisms $a \to b$, $b \to d$, $a \to c$, $c \to d$, identities, and one morphism $a \to d$',
 	'This category consists of a commutative square:
-	<p>$\begin{array}{ccc} a & \rightarrow & b \\ \downarrow && \downarrow \\ c & \rightarrow & d \end{array}$</p>
+	$$\begin{CD} a @>>> b \\ @VVV @VVV \\ c @>>> d \end{CD}$$
 	Its name comes from the fact that a functor out of it is the same as a <a href="https://ncatlab.org/nlab/show/commutative+square" target="_blank">commutative square</a> in the target category. Notice that the category is isomorphic to the product category $\{0 \to 1\} \times \{0 \to 1\}$ of the <a href="/category/walking_morphism">walking morphism</a> with itself. Hence, most (but not all) properties are inherited from it. It is also isomorphic to the partial order of positive divisors of $6$.',
 	'https://ncatlab.org/nlab/show/commutative+square',
 	NULL

--- a/databases/catdat/data/003_properties/003_limits-colimits-behavior.sql
+++ b/databases/catdat/data/003_properties/003_limits-colimits-behavior.sql
@@ -11,9 +11,9 @@ VALUES
 	'biproducts',
 	'has',
 	'A category has <i>biproducts</i> when it has zero morphisms, finite products (denoted $\times$), finite coproducts (denoted $\oplus$), and for every finite family of objects $A_1,\dotsc,A_n$ the canonical morphism
-	<p>$\mu : A_1 \oplus \cdots \oplus A_n \to A_1 \times \cdots \times A_n$</p>
+	$$\mu : A_1 \oplus \cdots \oplus A_n \to A_1 \times \cdots \times A_n$$
 	is an isomorphism. Such a category is also called <i>semi-additive</i>, and it is automatically enriched over commutative monoids: the sum of $f,g : A \rightrightarrows B$ is defined as:
-	<p>$A \xrightarrow{(f,g)} B \times B \xrightarrow{\mu^{-1}} B \oplus B \xrightarrow{\nabla} B$</p>',
+	$$A \xrightarrow{(f,g)} B \times B \xrightarrow{\mu^{-1}} B \oplus B \xrightarrow{\nabla} B$$',
 	'https://ncatlab.org/nlab/show/biproduct',
 	'biproducts',
 	TRUE
@@ -153,7 +153,8 @@ VALUES
 (
 	'disjoint finite products',
 	'has',
-	'A category has <i>disjoint finite products</i> if it has finite products, for every pair of objects $A,B$ the product projections $A \leftarrow A \times B \rightarrow B$ are epimorphisms, and the pushout $A \sqcup_{A \times B} B$ exists and is given by the terminal object $1$.<br>This terminology does not seem to be common, but we have added it as a dual for the more commonly known property of having disjoint finite coproducts.',
+	'A category has <i>disjoint finite products</i> if it has finite products, for every pair of objects $A,B$ the product projections $A \leftarrow A \times B \rightarrow B$ are epimorphisms, and the pushout $A \sqcup_{A \times B} B$ exists and is given by the terminal object $1$.<br>
+	This terminology does not seem to be common, but we have added it as a dual for the more commonly known property of having disjoint finite coproducts.',
 	NULL,
 	'disjoint finite coproducts',
 	TRUE
@@ -161,7 +162,8 @@ VALUES
 (
 	'disjoint products',
 	'has',
-	'A category has <i>disjoint products</i> if it has products, the product projections $\prod_{i \in I} A_i \to A_i$ are epimorphisms, and the pushout of the projections $\prod_{i \in I} A_i \to A_i$ and $\prod_{i \in I} A_i \to A_j$ for $i \neq j$ exists and is given by the terminal object $1$.<br>This terminology does not seem to be common, but we have added it as a dual for the more commonly known property of having disjoint coproducts.',
+	'A category has <i>disjoint products</i> if it has products, the product projections $\prod_{i \in I} A_i \to A_i$ are epimorphisms, and the pushout of the projections $\prod_{i \in I} A_i \to A_i$ and $\prod_{i \in I} A_i \to A_j$ for $i \neq j$ exists and is given by the terminal object $1$.<br>
+	This terminology does not seem to be common, but we have added it as a dual for the more commonly known property of having disjoint coproducts.',
 	NULL,
 	'disjoint coproducts',
 	TRUE
@@ -209,7 +211,8 @@ VALUES
 (
 	'infinitary coextensive',
 	'is',
-	'A category $\mathcal{C}$ is <i>infinitary coextensive</i> when it has products and for all families of objects $(A_i)_{i \in I}$ the product functor $\prod_{i \in I} A_i / \mathcal{C}/A_i \to \prod_{i \in I} A_i / \mathcal{C}$ is an equivalence of categories. <br>This terminology does not seem to be common, but we have added it as a dual for the more commonly known property of being infinitary extensive.',
+	'A category $\mathcal{C}$ is <i>infinitary coextensive</i> when it has products and for all families of objects $(A_i)_{i \in I}$ the product functor $\prod_{i \in I} A_i / \mathcal{C}/A_i \to \prod_{i \in I} A_i / \mathcal{C}$ is an equivalence of categories. <br>
+	This terminology does not seem to be common, but we have added it as a dual for the more commonly known property of being infinitary extensive.',
 	NULL,
 	'infinitary extensive',
 	TRUE
@@ -234,7 +237,7 @@ VALUES
 	'CIP',
 	'satisfies',
 	'A category satisfies <i>CIP</i> ("coproducts inject into products") if it has zero morphisms, products, coproducts, and for every family of objects $(X_i)_{i \in I}$ the canonical morphism
-	<p>$\alpha : \coprod_i X_i \to \prod_{i \in I} X_i$</p>
+	$$\textstyle \alpha : \coprod_i X_i \to \prod_{i \in I} X_i$$
 	defined by $p_j \circ \alpha \circ \iota_i = \delta_{i,j}$ is a monomorphism. This is no standard terminology. This property has been added to clarify relationships between other properties, in particular those concerning the commutation between limits and colimits.',
 	NULL,
 	'CSP',
@@ -244,7 +247,7 @@ VALUES
 	'CSP',
 	'satisfies',
 	'A category satisfies <i>CSP</i> ("coproducts surject onto products") if it has zero morphisms, products, coproducts, and for every family of objects $(X_i)_{i \in I}$ the canonical morphism
-	<p>$\alpha : \coprod_i X_i \to \prod_{i \in I} X_i$</p>
+	$$\textstyle \alpha : \coprod_i X_i \to \prod_{i \in I} X_i$$
 	defined by $p_j \circ \alpha \circ \iota_i = \delta_{i,j}$ is an epimorphism. This is no standard terminology. This property has been added to clarify relationships between other properties, in particular those concerning the commutation between limits and colimits.',
 	NULL,
 	'CIP',

--- a/databases/catdat/data/003_properties/005_morphism-behavior.sql
+++ b/databases/catdat/data/003_properties/005_morphism-behavior.sql
@@ -83,7 +83,7 @@ VALUES
 	'direct',
 	'is',
 	'A category is <i>direct</i> if it contains no infinite sequence of non-identity morphisms of the form
-	<p>$\cdots \to A_2 \to A_1 \to A_0.$</p>
+	$$\cdots \to A_2 \to A_1 \to A_0.$$
 	For example, a poset is direct iff it is well-founded.',
 	'https://ncatlab.org/nlab/show/direct+category',
 	'inverse',
@@ -93,7 +93,7 @@ VALUES
 	'inverse',
 	'is',
 	'A category is <i>inverse</i> if its dual is direct, i.e., if it contains no infinite sequence of non-identity morphisms of the form
-	<p>$A_0 \to A_1 \to A_2 \to \cdots.$</p>',
+	$$A_0 \to A_1 \to A_2 \to \cdots.$$',
 	'https://ncatlab.org/nlab/show/inverse+category',
 	'direct',
 	FALSE

--- a/databases/catdat/data/003_properties/006_additional-structure.sql
+++ b/databases/catdat/data/003_properties/006_additional-structure.sql
@@ -26,7 +26,8 @@ VALUES
 (
 	'preadditive',
 	'is',
-	'A category is <i>preadditive</i> when it is locally essentially small* and each hom-set carries the structure of an abelian group such that the composition is bilinear. Notice that "preadditive" is an extra structure. The property here just says that some preadditive structure exists.<br>*We demand this instead of the more common "locally small" to ensure that preadditive categories are invariant under equivalences of categories.',
+	'A category is <i>preadditive</i> when it is locally essentially small* and each hom-set carries the structure of an abelian group such that the composition is bilinear. Notice that "preadditive" is an extra structure. The property here just says that some preadditive structure exists.<br>
+	*We demand this instead of the more common "locally small" to ensure that preadditive categories are invariant under equivalences of categories.',
 	'https://ncatlab.org/nlab/show/Ab-enriched+category',
 	'preadditive',
 	TRUE

--- a/databases/catdat/data/003_properties/009_topos-theory.sql
+++ b/databases/catdat/data/003_properties/009_topos-theory.sql
@@ -103,7 +103,7 @@ VALUES
 	'natural numbers object',
 	'has a',
 	'A <i>natural numbers object</i> (NNO) in a category with finite products is a triple
-	<p>$(N,\, z : 1 \to N,\, s : N \to N)$</p>
+	$$(N,\, z : 1 \to N,\, s : N \to N)$$
 	satisfying the following universal property: for all $f : A \to X$,  $g : X \to X$ there is a unique $\Phi : A \times N \to X$ such that $\Phi(a,z)=f(a)$ and $\Phi(a,s(n)) = g(\Phi(a,n))$ in element notation.
 	<br>This concept is an abstraction of the set of natural numbers, which indeed provide a NNO for the category of sets. We have used the parametrized definition here which is more natural (sic!) for categories that are not cartesian closed (cf. <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Part A, Remark 2.5.3).',
 	'https://ncatlab.org/nlab/show/natural+numbers+object',

--- a/databases/catdat/data/003_properties/009_topos-theory.sql
+++ b/databases/catdat/data/003_properties/009_topos-theory.sql
@@ -42,8 +42,8 @@ VALUES
 (
 	'subobject classifier',
 	'has a',
-	'A category $\mathcal{C}$ has a <i>subobject classifier</i> if it has finite limits and a monomorphism* $\top : 1 \to \Omega$ such that for every monomorphism $m : A \to B$ there is a unique morphism $\chi_m : B \to \Omega$ such that
-	<p>$\begin{array}{ccc} A & \rightarrow & B \\ \downarrow && \downarrow \\ 1 & \rightarrow & \Omega \end{array}$</p>
+	'A category $\mathcal{C}$ has a <i>subobject classifier</i> if it has finite limits and a monomorphism* $\top : 1 \hookrightarrow \Omega$ such that for every monomorphism $m : A \hookrightarrow B$ there is a unique morphism $\chi_m : B \to \Omega$ such that
+	$$\begin{CD} A @>{m}>> B \\ @V{!}VV @VV{\chi_m}V \\ 1 @>>{\top}> \Omega \end{CD}$$
 	is a pullback diagram. Equivalently, the functor $\mathrm{Sub} : \mathcal{C}^{\mathrm{op}} \to \mathbf{Set}^+$ is representable.<br>
 	*Every morphism $1 \to \Omega$ is a split monomorphism anyway.',
 	'https://ncatlab.org/nlab/show/subobject+classifier',
@@ -53,8 +53,8 @@ VALUES
 (
 	'quotient object classifier',
 	'has a',
-	'A category $\mathcal{C}$ has a <i>quotient object classifier</i> if its dual has a subobject classifier. This means that it has finite colimits and an epimorphism* $\top : \Psi \to 0$ such that for every epimorphism $e : A \to B$ there is a unique morphism $\psi_e : \Psi \to A$ such that
-	<p>$\begin{array}{ccc} \Psi & \rightarrow & 0 \\ \downarrow && \downarrow \\ A & \rightarrow & B \end{array}$</p>
+	'A category $\mathcal{C}$ has a <i>quotient object classifier</i> if its dual has a subobject classifier. This means that it has finite colimits and an epimorphism* $\top : \Psi \twoheadrightarrow 0$ such that for every epimorphism $e : A \twoheadrightarrow B$ there is a unique morphism $\psi_e : \Psi \to A$ such that
+	$$\begin{CD} \Psi @>{\top}>> 0 \\ @V{\psi_e}VV @VV{!}V \\ A @>>{e}> B \end{CD}$$
 	is a pushout diagram. Equivalently, the functor $\mathrm{Quot} : \mathcal{C} \to \mathbf{Set}^+$ is representable.<br>
 	*Every morphism $\Psi \to 0$ is a split epimorphism anyway.',
 	NULL,
@@ -64,8 +64,8 @@ VALUES
 (
 	'regular subobject classifier',
 	'has a',
-	'A category $\mathcal{C}$ has a <i>regular subobject classifier</i> if it has finite limits and a regular monomorphism* $\top : 1 \to \Omega$ such that for every regular monomorphism $m : A \to B$ there is a unique morphism $\chi_m : B \to \Omega$ such that
-	<p>$\begin{array}{ccc} A & \rightarrow & B \\ \downarrow && \downarrow \\ 1 & \rightarrow & \Omega \end{array}$</p>
+	'A category $\mathcal{C}$ has a <i>regular subobject classifier</i> if it has finite limits and a regular monomorphism* $\top : 1 \hookrightarrow \Omega$ such that for every regular monomorphism $m : A \hookrightarrow B$ there is a unique morphism $\chi_m : B \to \Omega$ such that
+	$$\begin{CD} A @>{m}>> B \\ @V{!}VV @VV{\chi_m}V \\ 1 @>>{\top}> \Omega \end{CD}$$
 	is a pullback diagram. Equivalently, the functor $\mathrm{Sub}_{\mathrm{reg}} : \mathcal{C}^{\mathrm{op}} \to \mathbf{Set}^+$ is representable.<br>
 	*Every morphism $1 \to \Omega$ is a split monomorphism and hence regular anyway.',
 	'https://ncatlab.org/nlab/show/subobject+classifier',
@@ -75,8 +75,8 @@ VALUES
 (
 	'regular quotient object classifier',
 	'has a',
-	'A category $\mathcal{C}$ has a <i>regular quotient object classifier</i> if its dual has a regular subobject classifier. This means that it has finite colimits and a regular epimorphism* $\top : \Psi \to 0$ such that for every regular epimorphism $e : A \to B$ there is a unique morphism $\psi_e : \Psi \to A$ such that
-	<p>$\begin{array}{ccc} \Psi & \rightarrow & 0 \\ \downarrow && \downarrow \\ A & \rightarrow & B \end{array}$</p>
+	'A category $\mathcal{C}$ has a <i>regular quotient object classifier</i> if its dual has a regular subobject classifier. This means that it has finite colimits and a regular epimorphism* $\top : \Psi \twoheadrightarrow 0$ such that for every regular epimorphism $e : A \twoheadrightarrow B$ there is a unique morphism $\psi_e : \Psi \to A$ such that
+	$$\begin{CD} \Psi @>{\top}>> 0 \\ @V{\psi_e}VV @VV{!}V \\ A @>>{e}> B \end{CD}$$
 	is a pushout diagram. Equivalently, the functor $\mathrm{Quot}_{\mathrm{reg}} : \mathcal{C} \to \mathbf{Set}^+$ is representable.<br>
 	*Every morphism $\Psi \to 0$ is a split epimorphism anyway.',
 	NULL,

--- a/databases/catdat/data/003_properties/010_misc.sql
+++ b/databases/catdat/data/003_properties/010_misc.sql
@@ -59,7 +59,7 @@ VALUES
 	'sifted',
 	'is',
 	'A category $\mathcal{C}$ is <i>sifted</i> if it is inhabited and the diagonal functor $\Delta : \mathcal{C} \to \mathcal{C} \times \mathcal{C}$ is final, i.e. if it is non-empty and for any two objects $X,Y \in \mathcal{C}$ the category of cospans
-	<p>$X \rightarrow Z \leftarrow Y$</p>
+	$$X \rightarrow Z \leftarrow Y$$
 	is connected. Equivalently, a small category $\mathcal{C}$ is sifted if $\mathrm{colim} : \mathbf{Set}^{\mathcal{C}} \to \mathbf{Set}$ preserves finite products. This property is a weaker notion than being filtered.',
 	'https://ncatlab.org/nlab/show/sifted+category',
 	'cosifted',
@@ -69,7 +69,7 @@ VALUES
 	'cosifted',
 	'is',
 	'A category $\mathcal{C}$ is <i>cosifted</i> if it is inhabited and the diagonal functor $\Delta : \mathcal{C} \to \mathcal{C} \times \mathcal{C}$ is initial, i.e. if it is non-empty and for any two objects $X,Y \in \mathcal{C}$ the category of spans
-	<p>$X \leftarrow Z \rightarrow Y$</p>
+	$$X \leftarrow Z \rightarrow Y$$
 	is connected. Equivalently, a small category $\mathcal{C}$ is cosifted if $\mathrm{colim} : \mathbf{Set}^{{\mathcal{C}}^\mathrm{op}} \to \mathbf{Set}$ preserves finite products. This property is a weaker notion than being cofiltered.',
 	'https://ncatlab.org/nlab/show/sifted+category',
 	'sifted',

--- a/databases/catdat/data/004_property-assignments/Alg(R).sql
+++ b/databases/catdat/data/004_property-assignments/Alg(R).sql
@@ -88,7 +88,7 @@ VALUES
 	'cocartesian cofiltered limits',
 	FALSE,
 	'Consider the ring $A = R[X]$ and the sequence of rings $B_n = R[Y]/(Y^{n+1})$ with projections $B_{n+1} \to B_n$, whose limit is $R[[Y]]$. Every element in the coproduct of rings $R[X] \sqcup R[[Y]]$ has a finite "free product" length. Now consider the elements
-	<br>$w_n = (1 + XY) (1+XY^2) \cdots (1+X Y^n) \in A \sqcup B_n$.</br>
+	$$w_n = (1 + XY) (1+XY^2) \cdots (1+X Y^n) \in A \sqcup B_n.$$
 	Because of $w_n \equiv w_{n-1} \bmod Y^n$ these form an element $w \in \lim_n (A \sqcup B_n)$. Expanding $w_n$, the longest term is $XY XY^2 \cdots X Y^n$ of "free product" length $2n$, which is unbounded.'
 ),
 (

--- a/databases/catdat/data/004_property-assignments/Delta.sql
+++ b/databases/catdat/data/004_property-assignments/Delta.sql
@@ -76,9 +76,9 @@ VALUES
     'cosifted',
     TRUE,
     'Let $X,Y \in \Delta$. We may pick $x \in X$, $y \in Y$. Then there is a "point span" $X \xleftarrow{x} [0] \xrightarrow{y} Y$. Every span $X \xleftarrow{f} Z \xrightarrow{g} Y$ is connected to such a point span: Pick $z \in Z$. This defines a morphism of spans:
-    <p>$\begin{array}{ccccc} X & \xleftarrow{f(z)} & [0] & \xrightarrow{g(z)} & Y \\ \parallel & & \phantom{{\footnotesize z}} \downarrow {\footnotesize z} && \parallel \\ X & \xleftarrow{f} & Z & \xrightarrow{g} & Z \end{array}$</p>
+    $$\begin{CD} X @<{f(z)}<< [0] @>{g(z)}>> Y \\ @| @VV{z}V @| \\ X @<<{f}< Z @>>{g}> Y \end{CD}$$
     It remains to show that all point spans are connected to each other. Assume $x_0,x_1 \in X$ and $y \in Y$, w.l.o.g. $x_0 \leq x_1$. Define the map $f : [1] \to X$ by $f(0) = x_0$, $f(1) = x_1$, and the map $g : [1] \to Y$ by $g(0)=g(1)=y$. They are order-preserving and fit into a zig-zag of spans:
-    <p>$\begin{array}{ccccc} X & \xleftarrow{x_0} & [0] & \xrightarrow{y} & Y \\ \parallel && \phantom{ {\footnotesize 0}} \downarrow {\footnotesize 0} && \parallel \\ X & \xleftarrow{f} & [1] & \xrightarrow{g} & Y \\ \parallel && \phantom{ {\footnotesize 1}} \uparrow  {\footnotesize 1} && \parallel \\ X & \xleftarrow{x_1} & [0] & \xrightarrow{y} & Y \end{array}$</p>
+    $$\begin{CD} X @<{x_0}<< [0] @>{y}>> Y \\ @| @V{0}VV @| \\ X @<{f}<< [1] @>{g}>> Y \\ @| @A{1}AA @| \\ X @<{x_1}<< [0] @>{y}>> Y \end{CD}$$
     This shows that the choice of $x \in X$ does not matter, and for $y \in Y$ the proof is the same.'
 ),
 (

--- a/databases/catdat/data/004_property-assignments/FS.sql
+++ b/databases/catdat/data/004_property-assignments/FS.sql
@@ -123,11 +123,13 @@ VALUES
 	'FS',
 	'locally cocartesian coclosed',
 	FALSE,
-	'If $X$ is a finite set, the coslice category $X / \mathbf{FS}$ is thin and in fact equivalent to the lattice of equivalence relations on $X$. If $X$ has $\geq 3$ elements, it is not codistributive* and <a href="/category-implication/dual_distributive_criterion">hence</a> not cocartesian coclosed: For simplicity assume $X = \{a,b,c\}$. The bottom element $\bot$ corresponds to the partition $\{\{a\},\{b\},\{c\}\}$, the top element $\top$ to the partition $\{\{a,b,c\}\}$. Now consider the three equivalence relations $E_1,E_2,E_3$ corresponding to the three partitions $\{\{a,b\},\{c\}\}$, $\{\{a,c\},\{b\}\}$, $\{\{b,c\},\{a\}\}$. Then
-	$E_1 \vee (E_2 \wedge E_3) = E_1 \vee \bot = E_1$,
+	'If $X$ is a finite set, the coslice category $X / \mathbf{FS}$ is thin and in fact equivalent to the lattice of equivalence relations on $X$. If $X$ has $\geq 3$ elements, it is not codistributive* and <a href="/category-implication/dual_distributive_criterion">hence</a> not cocartesian coclosed: For simplicity assume $X = \{a,b,c\}$. The bottom element $\bot$ corresponds to the partition $\{\{a\},\{b\},\{c\}\}$, the top element $\top$ to the partition $\{\{a,b,c\}\}$. Now consider the three equivalence relations $E_1,E_2,E_3$ corresponding to the three partitions
+	$$\{\{a,b\},\{c\}\}, \, \{\{a,c\},\{b\}\}, \, \{\{b,c\},\{a\}\}.$$
+	Then
+	$$E_1 \vee (E_2 \wedge E_3) = E_1 \vee \bot = E_1,$$
 	but
-	$(E_1 \vee E_2) \wedge (E_1 \vee E_3) = \top \wedge \top = \top$.
-	<p>*For thin categories, the properties codistributive and distributive <a href="/category-implication/distributive_duality">are equivalent</a>.'
+	$$(E_1 \vee E_2) \wedge (E_1 \vee E_3) = \top \wedge \top = \top.$$
+	*For thin categories, the properties codistributive and distributive <a href="/category-implication/distributive_duality">are equivalent</a>.'
 ),
 (
 	'FS',

--- a/databases/catdat/data/004_property-assignments/FinSet.sql
+++ b/databases/catdat/data/004_property-assignments/FinSet.sql
@@ -88,6 +88,6 @@ VALUES
 	'natural numbers object',
 	FALSE,
 	'If $(N,z,s)$ is a natural numbers object, then
-	<p>$1 \xrightarrow{z} N \xleftarrow{s} N$</p>
+	$$1 \xrightarrow{z} N \xleftarrow{s} N$$
 	is a coproduct cocone by <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Part A, Lemma 2.5.5. But there is no finite set $N$ with $N \cong 1 + N$.'
 );

--- a/databases/catdat/data/004_property-assignments/Fld.sql
+++ b/databases/catdat/data/004_property-assignments/Fld.sql
@@ -100,6 +100,6 @@ VALUES
 	'cofiltered-limit-stable epimorphisms',
 	FALSE,
 	'Inside of $\mathbb{F}_p(X)$ consider the descending sequence of subfields
-	<p>$\mathbb{F}_p(X) \supseteq \mathbb{F}_p(X^p) \supseteq \mathbb{F}_p(X^{p^2}) \supseteq \cdots,$</p>
+	$$\mathbb{F}_p(X) \supseteq \mathbb{F}_p(X^p) \supseteq \mathbb{F}_p(X^{p^2}) \supseteq \cdots,$$
 	whose intersection is $\mathbb{F}_p$. Each $\mathbb{F}_p(X^{p^n}) \hookrightarrow \mathbb{F}_p(X)$ is purely inseparable, hence an epimorphism, but in the limit we get $\mathbb{F}_p \hookrightarrow \mathbb{F}_p(X)$, which is not even algebraic.'
 );

--- a/databases/catdat/data/004_property-assignments/Grp.sql
+++ b/databases/catdat/data/004_property-assignments/Grp.sql
@@ -94,9 +94,9 @@ VALUES
 	'cocartesian cofiltered limits',
 	FALSE,
 	'For cofiltered diagrams of groups $(H_i)$ and a group $G$ the canonical homomorphism
-	<br>$\alpha : G \sqcup \lim_i H_i \to \lim_i (G \sqcup H_i)$<br>
+	$$\textstyle \alpha : G \sqcup \lim_i H_i \to \lim_i (G \sqcup H_i)$$
 	is injective, but often fails to be surjective because the components of an element in the image have bounded <i>free product length</i> (the number of factors appearing in the reduced form). Specifically, consider the free groups $G = \langle y \rangle$ and $H_n = \langle x_1,\dotsc,x_n \rangle$ for $n \in \mathbb{N}$ with the truncation maps $H_{n+1} \to H_n$, $x_{n+1} \mapsto 1$. Define
-	<br>$p_n := x_1 \, y \, x_2 \, y \, \cdots \, x_{n-1} \, y \, x_n \, y^{-(n-1)} \in G \sqcup H_n$.<br>
+	$$p_n := x_1 \, y \, x_2 \, y \, \cdots \, x_{n-1} \, y \, x_n \, y^{-(n-1)} \in G \sqcup H_n.$$
 	If we substitute $x_{n+1}=1$ in $p_{n+1}$, we get $p_n$. Thus, we have $p = (p_n) \in \lim_n (G \sqcup H_n)$. This element does not lie in the image of $\alpha$ since the free product length of $p_n$ (which is well-defined) is $2n$, which is unbounded.'
 ),
 (

--- a/databases/catdat/data/004_property-assignments/Met.sql
+++ b/databases/catdat/data/004_property-assignments/Met.sql
@@ -142,6 +142,6 @@ VALUES
 	'natural numbers object',
 	FALSE,
 	'If $(N,z,s)$ is a natural numbers object in $\mathbf{Met}$, then
-	<p>$1 \xrightarrow{z} N \xleftarrow{s} N$</p>
+	$$1 \xrightarrow{z} N \xleftarrow{s} N$$
 	is a coproduct cocone by <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Part A, Lemma 2.5.5. Since there is a map $1 \to N$, we have $N \neq \varnothing$. However, the coproduct of two non-empty metric spaces does not exist, see <a href="https://math.stackexchange.com/questions/1778408" target="_blank">MSE/1778408</a>.'
 );

--- a/databases/catdat/data/004_property-assignments/PMet.sql
+++ b/databases/catdat/data/004_property-assignments/PMet.sql
@@ -136,6 +136,6 @@ VALUES
 	'natural numbers object',
 	FALSE,
 	'If $(N,z,s)$ is a natural numbers object in $\mathbf{PMet}$, then
-	<p>$1 \xrightarrow{z} N \xleftarrow{s} N$</p>
+	$$1 \xrightarrow{z} N \xleftarrow{s} N$$
 	is a coproduct cocone by <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Part A, Lemma 2.5.5. Since there is a map $1 \to N$, we have $N \neq \varnothing$. However, the coproduct of two non-empty pseudo-metric spaces does not exist, see <a href="https://math.stackexchange.com/questions/1778408" target="_blank">MSE/1778408</a>.'
 );

--- a/databases/catdat/data/004_property-assignments/Ring.sql
+++ b/databases/catdat/data/004_property-assignments/Ring.sql
@@ -88,7 +88,7 @@ VALUES
 	'cocartesian cofiltered limits',
 	FALSE,
 	'Consider the ring $A = \mathbb{Z}[X]$ and the sequence of rings $B_n = \mathbb{Z}[Y]/(Y^{n+1})$ with projections $B_{n+1} \to B_n$, whose limit is $\mathbb{Z}[[Y]]$. Every element in the coproduct of rings $\mathbb{Z}[X] \sqcup \mathbb{Z}[[Y]]$ has a finite "free product" length. Now consider the elements
-	<br>$w_n = (1 + XY) (1+XY^2) \cdots (1+X Y^n) \in A \sqcup B_n$.</br>
+	$$w_n = (1 + XY) (1+XY^2) \cdots (1+X Y^n) \in A \sqcup B_n.$$
 	Because of $w_n \equiv w_{n-1} \bmod Y^n$ these form an element $w \in \lim_n (A \sqcup B_n)$. Expanding $w_n$, the longest term is $XY XY^2 \cdots X Y^n$ of "free product" length $2n$, which is unbounded.'
 ),
 (

--- a/databases/catdat/data/004_property-assignments/Rng.sql
+++ b/databases/catdat/data/004_property-assignments/Rng.sql
@@ -82,7 +82,7 @@ VALUES
 	'cocartesian cofiltered limits',
 	FALSE,
 	'Consider the ring $A = \mathbb{Z}[X]$ and the sequence of rings $B_n = \mathbb{Z}[Y]/(Y^{n+1})$ with projections $B_{n+1} \to B_n$, whose limit is $\mathbb{Z}[[Y]]$ (both in $\mathbf{Ring}$ and $\mathbf{Rng}$). Every element in the coproduct of rngs $\mathbb{Z}[X] \sqcup \mathbb{Z}[[Y]]$ has a finite "free product" length. Now consider the elements
-	<br>$w_n = (1 + XY) (1+XY^2) \cdots (1+X Y^n) - 1 \in A \sqcup B_n$.</br>
+	$$w_n = (1 + XY) (1+XY^2) \cdots (1+X Y^n) - 1 \in A \sqcup B_n.$$
 	Because of $w_n \equiv w_{n-1} \bmod Y^n$ these form an element $w \in \lim_n (A \sqcup B_n)$. Expanding $w_n$, the longest term is $XY XY^2 \cdots X Y^n$ of "free product" length $2n$, which is unbounded.'
 ),
 (

--- a/databases/catdat/data/004_property-assignments/Sp.sql
+++ b/databases/catdat/data/004_property-assignments/Sp.sql
@@ -76,6 +76,6 @@ VALUES
 	'natural numbers object',
 	FALSE,
 	'If $(N,z,s)$ is a natural numbers object, then
-	<p>$1 \xrightarrow{z} N \xleftarrow{s} N$</p>
+	$$1 \xrightarrow{z} N \xleftarrow{s} N$$
 	is a coproduct cocone by <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Part A, Lemma 2.5.5. But there is no combinatorial species $N$ with $N \cong 1 + N$, since evaluating this at, say, $\varnothing$, would yield a finite set $N$ with this property.'
 );

--- a/databases/catdat/data/004_property-assignments/Top_pointed.sql
+++ b/databases/catdat/data/004_property-assignments/Top_pointed.sql
@@ -87,7 +87,8 @@ VALUES
 	'Top*',
 	'cocartesian cofiltered limits',
 	TRUE,
-	'We continue the proof for <a href="/category/Set*">$\mathbf{Set}_*$</a> by showing that the natural bijective map <br>$\alpha : X \vee \lim_i Y_i \to \lim_i (X \vee Y_i)$<br>
+	'We continue the proof for <a href="/category/Set*">$\mathbf{Set}_*$</a> by showing that the natural bijective map
+	$$\textstyle \alpha : X \vee \lim_i Y_i \to \lim_i (X \vee Y_i)$$
 	is open. It suffices to consider open sets of two types: (1) If $U \subseteq X$ is open, the $\alpha$-image of $U \vee \lim_i Y_i$ is $p_{i_0}^{-1}(U \vee Y_{i_0})$ for any chosen index $i_0$, hence open. (2) If $i$ is an index and $V_i \subseteq Y_i$ is open, then the $\alpha$-image of $X \vee (p_i^{-1}(V_i) \cap \lim_i Y_i)$ is $p_i^{-1}(X \vee V_i)$, hence open.'
 ),
 (

--- a/databases/catdat/data/005_implications/001_limits-colimits-existence-implications.sql
+++ b/databases/catdat/data/005_implications/001_limits-colimits-existence-implications.sql
@@ -171,7 +171,12 @@ VALUES
 	'sequential_colimits_consequence',
 	'["sequential colimits"]',
 	'["Cauchy complete"]',
-	'Assume that $e : X \to X$ is an idempotent morphism. Consider the sequence $X \xrightarrow{e} X \xrightarrow{e} X \to \cdots$. A cocone under this sequence is a family of morphisms $f_n : X \to Y$ satisfying $f_n = f_{n+1} e$. Then $f_n = f_{n+1} e = f_{n+2} e^2 = f_{n+2} e = f_{n+1}$ shows that all the morphisms are equal. Thus, a cocone is the same as a morphism $f_0 : X \to Y$ with $f_0 = f_0 e$, meaning it coequalizes $\mathrm{id}_X,e : X \rightrightarrows X$. Hence, if a colimit exists, $e$ splits.',
+	'Assume that $e : X \to X$ is an idempotent morphism. Consider the sequence
+	$$X \xrightarrow{e} X \xrightarrow{e} X \to \cdots.$$
+	A cocone under this sequence is a family of morphisms $f_n : X \to Y$ satisfying $$f_n = f_{n+1} e.$$
+	Then
+	$$f_n = f_{n+1} e = f_{n+2} e^2 = f_{n+2} e = f_{n+1}$$
+	shows that all the morphisms are equal. Thus, a cocone is the same as a morphism $f_0 : X \to Y$ with $f_0 = f_0 e$, meaning it coequalizes $\mathrm{id}_X,e : X \rightrightarrows X$. Hence, if a colimit exists, $e$ splits.',
 	FALSE
 ),
 (

--- a/databases/catdat/data/005_implications/002_limits-colimits-behavior-implications.sql
+++ b/databases/catdat/data/005_implications/002_limits-colimits-behavior-implications.sql
@@ -73,8 +73,8 @@ VALUES
 	'exact_filtered_colimits_monos',
 	'["exact filtered colimits"]',
 	'["filtered-colimit-stable monomorphisms"]',
-	'This is because $X \to Y$ is a monomorphism iff the diagram
-	<p>$\begin{array}{ccc} X & \rightarrow & X \\ \downarrow && \downarrow \\ X & \rightarrow & Y \end{array}$</p>
+	'This is because $f : X \longrightarrow Y$ is a monomorphism iff the diagram
+	$$\begin{CD} X @>{\mathrm{id}}>> X \\ @V{\mathrm{id}}VV @VV{f}V \\ X @>>{f}> Y \end{CD}$$
 	is a pullback, and if a functor preserves finite limits, it preserves pullbacks in particular.',
 	FALSE
 ),

--- a/databases/catdat/data/005_implications/002_limits-colimits-behavior-implications.sql
+++ b/databases/catdat/data/005_implications/002_limits-colimits-behavior-implications.sql
@@ -265,10 +265,13 @@ VALUES
 	'["copowers", "cartesian closed"]',
 	'["powers"]',
 	'The power $X^I$ can be constructed as $[I \otimes 1, X]$ because
-	<p>$\mathrm{Hom}(T,[I \otimes 1, X]) \cong \mathrm{Hom}(T \times (I \otimes 1),X)$</p>
-	<p>$\cong \mathrm{Hom}(I \otimes (T \times 1),X) \cong \mathrm{Hom}(I \otimes T,X)$</p>
-	<p>$ \cong \mathrm{Hom}(T,X)^I.$</p>
-	<p>In the second isomorphism we have used that $T \times -$ preserves copowers, which is true because it is a left adjoint.',
+	$$\begin{align*}
+	\mathrm{Hom}(T,[I \otimes 1, X]) & \cong \mathrm{Hom}(T \times (I \otimes 1),X) \\
+	& \cong \mathrm{Hom}(I \otimes (T \times 1),X) \\
+	& \cong \mathrm{Hom}(I \otimes T,X) \\
+	& \cong \mathrm{Hom}(T,X)^I.
+	\end{align*}$$
+	In the second isomorphism we have used that $T \times -$ preserves copowers, which is true because it is a left adjoint.',
 	FALSE
 ),
 (

--- a/databases/catdat/data/005_implications/004_morphism-behavior-implications.sql
+++ b/databases/catdat/data/005_implications/004_morphism-behavior-implications.sql
@@ -115,7 +115,8 @@ VALUES
 	'one-way_zero',
 	'["zero morphisms", "one-way"]',
 	'["thin"]',
-	'If $f,g : A \rightrightarrows B$ are two morphisms, then since $0_{B,B} = \mathrm{id}_B$ we have $f = 0_{B,B} \circ f = 0_{A,B} = 0_{B,B} \circ g = g$.',
+	'If $f,g : A \rightrightarrows B$ are two morphisms, then since $0_{B,B} = \mathrm{id}_B$ we have
+	$$f = 0_{B,B} \circ f = 0_{A,B} = 0_{B,B} \circ g = g.$$',
 	FALSE
 ),
 (

--- a/databases/catdat/data/005_implications/009_misc-implications.sql
+++ b/databases/catdat/data/005_implications/009_misc-implications.sql
@@ -108,7 +108,11 @@ VALUES
 	'sifted_left_cancellative_implies_thin',
 	'["sifted", "left cancellative"]',
 	'["thin"]',
-	'For any object $X$ in a left-cancellative category, the connected component containing $X \xrightarrow{\mathrm{id}} X \xleftarrow{\mathrm{id}} X$ in the category of cospans from $X$ to $X$ consists only of cospans $X \xrightarrow{f} Y \xleftarrow{g} X$ where $f=g$; hence when the category is also sifted, all cospans must be of this form, and so any two parallel morphisms are equal.',
+	'For any object $X$ in a left-cancellative category, the connected component containing
+	$$X \xrightarrow{\mathrm{id}} X \xleftarrow{\mathrm{id}} X$$
+	in the category of cospans from $X$ to $X$ consists only of cospans
+	$$X \xrightarrow{f} Y \xleftarrow{g} X$$
+	where $f=g$; hence when the category is also sifted, all cospans must be of this form, and so any two parallel morphisms are equal.',
 	FALSE
 ),
 (

--- a/databases/catdat/data/008_functors/001_functor-properties.sql
+++ b/databases/catdat/data/008_functors/001_functor-properties.sql
@@ -217,7 +217,8 @@ VALUES
     (
         'monomorphism-preserving',
         'is',
-        'A functor $F : \mathcal{C} \to \mathcal{D}$ preserves monomorphisms if every monomorphism in $\mathcal{C}$ is mapped to a monomorphism in $\mathcal{D}$.<br>This property is useful to rule out some adjunctions.',
+        'A functor $F : \mathcal{C} \to \mathcal{D}$ preserves monomorphisms if every monomorphism in $\mathcal{C}$ is mapped to a monomorphism in $\mathcal{D}$.<br>
+        This property is useful to rule out some adjunctions.',
         'https://ncatlab.org/nlab/show/monomorphism',
         TRUE,
         'epimorphism-preserving'
@@ -225,7 +226,8 @@ VALUES
     (
         'epimorphism-preserving',
         'is',
-        'A functor $F : \mathcal{C} \to \mathcal{D}$ preserves epimorphisms if every epimorphism in $\mathcal{C}$ is mapped to an epimorphism in $\mathcal{D}$.<br>This property is useful to rule out some adjunctions.',
+        'A functor $F : \mathcal{C} \to \mathcal{D}$ preserves epimorphisms if every epimorphism in $\mathcal{C}$ is mapped to an epimorphism in $\mathcal{D}$.<br>
+        This property is useful to rule out some adjunctions.',
         'https://ncatlab.org/nlab/show/epimorphism',
         TRUE,
         'monomorphism-preserving'

--- a/databases/catdat/data/010_lemmas/000_lemmas.sql
+++ b/databases/catdat/data/010_lemmas/000_lemmas.sql
@@ -20,20 +20,24 @@ INSERT INTO lemmas (
     'preadditive_structure_unique',
     'Uniqueness of preadditive structures',
     'Let $\mathcal{C}$ be a preadditive category (or more generally, a category enriched in commutative monoids) with finite products and finite coproducts. Then for all objects $X,Y$ the canonical morphism
-    <p>$\alpha : X \oplus Y \to X \times Y$</p>
+    $$\alpha : X \oplus Y \to X \times Y$$
     is an isomorphism. Moreover, the preadditive structure is <i>unique</i>: If $f,g : A \rightrightarrows B$ are morphisms, their sum
-    <p>$f+g : A \to B$</p>
+    $$f+g : A \to B$$
     is the composite of $(f,g) : A \to B \times B$, the inverse $\alpha^{-1} : B \oplus B \to B \times B$, and the codiagonal $\nabla : B \oplus B \to B$.',
     'The morphism $\alpha : X \oplus Y \to X \times Y$ is defined by the equations
-    <p>$p_1 \circ \alpha \circ i_1 = \mathrm{id}_X, \quad p_2 \circ \alpha \circ i_2 = \mathrm{id}_Y$</p>
-    <p>$p_2 \circ \alpha \circ i_1 = 0,\quad p_1 \circ \alpha \circ i_2 = 0$.</p>
+    $$p_1 \circ \alpha \circ i_1 = \mathrm{id}_X, \quad p_2 \circ \alpha \circ i_2 = \mathrm{id}_Y,$$
+    $$p_2 \circ \alpha \circ i_1 = 0,\quad p_1 \circ \alpha \circ i_2 = 0.$$
     It does not depend on the choice of preadditive structure since zero morphisms are unique. It is an isomorphism: Define
-    <p>$\beta := i_1 \circ p_1  + i_2 \circ p_2 : X \times Y \to X \oplus Y$.</p>
+    $$\beta := i_1 \circ p_1  + i_2 \circ p_2 : X \times Y \to X \oplus Y.$$
     Then $\alpha \circ \beta = \mathrm{id}_{X \times Y}$ because
-    <p>$p_1 \circ \alpha \circ \beta = p_1 \circ \alpha \circ i_1 \circ p_1 + p_1 \circ \alpha \circ i_2 \circ p_2 = \mathrm{id}_1 \circ p_1 + 0 \circ p_2 = p_1$</p>
-    and likewise $p_2 \circ \alpha \circ \beta = p_2$. We also have $\beta \circ \alpha = \mathrm{id}_{X \oplus Y}$ with a very similar calculation that shows $\beta \circ \alpha \circ i_1 = i_1$ and $\beta \circ \alpha \circ i_2 = i_2$.
-    <p>Therefore, for morphisms $f,g : A \rightrightarrows B$ the composite $A \to B$ in the claim is equal to</p>
-    $\begin{aligned} \nabla \circ \beta \circ (f,g) & = \nabla \circ (i_1 \circ p_1  + i_2 \circ p_2) \circ (f,g) \\ & = \nabla \circ i_1 \circ p_1 \circ (f,g) + \nabla \circ i_2 \circ p_2 \circ (f,g) \\ & = p_1 \circ (f,g)  +  p_2 \circ (f,g) \\ & = f + g. \end{aligned}$'
+    $$p_1 \circ \alpha \circ \beta = p_1 \circ \alpha \circ i_1 \circ p_1 + p_1 \circ \alpha \circ i_2 \circ p_2 = \mathrm{id}_1 \circ p_1 + 0 \circ p_2 = p_1$$
+    and likewise $p_2 \circ \alpha \circ \beta = p_2$. We also have $\beta \circ \alpha = \mathrm{id}_{X \oplus Y}$ with a very similar calculation that shows $\beta \circ \alpha \circ i_1 = i_1$ and $\beta \circ \alpha \circ i_2 = i_2$. Therefore, for morphisms $f,g : A \rightrightarrows B$ the composite $A \to B$ in the claim is equal to
+    $$\begin{align*}
+    \nabla \circ \beta \circ (f,g) & = \nabla \circ (i_1 \circ p_1  + i_2 \circ p_2) \circ (f,g) \\
+    & = \nabla \circ i_1 \circ p_1 \circ (f,g) + \nabla \circ i_2 \circ p_2 \circ (f,g) \\
+    & = p_1 \circ (f,g) + p_2 \circ (f,g) \\
+    & = f + g.
+    \end{align*}$$'
 ),
 (
 	'generator_construction',
@@ -59,9 +63,9 @@ INSERT INTO lemmas (
     'Finite structures usually have no sequential colimits',
     'Let $\mathcal{C}$ be a category with finite powers, including a terminal object $1$. Let $a : 1 \to X$ be a morphism. Assume that the sequence of morphisms $(X^n,a) : X^n \to X^{n+1}$ for $n \geq 0$ admits a colimit $(i_n : X^n \to C)$. Then for every $m \geq 0$ there is a split epimorphism $C \to X^m$. In particular, if $U : \mathcal{C} \to \mathbf{Set}$ is a functor preserving finite powers and $\mathrm{card}(U(X)) \geq 2$, then $U(C)$ is infinite.',
     'Let $m \geq 0$ be fixed. For $n \geq 0$ we define a morphism $u_n : X^n \to X^m$ as follows: It is the projection on the first $m$ factors for $m \leq n$, and $(X^n,a^{m-n})$ for $m \geq n$ (for $m=n$ these agree). With generalized elements this says:
-    <p>$u_n(x_1,\dotsc,x_n) = \begin{cases} (x_1,\dotsc,x_m) & m \leq n \\ (x_1,\dotsc,x_n,a,\dotsc,a) & m \geq n \end{cases}$</p>
+    $$u_n(x_1,\dotsc,x_n) = \begin{cases} (x_1,\dotsc,x_m) & m \leq n \\ (x_1,\dotsc,x_n,a,\dotsc,a) & m \geq n \end{cases}$$
     We claim that $u_n = u_{n+1} \circ (X^n,a)$, i.e.
-    <p>$u_n(x_1,\dotsc,x_n) = u_{n+1}(x_1,\dotsc,x_n,a)$.</p>
+    $$u_n(x_1,\dotsc,x_n) = u_{n+1}(x_1,\dotsc,x_n,a).$$
     If $m \leq n$ (hence, $m \leq n+1$), both sides are equal to $(x_1,\dotsc,x_m)$. If $m > n$, i.e. $m \geq n+1$, both sides are equal to $(x_1,\dotsc,x_n,a,\dotsc,a)$. This proves the claim.
     <br>Hence, there is a unique morphism $\varphi : C \to X^m$ such that $\varphi \circ i_n = u_n$ for all $n \geq 0$. Since $u_m$ is the identity, $\varphi$ is a split epimorphism.
     <br>If $U$ is a functor with the mentioned properties, $U(\varphi)$ is also a split epimorphism from $U(C)$ to $U(X^m) \cong U(X)^m$, and $U(X)^m$ has $\geq 2^m$ elements. This holds for all $m$, so that $U(C)$ is infinite.'
@@ -99,18 +103,17 @@ INSERT INTO lemmas (
     'Exact filtered colimits descend to nice subcategories',
     'Let $G : \mathcal{C} \to \mathcal{D}$ be a fully faithful functor with a left adjoint $F : \mathcal{D} \to \mathcal{C}$ that preserves finite limits. Assume that $\mathcal{D}$ has exact filtered colimits and that $\mathcal{C}$ has finite limits. Then $\mathcal{C}$ has exact filtered colimits as well.',
     'It is well-known (and easy to prove) that the colimit of a diagram $(X_j)$ in $\mathcal{C}$ is constructed as $F(\mathrm{colim}_j G(X_j))$, provided that colimit in $\mathcal{D}$ exists. In particular, $\mathcal{C}$ has filtered colimits. By assumption, it also has finite limits, and $G$ preserves these since it is a right adjoint. Now let $X : \mathcal{I} \times \mathcal{J} \to \mathcal{C}$ be a diagram, where $\mathcal{I}$ is finite and $\mathcal{J}$ is filtered. We compute:
-    <p>$\phantom{\cong} \mathrm{colim}_j \lim_i X(i,j)$</p>
-    <p>$\cong F(\mathrm{colim}_j G(\lim_i X(i,j)))$</p>
-    <p>$\cong F(\mathrm{colim}_j \lim_i G(X(i,j)))$</p>
-    <p>$\cong F(\lim_i \mathrm{colim}_j G(X(i,j)))$</p>
-    <p>$\cong \lim_i F(\mathrm{colim}_j G(X(i,j)))$</p>
-    <p>$\cong \lim_i \mathrm{colim}_j X(i,j)$</p>'
+    $$\begin{align*} \mathrm{colim}_j {\lim}_i X(i,j) & \cong F(\mathrm{colim}_j G({\lim}_i X(i,j))) \\
+    & \cong F(\mathrm{colim}_j {\lim}_i G(X(i,j))) \\
+    & \cong F({\lim}_i \mathrm{colim}_j G(X(i,j))) \\
+    & \cong {\lim}_i F(\mathrm{colim}_j G(X(i,j))) \\
+    & \cong {\lim}_i \mathrm{colim}_j X(i,j)
+    \end{align*}$$'
 ),
 (
     'filtered-monos',
     'Detection of filtered-colimit-stable monomorphisms',
-    'Let $\mathcal{C}$ be a category with filtered colimits. Assume that $U : \mathcal{C} \to \mathcal{D}$ is faithful functor which preserves monomorphisms and filtered colimits. If monomorphisms in $\mathcal{D}$ are stable under filtered colimits, then the same is true for $\mathcal{C}$.
-    <br><br>
+    'Let $\mathcal{C}$ be a category with filtered colimits. Assume that $U : \mathcal{C} \to \mathcal{D}$ is faithful functor which preserves monomorphisms and filtered colimits. If monomorphisms in $\mathcal{D}$ are stable under filtered colimits, then the same is true for $\mathcal{C}$.<br><br>
     For the record, here is the dual statement: Let $\mathcal{C}$ be a category with cofiltered limits. Assume that $U : \mathcal{C} \to \mathcal{D}$ is faithful functor which preserves epimorphisms and cofiltered limits. If epimorphisms in $\mathcal{D}$ are stable under cofiltered limits, then the same is true for $\mathcal{C}$.
     ',
     'Since $U$ is faithful, it reflects monomorphisms. From here the proof is straight forward.'

--- a/src/lib/content/foundations.md
+++ b/src/lib/content/foundations.md
@@ -4,7 +4,9 @@ In _CatDat_, we work with the following convenient set-theoretic foundation for 
 
 ### Sets, collections, and hypercollections
 
-We work with [ZFC](https://en.wikipedia.org/wiki/Zermelo%E2%80%93Fraenkel_set_theory) and two [Grothendieck universes](https://en.wikipedia.org/wiki/Grothendieck_universe), which we denote by $\mathrm{Set} \in \mathrm{Set}^+$. Thus, in principle everything is a set, but we rename them as follows to introduce three "levels of size":
+We work with [ZFC](https://en.wikipedia.org/wiki/Zermelo%E2%80%93Fraenkel_set_theory) and two [Grothendieck universes](https://en.wikipedia.org/wiki/Grothendieck_universe), which we denote by
+$$\mathrm{Set} \in \mathrm{Set}^+.$$
+Thus, in principle everything is a set, but we rename them as follows to introduce three "levels of size":
 
 - The sets in $\mathrm{Set}$ are renamed to _sets_ (sometimes also _small sets_).
 - The sets in $\mathrm{Set}^+$ are renamed to _collections_ (sometimes also _large sets_).
@@ -12,7 +14,9 @@ We work with [ZFC](https://en.wikipedia.org/wiki/Zermelo%E2%80%93Fraenkel_set_th
 
 For example, $\mathbb{R}$ is a set, $\mathrm{Set}$ is a collection, and $\mathrm{Set}^+$ is a hypercollection. The collection $\mathrm{Set}$ consists of all sets, and the hypercollection $\mathrm{Set}^+$ consists of all collections. Every set is also a collection, and every collection is also a hypercollection. There is a collection $\mathrm{Grp}$ that consists of all groups, a collection $\mathrm{Top}$ of all topological spaces, etc.
 
-Note that sets, collections, and hypercollections all satisfy the ZFC axioms. In this sense, (hyper)collections behave in the same way as sets. This is crucial for category theory. For example, we can form the collection of all maps between two collections. This basic property is not satisfied by [classes](<https://en.wikipedia.org/wiki/Class_(set_theory)>), which are not adequate for category theory. For example, there is a collection $[\mathrm{Set},\mathrm{Set}]$ that consists of all maps $\mathrm{Set} \to \mathrm{Set}$.
+Note that sets, collections, and hypercollections all satisfy the ZFC axioms. In this sense, (hyper)collections behave in the same way as sets. This is crucial for category theory. For example, we can form the collection of all maps between two collections. This basic property is not satisfied by [classes](<https://en.wikipedia.org/wiki/Class_(set_theory)>), which are not adequate for category theory.
+
+For example, there is a collection $[\mathrm{Set},\mathrm{Set}]$ that consists of all maps $\mathrm{Set} \to \mathrm{Set}$.
 
 Just imagine three copies of ZFC embedded into each other, each representing a "level of size". Grothendieck universes are merely an implementation detail, which we can _and will_ drop from now on. Sets are on level 1, collections on level 2, and hypercollections on level 3. Concrete mathematical objects such as numbers or functions can be thought of as living on level 0 (even though they are usually modeled as sets in ZFC).
 
@@ -37,11 +41,13 @@ A _category_ $\mathcal{C}$ consists of a pair of collections $O, M$, whose eleme
 
 such that the usual [axioms of a category](<https://en.wikipedia.org/wiki/Category_(mathematics)>) are satisfied. The domain of $c$ consists of all pairs of morphisms $(f,g)$ with $s(f) = t(g)$, and we write $f \circ g := c(f,g)$ for their composition. Instead of $i(X)$ one usually writes $\mathrm{id}_X$ for the identity morphism of $X$. Formally, a category is a tuple
 
-$\mathcal{C} = (O,M,i,s,t,c)$
+$$\mathcal{C} = (O,M,i,s,t,c)$$
 
 of collections (and hence a collection itself). We write $\mathrm{Ob}(\mathcal{C}) := O$ and $\mathrm{Mor}(\mathcal{C}) := M$. Instead of $X \in \mathrm{Ob}(\mathcal{C})$, we often write $X \in \mathcal{C}$.
 
-When $f \in \mathrm{Mor}(\mathcal{C})$ is a morphism with $s(f) = X$ and $t(f) = Y$, we write $f : X \to Y$. We write $\mathrm{Hom}(X,Y)$ or $\mathrm{Mor}(X,Y)$ for the collection of such morphisms. This collection need not be a set. If it is a set for all $X,Y$, the category is called _locally small_.
+When $f \in \mathrm{Mor}(\mathcal{C})$ is a morphism with $s(f) = X$ and $t(f) = Y$, we write
+$$f : X \to Y.$$
+We write $\mathrm{Hom}(X,Y)$ or $\mathrm{Mor}(X,Y)$ for the collection of such morphisms. This collection need not be a set. If it is a set for all $X,Y$, the category is called _locally small_.
 
 A _small category_ is defined as above, but using _sets_ $O$ and $M$ (instead of collections). A _hypercategory_ is defined similarly using _hypercollections_ $O$ and $M$. Every small category is a category, and every category is a hypercategory. Notice that there is a collection of all small categories $\mathrm{Cat}$, and likewise a hypercollection of all categories $\mathrm{Cat}^+$.
 
@@ -51,7 +57,10 @@ Collections are the objects of a hypercategory $\mathbf{Set}^+$.
 
 ### Functors
 
-A _functor_ $F : \mathcal{C} \to \mathcal{D}$ between two categories (or small categories, or hypercategories) is defined as usual; it consists of maps $\mathrm{Ob}(F) : \mathrm{Ob}(\mathcal{C}) \to \mathrm{Ob}(\mathcal{D})$ and $\mathrm{Mor}(F) : \mathrm{Mor}(\mathcal{C}) \to \mathrm{Mor}(\mathcal{D})$ satisfying the [functor axioms](https://en.wikipedia.org/wiki/Functor). Between two categories there is a collection of all functors, just as between two small categories there is a set of all functors.
+A _functor_ $F : \mathcal{C} \to \mathcal{D}$ between two categories (or small categories, or hypercategories) is defined as usual; it consists of maps
+$$\mathrm{Ob}(F) : \mathrm{Ob}(\mathcal{C}) \to \mathrm{Ob}(\mathcal{D}),$$
+$$\mathrm{Mor}(F) : \mathrm{Mor}(\mathcal{C}) \to \mathrm{Mor}(\mathcal{D})$$
+satisfying the [functor axioms](https://en.wikipedia.org/wiki/Functor). Between two categories there is a collection of all functors, just as between two small categories there is a set of all functors.
 
 Small categories and functors form the category $\mathbf{Cat}$ of small categories, which is locally small. There is also a hypercategory $\mathbf{Cat}^+$ consisting of all categories. For instance, $\mathbf{Set}$ is an object of $\mathbf{Cat}^+$, but not of $\mathbf{Cat}$.
 
@@ -65,11 +74,13 @@ It is better to state explicitly when the assumption of being locally small is n
 
 If $\mathcal{C}$ is any category and $A \in \mathcal{C}$, we have the Hom-functor
 
-$\mathrm{Hom}(A,-) : \mathcal{C} \to \mathbf{Set}^+$
+$$\mathrm{Hom}(A,-) : \mathcal{C} \to \mathbf{Set}^+$$
 
 defined as usual, but taking values in the hypercategory of all collections. The Yoneda lemma and its corollaries can be proved without assuming that $\mathcal{C}$ is locally small. If $\mathcal{C}$ is locally small, then $\mathrm{Hom}(A,-)$ takes values in $\mathbf{Set}$.
 
-Adjunctions are defined as usual via natural isomorphisms $\mathrm{Hom}(F(A),B) \cong \mathrm{Hom}(A,G(B))$ of functors valued in $\mathbf{Set}^+$. No local smallness assumption is required. Equivalently, they can be defined via morphisms of functors $\mathrm{id} \to G \circ F$ and $F \circ G \to \mathrm{id}$ satisfying the triangle identities.
+Adjunctions are defined as usual via natural isomorphisms
+$$\mathrm{Hom}(F(A),B) \cong \mathrm{Hom}(A,G(B))$$
+of functors valued in $\mathbf{Set}^+$. No local smallness assumption is required. Equivalently, they can be defined via morphisms of functors $\mathrm{id} \to G \circ F$ and $F \circ G \to \mathrm{id}$ satisfying the triangle identities.
 
 ### Limits and Colimits
 

--- a/src/lib/server/rendering.ts
+++ b/src/lib/server/rendering.ts
@@ -2,7 +2,10 @@ import katex from 'katex'
 import { is_object } from './utils'
 import MarkdownIt from 'markdown-it'
 
-function render_formula(formula: string): string {
+function render_formula(
+	formula: string,
+	options: { displayMode: boolean } = { displayMode: false },
+): string {
 	if (formula.includes('\\emptyset')) {
 		console.warn(
 			`Warning: Use \\varnothing instead of \\emptyset.\nFormula: ${formula}`,
@@ -11,14 +14,19 @@ function render_formula(formula: string): string {
 
 	return katex.renderToString(formula, {
 		throwOnError: true,
+		...options,
 	})
 }
 
-const math_regex = /\$(.*?)\$/g
+const math_regex = /\$\$(.*?)\$\$|\$(.*?)\$/gs
 
 export function render_formulas(txt: string): string {
-	return txt.replace(math_regex, (_, formula) => {
-		return render_formula(formula)
+	return txt.replace(math_regex, (_, display_formula, inline_formula) => {
+		if (display_formula !== undefined) {
+			return render_formula(display_formula, { displayMode: true })
+		}
+
+		return render_formula(inline_formula, { displayMode: false })
 	})
 }
 

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -284,3 +284,14 @@ label {
 		border-radius: 0.5rem;
 	}
 }
+
+/* cf. https://katex.org/docs/issues */
+.katex-display > .katex {
+	white-space: normal;
+}
+.katex-display > .base {
+	margin: 0.25em 0;
+}
+.katex-display {
+	margin: 0.5em 0;
+}


### PR DESCRIPTION
With this PR we can render formulas in display mode by using the delimiters `$$ ... $$`. The [katex documentation](https://katex.org/docs/options.html) explains what display mode means.

In display mode we can also typeset commutative diagrams via the [amscd package](https://www.jmilne.org/not/Mamscd.pdf).

For example, this commutative diagram

<img width="185" height="145" alt="Bildschirmfoto 2026-04-23 um 21 58 16" src="https://github.com/user-attachments/assets/615b966a-c494-4d09-8ba9-94abd499bd56" />

can be typeset via:

```
$$\begin{CD} X @>{\mathrm{id}}>> X \\ @V{\mathrm{id}}VV @VV{f}V \\ X @>>{f}> Y \end{CD}$$
```

## Diagrams

This PR has replaced all "manual" array diagrams with amscd diagrams. They look much better now.

<img width="600" alt="proof that Delta is cosifted" src="https://github.com/user-attachments/assets/0a8a7c39-d3fc-43af-aa5b-3a777f1a4743" /><br />

## Align environments

The `align` environment is also possible in display mode.

<img width="600"  alt="isomorphism chain in display mode" src="https://github.com/user-attachments/assets/904e8f06-4a84-40b3-9e25-ee69f6d3e289" /><br />

## Display mode

This PR also uses display mode in several existing formulas (probably not all) where it was intended anyway. 

<img width="600" alt="typical proof with displaymode formula" src="https://github.com/user-attachments/assets/3e401220-aac5-4e1b-9474-d1d90ea5c4b1" />




