### PR TITLE
Search: Save selected properties + link properties

### DIFF
--- a/src/components/Selection.svelte
+++ b/src/components/Selection.svelte
@@ -127,6 +127,7 @@
 		<div class="input-wrapper">
 			<input
 				aria-label={item_label}
+				name={item_label}
 				aria-invalid={item.trim().length > 0 && !is_valid(item)}
 				type="text"
 				bind:value={item}

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,5 +1,5 @@
 import { redirect } from '@sveltejs/kit'
-import { has_session } from './sessions.js'
+import { has_session } from './sessions'
 
 export const prerender = false
 

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -227,6 +227,7 @@ button:focus-visible {
 	padding: 0.2rem 0.8rem;
 	color: var(--button-text-color);
 	background-color: var(--button-color);
+	white-space: nowrap;
 }
 
 a.button {

--- a/src/routes/category-properties/+page.svelte
+++ b/src/routes/category-properties/+page.svelte
@@ -3,7 +3,7 @@
 	import SearchFilter from '$components/SearchFilter.svelte'
 	import SuggestionForm from '$components/SuggestionForm.svelte'
 	import { pluralize } from '$lib/client/utils'
-	import { get_property_url } from '$lib/commons/property.url.js'
+	import { get_property_url } from '$lib/commons/property.url'
 
 	let { data } = $props()
 

--- a/src/routes/category-search/+page.svelte
+++ b/src/routes/category-search/+page.svelte
@@ -5,6 +5,7 @@
 	import MetaData from '$components/MetaData.svelte'
 	import { SEARCH_SEPARATOR } from '$lib/commons/search.config'
 	import { navigating } from '$app/state'
+	import { browser } from '$app/environment'
 
 	let { data } = $props()
 
@@ -14,6 +15,26 @@
 	let is_valid_search = $derived(
 		satisfied_properties.length > 0 || unsatisfied_properties.length > 0,
 	)
+
+	$effect(() => {
+		preload_search_config()
+	})
+
+	function preload_search_config() {
+		if (!browser) return
+
+		const saved_search_txt = window.sessionStorage.getItem('category-search')
+		if (!saved_search_txt) return
+
+		try {
+			const saved_search = JSON.parse(saved_search_txt) as {
+				satisfied_properties: string[]
+				unsatisfied_properties: string[]
+			}
+			satisfied_properties = saved_search.satisfied_properties
+			unsatisfied_properties = saved_search.unsatisfied_properties
+		} catch (_) {}
+	}
 
 	function request_search_results() {
 		if (!is_valid_search) return
@@ -30,6 +51,13 @@
 
 		if (satisfied_query) url.searchParams.set('satisfied', satisfied_query)
 		if (unsatisfied_query) url.searchParams.set('unsatisfied', unsatisfied_query)
+
+		if (browser) {
+			window.sessionStorage.setItem(
+				'category-search',
+				JSON.stringify({ satisfied_properties, unsatisfied_properties }),
+			)
+		}
 
 		goto(url)
 	}

--- a/src/routes/category-search/+page.svelte
+++ b/src/routes/category-search/+page.svelte
@@ -62,6 +62,12 @@
 		goto(url)
 	}
 
+	function reset() {
+		if (browser) window.sessionStorage.removeItem('category-search')
+		satisfied_properties = []
+		unsatisfied_properties = []
+	}
+
 	const sample_search_url = `/category-search/results?satisfied=finitely_complete${SEARCH_SEPARATOR}pointed&unsatisfied=complete`
 
 	let is_searching = $derived(navigating.to?.route.id === '/category-search/results')
@@ -96,15 +102,25 @@
 	item_label="Unsatisfied property"
 />
 
-<button
-	type="button"
-	class="button"
-	onclick={request_search_results}
-	disabled={is_searching || !is_valid_search}
->
-	{#if is_searching}
-		Searching...
-	{:else}
-		Search
-	{/if}
-</button>
+<menu>
+	<button
+		class="button"
+		onclick={request_search_results}
+		disabled={is_searching || !is_valid_search}
+	>
+		{#if is_searching}
+			Searching...
+		{:else}
+			Search
+		{/if}
+	</button>
+
+	<button class="button" onclick={reset} disabled={is_searching}>Reset</button>
+</menu>
+
+<style>
+	menu {
+		display: flex;
+		gap: 1rem;
+	}
+</style>

--- a/src/routes/category-search/results/+page.svelte
+++ b/src/routes/category-search/results/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment'
 	import CategoryList from '$components/CategoryList.svelte'
-	import { encode_property_ID } from '$lib/commons/property.url'
+	import { encode_property_ID, get_property_url } from '$lib/commons/property.url'
 	import MetaData from '$components/MetaData.svelte'
 	import { SEARCH_SEPARATOR } from '$lib/commons/search.config'
 	import { pluralize } from '$lib/client/utils'
@@ -37,18 +37,31 @@
 
 <h2>Search Results</h2>
 
-<ul>
-	{#if data.satisfied_properties.length > 0}
-		<li>
-			Satisfied properties: {data.satisfied_properties.join(', ')}
-		</li>
-	{/if}
-	{#if data.unsatisfied_properties.length > 0}
-		<li>
-			Unsatisfied properties: {data.unsatisfied_properties.join(', ')}
-		</li>
-	{/if}
-</ul>
+{#if data.satisfied_properties.length > 0}
+	<div>
+		<span>Satisfied properties:</span>
+
+		{#each data.satisfied_properties as property, index}
+			<a href={get_property_url(property, 'category')}>{property}</a
+			>{#if index < data.satisfied_properties.length - 1}
+				,&nbsp;
+			{/if}
+		{/each}
+	</div>
+{/if}
+
+{#if data.unsatisfied_properties.length > 0}
+	<div>
+		<span>Unsatisfied properties:</span>
+
+		{#each data.unsatisfied_properties as property, index}
+			<a href={get_property_url(property, 'category')}>{property}</a
+			>{#if index < data.unsatisfied_properties.length - 1}
+				,&nbsp;
+			{/if}
+		{/each}
+	</div>
+{/if}
 
 {#if data.is_consistent}
 	<p class="hint">

--- a/src/routes/category-search/results/+page.svelte
+++ b/src/routes/category-search/results/+page.svelte
@@ -78,7 +78,7 @@
 {/if}
 
 <menu>
-	<a class="button" href="/category-search">Start new search</a>
+	<a class="button" href="/category-search">Adjust search</a>
 
 	{#if data.dual_search_available}
 		<a class="button" href={get_dual_search_results_link()}>Dualize search</a>

--- a/src/routes/functor-search/+page.svelte
+++ b/src/routes/functor-search/+page.svelte
@@ -62,6 +62,12 @@
 		goto(url)
 	}
 
+	function reset() {
+		if (browser) window.sessionStorage.removeItem('functor-search')
+		satisfied_properties = []
+		unsatisfied_properties = []
+	}
+
 	const sample_search_url = `/functor-search/results?satisfied=continuous&unsatisfied=cocontinuous`
 
 	let is_searching = $derived(navigating.to?.route.id === '/functor-search/results')
@@ -96,15 +102,26 @@
 	item_label="Unsatisfied property"
 />
 
-<button
-	type="button"
-	class="button"
-	onclick={request_search_results}
-	disabled={is_searching || !is_valid_search}
->
-	{#if is_searching}
-		Searching...
-	{:else}
-		Search
-	{/if}
-</button>
+<menu>
+	<button
+		type="button"
+		class="button"
+		onclick={request_search_results}
+		disabled={is_searching || !is_valid_search}
+	>
+		{#if is_searching}
+			Searching...
+		{:else}
+			Search
+		{/if}
+	</button>
+
+	<button class="button" onclick={reset} disabled={is_searching}>Reset</button>
+</menu>
+
+<style>
+	menu {
+		display: flex;
+		gap: 1rem;
+	}
+</style>

--- a/src/routes/functor-search/+page.svelte
+++ b/src/routes/functor-search/+page.svelte
@@ -5,6 +5,7 @@
 	import MetaData from '$components/MetaData.svelte'
 	import { SEARCH_SEPARATOR } from '$lib/commons/search.config'
 	import { navigating } from '$app/state'
+	import { browser } from '$app/environment'
 
 	let { data } = $props()
 
@@ -14,6 +15,26 @@
 	let is_valid_search = $derived(
 		satisfied_properties.length > 0 || unsatisfied_properties.length > 0,
 	)
+
+	$effect(() => {
+		preload_search_config()
+	})
+
+	function preload_search_config() {
+		if (!browser) return
+
+		const saved_search_txt = window.sessionStorage.getItem('functor-search')
+		if (!saved_search_txt) return
+
+		try {
+			const saved_search = JSON.parse(saved_search_txt) as {
+				satisfied_properties: string[]
+				unsatisfied_properties: string[]
+			}
+			satisfied_properties = saved_search.satisfied_properties
+			unsatisfied_properties = saved_search.unsatisfied_properties
+		} catch (_) {}
+	}
 
 	function request_search_results() {
 		if (!is_valid_search) return
@@ -30,6 +51,13 @@
 
 		if (satisfied_query) url.searchParams.set('satisfied', satisfied_query)
 		if (unsatisfied_query) url.searchParams.set('unsatisfied', unsatisfied_query)
+
+		if (browser) {
+			window.sessionStorage.setItem(
+				'functor-search',
+				JSON.stringify({ satisfied_properties, unsatisfied_properties }),
+			)
+		}
 
 		goto(url)
 	}

--- a/src/routes/functor-search/results/+page.svelte
+++ b/src/routes/functor-search/results/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment'
-	import { encode_property_ID } from '$lib/commons/property.url'
+	import { encode_property_ID, get_property_url } from '$lib/commons/property.url'
 	import MetaData from '$components/MetaData.svelte'
 	import { SEARCH_SEPARATOR } from '$lib/commons/search.config'
 	import { pluralize } from '$lib/client/utils'
@@ -35,18 +35,31 @@
 
 <h2>Search results</h2>
 
-<ul>
-	{#if data.satisfied_properties.length > 0}
-		<li>
-			Satisfied properties: {data.satisfied_properties.join(', ')}
-		</li>
-	{/if}
-	{#if data.unsatisfied_properties.length > 0}
-		<li>
-			Unsatisfied properties: {data.unsatisfied_properties.join(', ')}
-		</li>
-	{/if}
-</ul>
+{#if data.satisfied_properties.length > 0}
+	<div>
+		<span>Satisfied properties:</span>
+
+		{#each data.satisfied_properties as property, index}
+			<a href={get_property_url(property, 'functor')}>{property}</a
+			>{#if index < data.satisfied_properties.length - 1}
+				,&nbsp;
+			{/if}
+		{/each}
+	</div>
+{/if}
+
+{#if data.unsatisfied_properties.length > 0}
+	<div>
+		<span>Unsatisfied properties:</span>
+
+		{#each data.unsatisfied_properties as property, index}
+			<a href={get_property_url(property, 'functor')}>{property}</a
+			>{#if index < data.unsatisfied_properties.length - 1}
+				,&nbsp;
+			{/if}
+		{/each}
+	</div>
+{/if}
 
 <p class="hint">
 	{pluralize(data.found_objects.length, {

--- a/src/routes/functor-search/results/+page.svelte
+++ b/src/routes/functor-search/results/+page.svelte
@@ -71,7 +71,7 @@
 <FunctorList functors={data.found_objects ?? []} />
 
 <menu>
-	<a class="button" href="/functor-search">Start new search</a>
+	<a class="button" href="/functor-search">Adjust search</a>
 
 	{#if data.dual_search_available}
 		<a class="button" href={get_dual_search_results_link()}>Dualize search</a>


### PR DESCRIPTION
This PR implements #130 and #131.

1. Selected properties on the search result page are links to their detail pages.
3. The selected properties are saved (in the browser's session storage). Thus, when the user goes back from the search result page to the search page*, they can *adjust* the search and do not need to start over. Hence, the button text "Start new search" has been replaced with "Adjust search"
4. On the search page, there is a button that clears the selected properties.
5. All adjustments to the category search have also been made to the functor search.



*Why these should be separate pages has been explained and implemented in #60.