### PR TITLE
Order property assignments

### DIFF
--- a/databases/catdat/migrations/014_order_assignments.sql
+++ b/databases/catdat/migrations/014_order_assignments.sql
@@ -1,0 +1,35 @@
+DROP TABLE category_property_assignments;
+
+CREATE TABLE category_property_assignments (
+    id INTEGER PRIMARY KEY,
+    category_id TEXT NOT NULL,
+    property_id TEXT NOT NULL,
+    is_satisfied INTEGER NOT NULL
+        CHECK (is_satisfied in (TRUE, FALSE)),
+    reason TEXT NOT NULL CHECK (length(reason) > 0),
+    is_deduced INTEGER NOT NULL DEFAULT FALSE
+        CHECK (is_deduced in (TRUE, FALSE)),
+    UNIQUE (category_id, property_id),
+    FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE,
+    FOREIGN KEY (property_id) REFERENCES category_properties (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_property_category ON category_property_assignments (property_id);
+
+DROP TABLE functor_property_assignments;
+
+CREATE TABLE functor_property_assignments (
+    id INTEGER PRIMARY KEY,
+    functor_id TEXT NOT NULL,
+    property_id TEXT NOT NULL,
+    is_satisfied INTEGER NOT NULL
+        CHECK (is_satisfied IN (TRUE, FALSE)),
+    reason TEXT NOT NULL CHECK (length(reason) > 0),
+    is_deduced INTEGER NOT NULL DEFAULT FALSE
+        CHECK (is_deduced in (TRUE, FALSE)),
+    UNIQUE (functor_id, property_id),
+    FOREIGN KEY (functor_id) REFERENCES functors (id) ON DELETE CASCADE,
+    FOREIGN KEY (property_id) REFERENCES functor_properties (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_property_functor ON functor_property_assignments (property_id);

--- a/databases/catdat/scripts/deduce-category-properties.ts
+++ b/databases/catdat/scripts/deduce-category-properties.ts
@@ -281,18 +281,17 @@ async function deduce_satisfied_category_properties(
 		const value_fragments: string[] = []
 		const values: (string | number)[] = []
 
-		for (let i = 0; i < deduced_satisfied_props.length; i++) {
-			const id = deduced_satisfied_props[i]
-			value_fragments.push(`(?, ?, TRUE, ?, ?, TRUE)`)
-			values.push(category_id, id, reasons[id], i + 1)
+		for (const id of deduced_satisfied_props) {
+			value_fragments.push(`(?, ?, TRUE, ?, TRUE)`)
+			values.push(category_id, id, reasons[id])
 		}
 
 		const insert_sql = options.check_conflicts
 			? `INSERT INTO category_property_assignments
-				(category_id, property_id, is_satisfied, reason, position, is_deduced)
+				(category_id, property_id, is_satisfied, reason, is_deduced)
 				VALUES ${value_fragments.join(',\n')}`
 			: `INSERT INTO category_property_assignments
-				(category_id, property_id, is_satisfied, reason, position, is_deduced)
+				(category_id, property_id, is_satisfied, reason, is_deduced)
 				VALUES ${value_fragments.join(',\n')}
 				ON CONFLICT (category_id, property_id) DO NOTHING`
 
@@ -390,18 +389,17 @@ async function deduce_unsatisfied_category_properties(
 		const value_fragments: string[] = []
 		const values: (string | number)[] = []
 
-		for (let i = 0; i < deduced_unsatisfied_props.length; i++) {
-			const id = deduced_unsatisfied_props[i]
-			value_fragments.push('(?, ?, FALSE, ?, ?, TRUE)')
-			values.push(category_id, id, reasons[id], i + 1)
+		for (const id of deduced_unsatisfied_props) {
+			value_fragments.push('(?, ?, FALSE, ?, TRUE)')
+			values.push(category_id, id, reasons[id])
 		}
 
 		const insert_query = options.check_conflicts
 			? `INSERT INTO category_property_assignments
-				(category_id, property_id, is_satisfied, reason, position, is_deduced)
+				(category_id, property_id, is_satisfied, reason, is_deduced)
 				VALUES ${value_fragments.join(',\n')}`
 			: `INSERT INTO category_property_assignments
-				(category_id, property_id, is_satisfied, reason, position, is_deduced)
+				(category_id, property_id, is_satisfied, reason, is_deduced)
 				VALUES ${value_fragments.join(',\n')}
 				ON CONFLICT (category_id, property_id) DO NOTHING`
 

--- a/databases/catdat/scripts/deduce-category-properties.ts
+++ b/databases/catdat/scripts/deduce-category-properties.ts
@@ -286,14 +286,16 @@ async function deduce_satisfied_category_properties(
 			values.push(category_id, id, reasons[id])
 		}
 
-		const insert_sql = options.check_conflicts
-			? `INSERT INTO category_property_assignments
+		const conflict_clause = options.check_conflicts
+			? ''
+			: 'ON CONFLICT (category_id, property_id) DO NOTHING'
+
+		const insert_sql = `
+			INSERT INTO category_property_assignments
 				(category_id, property_id, is_satisfied, reason, is_deduced)
-				VALUES ${value_fragments.join(',\n')}`
-			: `INSERT INTO category_property_assignments
-				(category_id, property_id, is_satisfied, reason, is_deduced)
-				VALUES ${value_fragments.join(',\n')}
-				ON CONFLICT (category_id, property_id) DO NOTHING`
+			VALUES ${value_fragments.join(',\n')}
+			${conflict_clause}
+		`
 
 		try {
 			await tx.execute({ sql: insert_sql, args: values })
@@ -394,14 +396,16 @@ async function deduce_unsatisfied_category_properties(
 			values.push(category_id, id, reasons[id])
 		}
 
-		const insert_query = options.check_conflicts
-			? `INSERT INTO category_property_assignments
+		const conflict_clause = options.check_conflicts
+			? ''
+			: 'ON CONFLICT (category_id, property_id) DO NOTHING'
+
+		const insert_query = `
+			INSERT INTO category_property_assignments
 				(category_id, property_id, is_satisfied, reason, is_deduced)
-				VALUES ${value_fragments.join(',\n')}`
-			: `INSERT INTO category_property_assignments
-				(category_id, property_id, is_satisfied, reason, is_deduced)
-				VALUES ${value_fragments.join(',\n')}
-				ON CONFLICT (category_id, property_id) DO NOTHING`
+			VALUES ${value_fragments.join(',\n')}
+			${conflict_clause}
+		`
 
 		try {
 			await tx.execute({ sql: insert_query, args: values })

--- a/databases/catdat/scripts/deduce-functor-properties.ts
+++ b/databases/catdat/scripts/deduce-functor-properties.ts
@@ -270,15 +270,14 @@ async function deduce_satisfied_functor_properties(
 		const value_fragments: string[] = []
 		const values: (string | number)[] = []
 
-		for (let i = 0; i < deduced_satisfied_props.length; i++) {
-			const id = deduced_satisfied_props[i]
-			value_fragments.push(`(?, ?, TRUE, ?, ?, TRUE)`)
-			values.push(functor.id, id, reasons[id], i + 1)
+		for (const id of deduced_satisfied_props) {
+			value_fragments.push(`(?, ?, TRUE, ?, TRUE)`)
+			values.push(functor.id, id, reasons[id])
 		}
 
 		const insert_sql = `
 			INSERT INTO functor_property_assignments (
-				functor_id, property_id, is_satisfied, reason, position, is_deduced
+				functor_id, property_id, is_satisfied, reason, is_deduced
 			)
 			VALUES
 			${value_fragments.join(',\n')}
@@ -361,13 +360,13 @@ async function deduce_unsatisfied_functor_properties(
 
 		for (let i = 0; i < deduced_unsatisfied_props.length; i++) {
 			const id = deduced_unsatisfied_props[i]
-			value_fragments.push('(?, ?, FALSE, ?, ?, TRUE)')
-			values.push(functor.id, id, reasons[id], i + 1)
+			value_fragments.push('(?, ?, FALSE, ?, TRUE)')
+			values.push(functor.id, id, reasons[id])
 		}
 
 		const insert_query = `
 			INSERT INTO functor_property_assignments (
-				functor_id, property_id, is_satisfied, reason, position, is_deduced
+				functor_id, property_id, is_satisfied, reason, is_deduced
 			)
 			VALUES
 			${value_fragments.join(',\n')}`

--- a/src/routes/category/[id]/+page.server.ts
+++ b/src/routes/category/[id]/+page.server.ts
@@ -82,7 +82,7 @@ export const load = async (event) => {
 			INNER JOIN category_properties p ON p.id = cp.property_id
 			INNER JOIN relations r ON r.relation = p.relation
 			WHERE cp.category_id = ${id}
-			ORDER BY cp.position, lower(cp.property_id)
+			ORDER BY cp.id
 		`,
 		// unknown properties
 		sql`

--- a/src/routes/functor/[id]/+page.server.ts
+++ b/src/routes/functor/[id]/+page.server.ts
@@ -51,7 +51,7 @@ export const load = async (event) => {
 			INNER JOIN functor_properties p ON p.id = fp.property_id
 			INNER JOIN relations r ON r.relation = p.relation
 			WHERE fp.functor_id = ${id}
-			ORDER BY fp.position, lower(fp.property_id)
+			ORDER BY fp.id
 		`,
 		// unknown properties
 		sql`


### PR DESCRIPTION
When manually assigning properties to categories, it often happens that one proof refers to an assignment made earlier in the file. However, before this PR, manually assigned properties were listed alphabetically. This could be confusing, since the proofs could not be read from top to bottom in their natural order. It could also result in less important properties being listed first.

This PR resolves the issue by assigning an autoincrementing ID to every property assignment, whether manual or deduced. Previously, the table used a composite primary key consisting of category ID and property ID. Displayed properties are now ordered by ID and therefore appear in the same order as in the file where they are assigned. This also allows contributors to deliberately choose which properties should be shown first.

The `position` column previously used for deduced properties is now redundant. Deduced properties are still displayed in a logical order, unaffected by this PR, and their order cannot be influenced by contributors.

The same remarks apply to assignments of properties to functors.

## Before

This is from the `walking_fork` page. It is weird that "cofiltered-limit-stable epimorphisms" appears first.

<img width="378" height="464" alt="Bildschirmfoto 2026-04-25 um 13 02 54" src="https://github.com/user-attachments/assets/526e8774-5433-43a4-b381-7b716c984ba5" /><br />

## After

<img width="399" height="465" alt="Bildschirmfoto 2026-04-25 um 13 03 04" src="https://github.com/user-attachments/assets/0d4a54ee-8ded-4ee7-baa1-37bc1888389c" /><br />

This has now the same order as in the file:

```sql
(
	'walking_fork',
	'finite',
	TRUE,
	'This is trivial.'
),
(
	'walking_fork',
	'small',
	TRUE,
	'This is trivial.'
),
...
```

## Before

This is taken from the `Top` page. It is weird that "locally small" is quite at the bottom, while "coregular" is quite at the top (among other things).

<img width="394" height="458" alt="Bildschirmfoto 2026-04-25 um 13 13 44" src="https://github.com/user-attachments/assets/fcfc9ac5-41aa-4806-bddf-9e89e2872d6a" /><br />

## After

<img width="402" height="467" alt="Bildschirmfoto 2026-04-25 um 13 13 53" src="https://github.com/user-attachments/assets/a35b47e6-6758-401a-8d5c-de49a11abeeb" /><br />





