### PR TITLE
Two results on finite categories

### DIFF
--- a/databases/catdat/data/003_category-property-assignments/walking_fork.sql
+++ b/databases/catdat/data/003_category-property-assignments/walking_fork.sql
@@ -73,12 +73,6 @@ VALUES
 ),
 (
 	'walking_fork',
-	'cofiltered-limit-stable epimorphisms',
-	TRUE,
-	'Let $(X_p)$ and $(Y_p)$ be diagrams in the walking fork indexed by a cofiltered poset $P$. Let $(X_p \to Y_p)_{p \in P}$ be compatible epimorphisms, we need to show that $\lim_p X_p \to \lim_p Y_p$ is an epimorphism as well. Assume it is not. The only non-epimorphism is $i : 0 \to 1$. Hence, $\lim_p X_p = 0$ and $\lim_p Y_p = 1$. So for every $p$ there is a morphism $1 \to Y_p$, meaning $Y_p \in \{1,2\}$. If $Y_p = 2$ for all $p$, the transition morphisms between them must be identities, so that $\lim_p Y_p = 2$, a contradiction. Choose $p$ with $Y_p = 1$. Then for all $q \leq p$ the morphism $Y_q \to Y_p$ shows that $Y_q = 1$ as well. Since $X_q \to Y_q = 1$ is an epimorphism by assumption, it cannot be $i : 0 \to 1$, and we see that $X_q = 1$. Then the transitions between the $X_q$ are identities, and we get the contradiction $\lim_p X_p = \lim_q X_q = 1$.'
-),
-(
-	'walking_fork',
 	'terminal object',
 	FALSE,
 	'$0$ and $1$ are not terminal since there is no morphism from $2$, and $2$ is not terminal since there are two different morphisms $1 \rightrightarrows 2$.'

--- a/databases/catdat/data/003_category-property-assignments/walking_splitting.sql
+++ b/databases/catdat/data/003_category-property-assignments/walking_splitting.sql
@@ -75,12 +75,6 @@ VALUES
 ),
 (
 	'walking_splitting',
-	'filtered-colimit-stable monomorphisms',
-	TRUE,
-	'We saw above that the embedding $\mathbf{Vect}^{\leq 1}_{\mathbb{F}_2} \hookrightarrow \mathbf{Vect}_{\mathbb{F}_2}$ is closed under sifted colimits, hence under filtered colimits. Hence, it preserves filtered colimits. Moreover, it preserves and reflects monomorphisms. Therefore, the claim follows from $\mathbf{Vect}_{\mathbb{F}_2}$.'
-),
-(
-	'walking_splitting',
 	'one-way',
 	FALSE,
 	'The morphism $ip : 1 \to 1$ provides a counterexample.'

--- a/databases/catdat/data/004_category-implications/001_limits-colimits-existence-implications.sql
+++ b/databases/catdat/data/004_category-implications/001_limits-colimits-existence-implications.sql
@@ -181,6 +181,15 @@ VALUES
 ),
 (
 	'finite_filtered_colimits',
+	-- TODO: combine this with "finitely accessible" below
+	-- once its dual is added to the database.
+	'["essentially finite", "Cauchy complete"]',
+	'["filtered colimits"]',
+	'See <a href="https://mathoverflow.net/questions/509853" target="_blank">MO/509853</a>.',
+	FALSE
+),
+(
+	'finite_accessible',
 	'["essentially finite", "Cauchy complete"]',
 	'["finitely accessible"]',
 	'See <a href="https://mathoverflow.net/questions/509853" target="_blank">MO/509853</a>, where it is in fact shown that the ind-completion of any finite Cauchy-complete category becomes itself.',

--- a/databases/catdat/data/004_category-implications/001_limits-colimits-existence-implications.sql
+++ b/databases/catdat/data/004_category-implications/001_limits-colimits-existence-implications.sql
@@ -184,8 +184,8 @@ VALUES
 	-- TODO: combine this with "finitely accessible" below
 	-- once its dual is added to the database.
 	'["essentially finite", "Cauchy complete"]',
-	'["filtered colimits"]',
-	'See <a href="https://mathoverflow.net/questions/509853" target="_blank">MO/509853</a>.',
+	'["filtered colimits", "filtered-colimit-stable monomorphisms"]',
+	'We may assume that the category $\mathcal{C}$ is finite and Cauchy complete. The answer at <a href="https://mathoverflow.net/questions/509853" target="_blank">MO/509853</a> shows that every filtered colimit in $\mathcal{C}$ exists, in fact it is a retract of one of the objects in the diagram. Now apply this to the morphism category of $\mathcal{C}$. It follows that for every filtered diagram of morphisms $X_i \to Y_i$ their colimit $X_\infty \to Y_\infty$ exists, which is a retract of one of the $X_i \to Y_i$. Therefore, if every $X_i \to Y_i$ is a monomorphism, also $X_\infty \to Y_\infty$ is a monomorphism.',
 	FALSE
 ),
 (


### PR DESCRIPTION
This PR adds back the implication "finite + cauchy complete => filtered colimits", which was in the DB before, but was replaced with the stronger statement "finite + cauchy complete => finitely accessible" (in #97). The problem is that the stronger statement is not dualized automatically since "finitely accessible" has no dual in the database (as of now). So we have both "versions" now, and the first one is dualized automatically to "finite + cauchy complete => cofiltered limits".

Also, this PR adds the result "finite + cauchy complete => monos are stable under filtered colimits" (which is also dualized automatically). As a consequence, two manual assignments could be removed (and also another one in a PR in progress, #136).

💭 Let's make it a rule from now on to always add the dual property as well when a new property is added. Only then the deduction system works to its full power.