### PR TITLE
Add the walking coreflexive pair

### DIFF
--- a/databases/catdat/data/001_categories/008_tiny.sql
+++ b/databases/catdat/data/001_categories/008_tiny.sql
@@ -130,4 +130,16 @@ VALUES
 	'This category could also be called the "walking split idempotent" (or "walking section", "walking retraction"), but we chose a name that emphasizes that the splitting belongs to the data. Notice that the $5$ given morphisms are indeed closed under composition. For example, $p \circ ip = p$ and $ip \circ i = i$.<br>The walking splitting can be interpreted as a skeleton of the category of $\mathbb{F}_2$-vector spaces of dimension $\leq 1$.',
 	NULL,
 	NULL
+),
+(
+	'walking_coreflexive_pair',
+	'walking coreflexive pair',
+	'$\Delta^{\leq 1}$',
+	'two objects $[0]$ and $[1]$',
+	'the identities, two morphisms $i,j : [0] \rightrightarrows [1]$, a morphism $p : [1] \to [0]$ with $p i = p j = \mathrm{id}_{[0]}$, and the two idempotent morphisms $ip, jp : [1] \to [1]$.',
+	'This category is equal to the truncated simplex category $\Delta^{\leq 1}$, i.e. the full subcategory of $\Delta$ spanned by $[0] = \{0\}$ and $[1] = \{0 < 1\}$; this also explains our notation of the category and its objects.
+	$$[0] \begin{array}{c} \xhookrightarrow{~~i~~} \\ \xtwoheadleftarrow{~~p~~} \\ \xhookrightarrow{~~j~~} \end{array} [1]$$
+	The morphisms $i,j$ are the two inclusions, $p$ is their unique retraction, and $ip,jp : [1] \to [1]$ are the two constant maps. The name of this category comes from the fact that a functor out of it is the same as a <a href="https://ncatlab.org/nlab/show/reflexive+pair" target="_blank">coreflexive pair</a> in the target category. Its dual is therefore the walking reflexive pair.',
+	NULL,
+	NULL
 );

--- a/databases/catdat/data/001_categories/100_related-categories.sql
+++ b/databases/catdat/data/001_categories/100_related-categories.sql
@@ -37,6 +37,7 @@ VALUES
 ('Delta', 'sSet'),
 ('Delta', 'FinOrd'),
 ('Delta', 'Setne'),
+('Delta', 'walking_coreflexive_pair'),
 ('FI', 'B'),
 ('FI', 'FS'),
 ('FS', 'B'),
@@ -158,7 +159,12 @@ VALUES
 ('walking_morphism', 'walking_splitting'),
 ('walking_pair', 'walking_morphism'),
 ('walking_pair', 'walking_fork'),
+('walking_pair', 'walking_coreflexive_pair'),
+('walking_coreflexive_pair', 'walking_pair'),
+('walking_coreflexive_pair', 'walking_splitting'),
+('walking_coreflexive_pair', 'Delta'),
 ('walking_span', 'walking_morphism'),
 ('walking_span', 'walking_pair'),
 ('walking_splitting', 'walking_idempotent'),
-('walking_splitting', 'walking_isomorphism');
+('walking_splitting', 'walking_isomorphism'),
+('walking_splitting', 'walking_coreflexive_pair');

--- a/databases/catdat/data/001_categories/200_category-tags.sql
+++ b/databases/catdat/data/001_categories/200_category-tags.sql
@@ -108,6 +108,8 @@ VALUES
 ('walking_morphism', 'thin'),
 ('walking_pair', 'finite'),
 ('walking_pair', 'category theory'),
+('walking_coreflexive_pair', 'finite'),
+('walking_coreflexive_pair', 'category theory'),
 ('walking_span', 'finite'),
 ('walking_span', 'category theory'),
 ('walking_span', 'thin'),

--- a/databases/catdat/data/003_category-property-assignments/walking_coreflexive_pair.sql
+++ b/databases/catdat/data/003_category-property-assignments/walking_coreflexive_pair.sql
@@ -1,0 +1,110 @@
+INSERT INTO category_property_assignments (
+	category_id,
+	property_id,
+	is_satisfied,
+	reason
+)
+VALUES
+(
+	'walking_coreflexive_pair',
+	'finite',
+	TRUE,
+	'This is trivial.'
+),
+(
+	'walking_coreflexive_pair',
+	'small',
+	TRUE,
+	'This is trivial.'
+),
+(
+	'walking_coreflexive_pair',
+	'strongly connected',
+	TRUE,
+	'This is trivial.'
+),
+(
+	'walking_coreflexive_pair',
+	'gaunt',
+	TRUE,
+	'This is obvious.'
+),
+(
+	'walking_coreflexive_pair',
+	'terminal object',
+	TRUE,
+	'The object $[0]$ is terminal since it is already terminal in $\Delta$.'
+),
+(
+	'walking_coreflexive_pair',
+	'epi-regular',
+	TRUE,
+	'The only non-identity epimorphism is $p$, which is the coequalizer of $\mathrm{id}, ip : [1] \rightrightarrows [1]$ (since $pi = \mathrm{id}$).'
+),
+(
+	'walking_coreflexive_pair',
+	'mono-regular',
+	TRUE,
+	'The only non-identity monomorphisms are $i$ and $j$. The morphism $i$ is the equalizer of $\mathrm{id}, ip : [1] \rightrightarrows [1]$ (since $pi = \mathrm{id}$), and for $j$ it is the same argument.'
+),
+(
+	'walking_coreflexive_pair',
+	'coequalizers',
+	TRUE,
+	'We already know that the <a href="/category/Delta">simplex category $\Delta$ has coequalizers</a>, and the proof has shown that the cardinality does not increase, so we are done. But a direct proof is also possible: There are four non-equal parallel pairs: $(i,j)$, $(ip,jp)$, $(\mathrm{id},ip)$, and $(\mathrm{id},jp)$. The first two have the same coequalizer (if it exists) since $p$ is an epimorphism, the last two are symmetric, and we already remarked that $p$ is a coequalizer of $(\mathrm{id},ip)$. So it suffices to check that $p$ is a coequalizer of $i,j$, which is easy.'
+),
+(
+	'walking_coreflexive_pair',
+	'generator',
+	TRUE,
+	'The object $[0]$ is generator since this is already true in $\Delta$. A direct proof is also possible.'
+),
+(
+	'walking_coreflexive_pair',
+	'cogenerator',
+	TRUE,
+	'The object $[1]$ is cogenerator since this is already true in $\Delta$. A direct proof is also possible.'
+),
+(
+	'walking_coreflexive_pair',
+	'cosifted',
+	TRUE,
+	'Our proof that the <a href="/category/Delta">simplex category $\Delta$ is cosifted</a> has only used $[0],[1]$ as auxiliary objects and therefore also shows that $\Delta^{\leq 1}$ is cosifted.'
+),
+(
+	'walking_coreflexive_pair',
+	'generalized variety',
+	TRUE,
+	'This actually holds for every truncated simplex category $\Delta^{\leq n}$. See <a href="https://mathoverflow.net/questions/510760" target="_blank">MO/510760</a> for a proof that sifted colimits exist. See <a href="https://mathoverflow.net/questions/510827" target="_blank">MO/510827</a> for a proof that every object is strongly finitely presentable.'
+),
+(
+	'walking_coreflexive_pair',
+	'strict terminal object',
+	FALSE,
+	'The morphism $i : [0] \to [1]$ from the terminal object $[0]$ is a witness.'
+),
+(
+	'walking_coreflexive_pair',
+	'cofiltered',
+	FALSE,
+	'The morphisms $i,j : [0] \rightrightarrows [1]$ are not equalized by any morphism.'
+),
+(
+	'walking_coreflexive_pair',
+	'coreflexive equalizers',
+	FALSE,
+	'The coreflexive pair $i,j : [0] \rightrightarrows [1]$ has no equalizer, in fact is not equalized by any morphism.'
+),
+(
+	'walking_coreflexive_pair',
+	'pushouts',
+	FALSE,
+	'Assume that $[1] \xleftarrow{i} [0] \xrightarrow{i} [1]$ has a pushout in $\Delta^{\leq 1}$, where $i(0)=0$. This amounts to a universal totally ordered set of cardinality $\leq 2$ with elements $a,b,c$ satisfying $a \leq b$, $a \leq c$. Since a finite totally ordered set has trivial automorphism group, the automorphism defined by $a \mapsto a$, $b \mapsto c$, $c \mapsto b$ must be the identity, i.e., we have $b = c$. However, in $[1]$ the equations $0 \leq 0$, $0 \leq 1$ then show that the universal property fails.'
+),
+(
+	-- TODO: remove this manual proof once locally multi-presentable is dualized, cf. #139
+	'walking_coreflexive_pair',
+	'multi-complete',
+	FALSE,
+	'This follows directly from existing results: If its dual, the walking reflexive pair, was multi-cocomplete, then since it is also accessible, it would be <a href="/category-property/locally_multi-presentable">locally multi-presentable</a>. But then it would have connected limits, in particular pullbacks.'
+);

--- a/databases/catdat/data/005_special-objects/003_terminal_objects.sql
+++ b/databases/catdat/data/005_special-objects/003_terminal_objects.sql
@@ -53,6 +53,7 @@ VALUES
 ('Top*', 'singleton space with the unique base point'),
 ('Vect', 'trivial vector space'),
 ('walking_commutative_square', '$d$'),
+('walking_coreflexive_pair', '$[1]$'),
 ('walking_isomorphism', 'both objects'),
 ('walking_morphism', '$1$'),
 ('walking_splitting', '$0$'),

--- a/databases/catdat/data/006_special-morphisms/002_isomorphisms.sql
+++ b/databases/catdat/data/006_special-morphisms/002_isomorphisms.sql
@@ -326,6 +326,11 @@ VALUES
 	'This is trivial.'
 ),
 (
+	'walking_coreflexive_pair',
+	'the two identities',
+	'This is obvious.'
+),
+(
 	'walking_fork',
 	'the three identities',
 	'This is trivial.'

--- a/databases/catdat/data/006_special-morphisms/003_monomorphisms.sql
+++ b/databases/catdat/data/006_special-morphisms/003_monomorphisms.sql
@@ -316,6 +316,11 @@ VALUES
 	'It is a thin category.'
 ),
 (
+	'walking_coreflexive_pair',
+	'the identities and $i$, $j$',
+	'Since $pi = \mathrm{id}$, but $ip \neq \mathrm{id}$, we conclude that $i$ is a monomorphism, but $p$ is not. Likewise, $j$ is a monomorphism. Since $p$ is not a monomorphism, $ip$ and $jp$ are also no monomorphisms.'
+),
+(
 	'walking_fork',
 	'every morphism',
 	'This is easily checked.'

--- a/databases/catdat/data/006_special-morphisms/004_epimorphisms.sql
+++ b/databases/catdat/data/006_special-morphisms/004_epimorphisms.sql
@@ -302,6 +302,11 @@ VALUES
 	'It is a thin category.'
 ),
 (
+	'walking_coreflexive_pair',
+	'the identities and $p$',
+	'Since $pi = \mathrm{id}$, but $ip \neq \mathrm{id}$, we conclude that $p$ is an epimorphism, but $i$ is not. Hence, also $ip$ is not an epimorphism. Likewise, $j$ and $jp$ are no epimorphisms.'
+),
+(
 	'walking_fork',
 	'the identities and $f,g$',
 	'This is easily checked.'

--- a/databases/catdat/data/006_special-morphisms/005_regular-monomorphisms.sql
+++ b/databases/catdat/data/006_special-morphisms/005_regular-monomorphisms.sql
@@ -261,6 +261,11 @@ VALUES
     'This is because the category is right cancellative.'
 ),
 (
+    'walking_coreflexive_pair',
+    'same as monomorphisms',
+    'This is because the category is mono-regular.'
+),
+(
 	'walking_idempotent',
 	'the identity',
 	'This is trivial.'

--- a/databases/catdat/data/006_special-morphisms/006_regular-epimorphisms.sql
+++ b/databases/catdat/data/006_special-morphisms/006_regular-epimorphisms.sql
@@ -251,6 +251,11 @@ VALUES
     'This is because the category is left cancellative.'
 ),    
 (
+    'walking_coreflexive_pair',
+    'same as epimorphisms',
+    'This is because the category is epi-regular.'
+),
+(
     'walking_fork',
     'same as isomorphisms',
     'This is because the category is left cancellative.'


### PR DESCRIPTION
This PR adds the walking coreflexive pair, the category generated by two morphisms $i,j : [0] \to [1]$ and a morphism $p: [1] \to [0]$ with $pi = pj = \mathrm{id}$. This is just the truncated simplex category $\Delta^{\leq 1}$.

![diagram](https://i.sstatic.net/ypDCVH0w.png)

This PR resolves (the dual of) #122. At first, I wanted to add the walking reflexive pair (#136), but while deciding its properties, it become more and more clear that its dual category is easier to handle and that we can recycle some arguments from the simplex category which already is in the database.

Interestingly, dualizing the proofs from #136 added two new unknown properties (I expected the same number). The first one, being multi-complete, could not be deduced because the property of being locally multi-presentable currently does not have a dual in the database. This is bad, we should always add duals from now on, since otherwise the deduction system is not "symmetric". The second one, being a generalized variety, was simply not visible for the walking reflexive pair since this property has no dual in the database. To be precise: the walking coreflexive pair does not have cosifted limits ( = the walking reflexive pair does not have sifted colimits), so that the walking coreflexive pair is not a "generalized covariety" ( = the walking reflexive pair is not a generalized variety). For the walking reflexive pair, this was already the end of the story, but not for the walking coreflexive pair. It is indeed a generalized variety, but that is somewhat non-trivial.

All properties for the walking coreflexive pair have been decided. 