### PR TITLE
Improve filtering

### DIFF
--- a/src/components/Selection.svelte
+++ b/src/components/Selection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import ChipGroup from './ChipGroup.svelte'
 	import Chip from './Chip.svelte'
-	import { normalize_text } from '$lib/client/utils'
+	import { get_comparison_score, normalize_text } from '$lib/client/utils'
 
 	type Props = {
 		title?: string
@@ -27,18 +27,17 @@
 
 	const id = $props.id()
 
-	let suggestions = $derived(
-		selected_items.length >= max ? [] : allowed_items.filter(is_suggestion),
-	)
-
-	let suggestions_element = $state<HTMLDivElement | null>(null)
-
-	function is_suggestion(allowed_item: string) {
-		return (
-			!selected_items.includes(allowed_item) &&
-			normalize_text(allowed_item).includes(normalize_text(item.trim()))
-		)
-	}
+	let suggestions = $derived.by(() => {
+		if (selected_items.length >= max) return []
+		const q = item.trim()
+		if (!q) return []
+		return allowed_items
+			.filter((a) => !selected_items.includes(a))
+			.map((a) => ({ a, r: get_comparison_score(a, q) }))
+			.filter((x) => x.r > 0)
+			.sort((x, y) => y.r - x.r || x.a.localeCompare(y.a))
+			.map((x) => x.a)
+	})
 
 	function is_valid(item: string) {
 		return (
@@ -62,6 +61,8 @@
 		show_suggestions = false
 		active_index = 0
 	}
+
+	let suggestions_element = $state<HTMLDivElement | null>(null)
 
 	function handle_blur(e: FocusEvent) {
 		const is_suggestion_click = suggestions_element?.contains(e.relatedTarget as Node)

--- a/src/components/Selection.svelte
+++ b/src/components/Selection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ChipGroup from './ChipGroup.svelte'
 	import Chip from './Chip.svelte'
+	import { normalize_text } from '$lib/client/utils'
 
 	type Props = {
 		title?: string
@@ -35,7 +36,7 @@
 	function is_suggestion(allowed_item: string) {
 		return (
 			!selected_items.includes(allowed_item) &&
-			allowed_item.toLowerCase().includes(item.trim().toLowerCase())
+			normalize_text(allowed_item).includes(normalize_text(item.trim()))
 		)
 	}
 

--- a/src/lib/client/utils.ts
+++ b/src/lib/client/utils.ts
@@ -17,6 +17,16 @@ export function pluralize(count: number, forms: { one: string; other: string }) 
 	return word.replace('{count}', String(count))
 }
 
+/**
+ * Removes accents from letters and transforms to lowercase
+ */
+export function normalize_text(txt: string) {
+	return txt
+		.toLowerCase()
+		.normalize('NFD')
+		.replace(/\p{Diacritic}/gu, '')
+}
+
 export const resize_textarea: Attachment = (textarea) => {
 	if (!(textarea instanceof HTMLTextAreaElement)) return
 

--- a/src/lib/client/utils.ts
+++ b/src/lib/client/utils.ts
@@ -27,6 +27,16 @@ export function normalize_text(txt: string) {
 		.replace(/\p{Diacritic}/gu, '')
 }
 
+export function get_comparison_score(value: string, query: string) {
+	if (!query) return -1
+	const v = normalize_text(value)
+	const q = normalize_text(query)
+	if (v === q) return 3
+	if (v.startsWith(q)) return 2
+	if (v.includes(q)) return 1
+	return 0
+}
+
 export const resize_textarea: Attachment = (textarea) => {
 	if (!(textarea instanceof HTMLTextAreaElement)) return
 

--- a/src/routes/categories/+page.svelte
+++ b/src/routes/categories/+page.svelte
@@ -5,7 +5,7 @@
 	import MetaData from '$components/MetaData.svelte'
 	import SearchFilter from '$components/SearchFilter.svelte'
 	import SuggestionForm from '$components/SuggestionForm.svelte'
-	import { filter_by_tag, pluralize } from '$lib/client/utils'
+	import { filter_by_tag, normalize_text, pluralize } from '$lib/client/utils'
 
 	let { data } = $props()
 
@@ -14,7 +14,7 @@
 	let searched_categories = $derived(
 		search
 			? data.categories.filter((category) =>
-					category.name.toLowerCase().includes(search.toLowerCase()),
+					normalize_text(category.name).includes(normalize_text(search)),
 				)
 			: data.categories,
 	)

--- a/src/routes/category-implications/+page.svelte
+++ b/src/routes/category-implications/+page.svelte
@@ -4,7 +4,7 @@
 	import MetaData from '$components/MetaData.svelte'
 	import SearchFilter from '$components/SearchFilter.svelte'
 	import SuggestionForm from '$components/SuggestionForm.svelte'
-	import { pluralize } from '$lib/client/utils'
+	import { normalize_text, pluralize } from '$lib/client/utils'
 
 	let { data } = $props()
 
@@ -25,14 +25,10 @@
 
 	let filtered_implications = $derived(
 		search
-			? displayed_implications.filter(
-					(implication) =>
-						implication.assumptions.some((prop) =>
-							prop.toLowerCase().includes(search.toLowerCase()),
-						) ||
-						implication.conclusions.some((prop) =>
-							prop.toLowerCase().includes(search.toLowerCase()),
-						),
+			? displayed_implications.filter((implication) =>
+					[...implication.assumptions, ...implication.conclusions].some(
+						(prop) => normalize_text(prop).includes(normalize_text(search)),
+					),
 				)
 			: displayed_implications,
 	)

--- a/src/routes/category-properties/+page.svelte
+++ b/src/routes/category-properties/+page.svelte
@@ -2,7 +2,7 @@
 	import MetaData from '$components/MetaData.svelte'
 	import SearchFilter from '$components/SearchFilter.svelte'
 	import SuggestionForm from '$components/SuggestionForm.svelte'
-	import { pluralize } from '$lib/client/utils'
+	import { normalize_text, pluralize } from '$lib/client/utils'
 	import { get_property_url } from '$lib/commons/property.url'
 
 	let { data } = $props()
@@ -13,10 +13,11 @@
 		search
 			? data.grouped_properties.filter(
 					(property) =>
-						property.id.toLowerCase().includes(search.toLowerCase()) ||
-						property.dual_property_id
-							?.toLowerCase()
-							.includes(search.toLowerCase()),
+						normalize_text(property.id).includes(normalize_text(search)) ||
+						(!!property.dual_property_id &&
+							normalize_text(property.dual_property_id).includes(
+								normalize_text(search),
+							)),
 				)
 			: data.grouped_properties,
 	)


### PR DESCRIPTION
1. This PR improves the filtering (available in list pages for categories, properties, and implications) by ignoring accents. For example, the a user is looking for the Jónsson-Tarski topos (#89) (which I am currently adding), entering "Jo" should find it. Also, in case we add a term like "étale", it should be found via "etale".

2. Also, this PR improves the suggestion component that is used in the search page and the comparison page. When the user enters "finite", it should *not* list all properties with "finite" inside alphabetically. Instead, it should list the exact match first, then properties starting with "finite", and then all other properties (alphabetically) that contain that word. 

### Before

<img width="520" height="321" alt="Bildschirmfoto 2026-05-01 um 13 00 28" src="https://github.com/user-attachments/assets/8c750c91-bde1-4cd1-b9e7-1bd3e207732d" /><br /><br />

### After

<img width="520" height="321" alt="Bildschirmfoto 2026-05-01 um 13 00 16" src="https://github.com/user-attachments/assets/6044a08e-ee86-41f0-8311-a52493dd9697" /><br /><br />

### Before

<img width="520" height="321" alt="Bildschirmfoto 2026-05-01 um 13 04 38" src="https://github.com/user-attachments/assets/dcf54a79-eac6-437b-8619-b6b6259c03da" /><br /><br />

### After

<img width="520" height="321" alt="Bildschirmfoto 2026-05-01 um 13 04 49" src="https://github.com/user-attachments/assets/fe320c9d-731e-4d62-873c-e15ce476a4c4" /><br /><br />



