### PR TITLE
Add properties: subobject-trivial and quotient-trivial

### DIFF
--- a/databases/catdat/data/002_category-properties/004_morphism-behavior.sql
+++ b/databases/catdat/data/002_category-properties/004_morphism-behavior.sql
@@ -142,4 +142,20 @@ VALUES
 	'https://ncatlab.org/nlab/show/gaunt+category',
 	'gaunt',
 	FALSE
+),
+(
+	'subobject-trivial',
+	'is',
+	'A category is <i>subobject-trivial</i> if every monomorphism is an isomorphism. Equivalently, the poset of subobjects of any object is trivial. This is no standard terminology. We have added it to the database since it clarifies the relationship between several related properties.',
+	NULL,
+	'quotient-trivial',
+	TRUE
+),
+(
+	'quotient-trivial',
+	'is',
+	'A category is <i>quotient-trivial</i> if every epimorphism is an isomorphism. Equivalently, the poset of quotients of any object is trivial. This is no standard terminology. We have added it to the database since it clarifies the relationship between several related properties.',
+	NULL,
+	'subobject-trivial',
+	TRUE
 );

--- a/databases/catdat/data/002_category-properties/100_related-category-properties.sql
+++ b/databases/catdat/data/002_category-properties/100_related-category-properties.sql
@@ -231,6 +231,8 @@ VALUES
 ('right cancellative', 'groupoid'),
 ('groupoid', 'left cancellative'),
 ('groupoid', 'right cancellative'),
+('groupoid', 'subobject-trivial'),
+('groupoid', 'quotient-trivial'),
 ('wide pullbacks', 'pullbacks'),
 ('wide pushouts', 'pushouts'),
 ('split abelian', 'abelian'),
@@ -339,7 +341,9 @@ VALUES
 ('cofiltered', 'finitely complete'),
 ('cofiltered', 'cofiltered limits'),
 ('mono-regular', 'normal'),
+('mono-regular', 'subobject-trivial'),
 ('epi-regular', 'conormal'),
+('epi-regular', 'quotient-trivial'),
 ('normal', 'zero morphisms'),
 ('normal', 'mono-regular'),
 ('normal', 'kernels'),
@@ -403,4 +407,8 @@ VALUES
 ('CSP', 'zero morphisms'),
 ('CSP', 'unital'),
 ('CSP', 'cofiltered-limit-stable epimorphisms'),
-('finitary algebraic', 'locally strongly finitely presentable');
+('finitary algebraic', 'locally strongly finitely presentable'),
+('subobject-trivial', 'mono-regular'),
+('subobject-trivial', 'groupoid'),
+('quotient-trivial', 'epi-regular'),
+('quotient-trivial', 'groupoid');

--- a/databases/catdat/data/003_category-property-assignments/FI.sql
+++ b/databases/catdat/data/003_category-property-assignments/FI.sql
@@ -55,12 +55,6 @@ VALUES
 ),
 (
 	'FI',
-	'epi-regular',
-	TRUE,
-	'This is because every epimorphism is actually an isomorphism (see below).'
-),
-(
-	'FI',
 	'semi-strongly connected',
 	TRUE,
 	'If $X,Y$ are two finite sets, we have $\mathrm{card}(X) \leq \mathrm{card}(Y)$ or $\mathrm{card}(Y) \leq \mathrm{card}(X)$. In the first case there will be an injection $X \to Y$, in the second case there will be an injection $Y \to X$.'
@@ -70,12 +64,6 @@ VALUES
 	'locally cartesian closed',
 	TRUE,
 	'IF $X$ is a finite set, the slice category $\mathbf{FI} / X$ is equivalent to the poset of subsets of $X$. This is cartesian closed because $A \cap B \subseteq C$ holds if and only if $B \subseteq (X \setminus A) \cup C$, where $A,B,C \subseteq X$.'
-),
-(
-	'FI',
-	'cofiltered-limit-stable epimorphisms',
-	TRUE,
-	'This is because every epimorphism is an isomorphism in this category (see below), and isomorphisms are always stable under any type of limit.'
 ),
 (
 	'FI',

--- a/databases/catdat/data/003_category-property-assignments/FS.sql
+++ b/databases/catdat/data/003_category-property-assignments/FS.sql
@@ -43,21 +43,9 @@ VALUES
 ),
 (
 	'FS',
-	'mono-regular',
-	TRUE,
-	'Every monomorphism is an isomorphism (see below), hence regular.'
-),
-(
-	'FS',
 	'epi-regular',
 	TRUE,
 	'If $f : X \to Y$ is a surjective map of finite sets, it is the coequalizer of the two projections $p_1, p_2 : X \times_Y X \rightrightarrows X$ in $\mathbf{FinSet}$, but also in $\mathbf{FS}$. Notice that $p_1,p_2$ are surjective. Even though $X \times_Y X$ is not a pullback in $\mathbf{FS}$, we can use this finite set here.'
-),
-(
-	'FS',
-	'filtered-colimit-stable monomorphisms',
-	TRUE,
-	'This is because every monomorphism is an isomorphism in this category (see below), and isomorphisms are always stable under any type of colimit.'
 ),
 (
 	'FS',

--- a/databases/catdat/data/003_category-property-assignments/walking_idempotent.sql
+++ b/databases/catdat/data/003_category-property-assignments/walking_idempotent.sql
@@ -37,7 +37,7 @@ VALUES
 ),
 (
 	'walking_idempotent',
-	'mono-regular',
+	'subobject-trivial',
     TRUE,
 	'This is because the identity is the only monomorphism.'
 ),

--- a/databases/catdat/data/003_category-property-assignments/walking_pair.sql
+++ b/databases/catdat/data/003_category-property-assignments/walking_pair.sql
@@ -61,18 +61,6 @@ VALUES
 ),
 (
 	'walking_pair',
-	'binary products',
-	FALSE,
-	'We cannot have $0 \times 1 = 1$ since there is no morphism $1 \to 0$. So assume $0 \times 1 = 0$, say with projections $\mathrm{id}_0 : 0 \to 0$ and $a : 0 \to 1$. By applying the universal property to  $\mathrm{id}_0 : 0 \to 0$ and the other morphism $b : 0 \to 1$, it immediately follows $a=b$, which is a contradiction.'
-),
-(
-	'walking_pair',
-	'equalizers',
-	FALSE,
-	'The two morphisms $a,b : 0 \rightrightarrows 1$ have no equalizer, since it would have to be the identity of $0$, but $a \neq b$.'
-),
-(
-	'walking_pair',
 	'pullbacks',
 	FALSE,
 	'The two morphisms $a,b : 0 \rightrightarrows 1$ have no pullback, since it would have to consist of identities $0 \leftarrow 0 \rightarrow 0$, but $a \neq b$.'

--- a/databases/catdat/data/004_category-implications/004_morphism-behavior-implications.sql
+++ b/databases/catdat/data/004_category-implications/004_morphism-behavior-implications.sql
@@ -42,6 +42,13 @@ VALUES
 	FALSE
 ),
 (
+	'reflexive_pair_trivial_2',
+	'["subobject-trivial"]',
+	'["reflexive coequalizers", "coreflexive equalizers"]',
+	'Any parallel pair of morphisms with a common section (or retraction) must be a pair of equal isomorphisms.',
+	FALSE
+),
+(
 	'groupoid_consequence',
 	'["groupoid"]',
 	'["self-dual", "mono-regular", "pullbacks", "directed limits", "left cancellative", "well-powered"]',
@@ -169,6 +176,13 @@ VALUES
 	FALSE
 ),
 (
+	'filtered_monos_iso',
+	'["subobject-trivial", "filtered colimits"]',
+	'["filtered-colimit-stable monomorphisms"]',
+	'This is trivial.',
+	FALSE
+),
+(
 	'thin_groupoids',
 	'["groupoid", "core-thin"]',
 	'["thin"]',
@@ -188,4 +202,32 @@ VALUES
 	'["skeletal", "core-thin"]',
 	'This is trivial.',
 	TRUE
+),
+(
+	'thin_subobject-trivial',
+	'["subobject-trivial", "equalizers"]',
+	'["thin"]',
+	'If $f,g : X \rightrightarrows Y$ are morphisms, their equalizer is a monomorphism $E \hookrightarrow X$, hence an isomorphism. But this means $f = g$.',
+	FALSE
+),
+(
+	'subobject-trivial_consequence',
+	'["subobject-trivial"]',
+	'["mono-regular"]',
+	'This is trivial.',
+	FALSE
+),
+(
+	'subobject-trivial_groupoids',
+	'["groupoid"]',
+	'["subobject-trivial"]',
+	'This is trivial.',
+	FALSE
+),
+(
+	'subobject-trivial_criterion',
+	'["right cancellative", "epi-regular"]',
+	'["subobject-trivial"]',
+	'This is because a monomorphism which is also a regular epimorphism is an isomorphism.',
+	FALSE
 );

--- a/databases/catdat/scripts/expected-data/Ab.json
+++ b/databases/catdat/scripts/expected-data/Ab.json
@@ -153,5 +153,7 @@
 	"cofiltered-limit-stable epimorphisms": false,
 	"exact cofiltered limits": false,
 	"gaunt": false,
-	"core-thin": false
+	"core-thin": false,
+	"subobject-trivial": false,
+	"quotient-trivial": false
 }

--- a/databases/catdat/scripts/expected-data/Set.json
+++ b/databases/catdat/scripts/expected-data/Set.json
@@ -153,5 +153,7 @@
 	"cofiltered-limit-stable epimorphisms": false,
 	"exact cofiltered limits": false,
 	"gaunt": false,
-	"core-thin": false
+	"core-thin": false,
+	"subobject-trivial": false,
+	"quotient-trivial": false
 }

--- a/databases/catdat/scripts/expected-data/Top.json
+++ b/databases/catdat/scripts/expected-data/Top.json
@@ -153,5 +153,7 @@
 	"cofiltered-limit-stable epimorphisms": false,
 	"exact cofiltered limits": false,
 	"gaunt": false,
-	"core-thin": false
+	"core-thin": false,
+	"subobject-trivial": false,
+	"quotient-trivial": false
 }


### PR DESCRIPTION
A category is *subobject-trivial* if every monomorphisms is an isomorphism. Dually, it is *quotient-trivial* if every epimorphism is an isomorphism. This is no standard terminology, and the properties are not much interesting in their own right. However, it makes sense to add them since they clarify the relationship between other properties. Also, some manual assignments could be removed. The properties have been decided for all categories (mostly using implications).