### PR TITLE
Separate assignment of dual categories

### DIFF
--- a/databases/catdat/data/001_categories/001_set-theory.sql
+++ b/databases/catdat/data/001_categories/001_set-theory.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'sets',
 	'maps',
 	'The category of sets plays a fundamental role in category theory. Due to the Yoneda embedding, many results about general categories can be reduced to the category of sets. It is also usually the first example of a category that one encounters.',
-	'https://ncatlab.org/nlab/show/Set',
-	'Set_op'
+	'https://ncatlab.org/nlab/show/Set'
 ),
 (
 	'SetxSet',
@@ -26,7 +24,6 @@ VALUES
 	'pairs $(A,B)$ of sets $A$ and $B$',
 	'A morphism $(A,B) \to (C,D)$ consists of a map $A \to C$ and a map $B \to D$.',
 	'This is an example of the <a href="https://ncatlab.org/nlab/show/product+category" target="_blank">product of categories</a>. It inherits most (but not all) properties from $\Set$. It can also be seen as the category $\Sh(1+1)$ of sheaves on a discrete space with two points, and also as the slice category $\Set/(1+1)$.',
-	NULL,
 	NULL
 ),
 (
@@ -36,8 +33,7 @@ VALUES
 	'sets',
 	'A morphism $f : X \to Y$ is a map of sets $Y \to X$.',
 	'By definition, this category is the dual (or opposite) of <a href="/category/Set">the category of sets</a>.',
-	'https://ncatlab.org/nlab/show/opposite+category',
-	'Set'
+	'https://ncatlab.org/nlab/show/opposite+category'
 ),
 (
 	'Set*',
@@ -46,8 +42,7 @@ VALUES
 	'pointed sets',
 	'pointed maps',
 	'This is the category of sets with a distinguished element, often called the base point. A map is called pointed when it preserves the base point.',
-	'https://ncatlab.org/nlab/show/pointed+set',
-	NULL
+	'https://ncatlab.org/nlab/show/pointed+set'
 ),
 (
 	'Setne',
@@ -56,8 +51,7 @@ VALUES
 	'non-empty sets',
 	'maps',
 	'This entry demonstrates that removing an object (the empty set) can drastically change the properties of a category. In particular, this category is neither complete nor cocomplete.',
-	'https://ncatlab.org/nlab/show/inhabited+set',
-	NULL
+	'https://ncatlab.org/nlab/show/inhabited+set'
 ),
 (
 	'Rel',
@@ -66,8 +60,7 @@ VALUES
 	'sets',
 	'A morphism from $A$ to $B$ is a relation, i.e. a subset of $A \times B$.',
 	'This category is self-dual as it can be: There is an isomorphism $\Rel \cong \Rel^{\op}$ that is the identity on objects and maps a relation to its opposite relation. It is the prototype of a dagger-category.',
-	'https://ncatlab.org/nlab/show/Rel',
-	NULL
+	'https://ncatlab.org/nlab/show/Rel'
 ),
 (
 	'Set_c',
@@ -76,7 +69,6 @@ VALUES
 	'countable sets',
 	'maps',
 	'A set is countable if it admits a surjection from $\IN$. In particular, every finite set is countable.',
-	NULL,
 	NULL
 ),
 (
@@ -86,6 +78,5 @@ VALUES
 	'sets',
 	'maps $f : X \to Y$ with the property that for every $y \in Y$ the fiber $f^*(\{y\})$ is a finite set',
 	'In this variant of $\Set$ we only consider maps with finite fibers, which are commonly called <i>finite-to-one</i>. Equivalently, every preimage of a finite set is again finite, and this description makes it obvious that composition is well-defined.',
-	NULL,
 	NULL
 );

--- a/databases/catdat/data/001_categories/002_algebra.sql
+++ b/databases/catdat/data/001_categories/002_algebra.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'abelian groups',
 	'group homomorphisms',
 	'This is the prototype of an abelian category.',
-	'https://ncatlab.org/nlab/show/Ab',
-	NULL
+	'https://ncatlab.org/nlab/show/Ab'
 ),
 (
 	'Grp',
@@ -26,8 +24,7 @@ VALUES
 	'groups',
 	'group homomorphisms',
 	'This is the prototype of a finitary algebraic category.',
-	'https://ncatlab.org/nlab/show/Grp',
-	NULL
+	'https://ncatlab.org/nlab/show/Grp'
 ),
 (
 	'Vect',
@@ -36,8 +33,7 @@ VALUES
 	'vector spaces over a field $K$',
 	'linear maps',
 	'This is a special case of the category of modules over a ring, where the ring is a field. It is the prototype of a split abelian category.',
-	'https://ncatlab.org/nlab/show/Vect',
-	NULL
+	'https://ncatlab.org/nlab/show/Vect'
 ),
 (
 	'Ring',
@@ -46,8 +42,7 @@ VALUES
 	'rings',
 	'ring homomorphisms',
 	'Here, rings always have a unit, and homomorphisms preserve them.',
-	'https://ncatlab.org/nlab/show/Ring',
-	NULL
+	'https://ncatlab.org/nlab/show/Ring'
 ),
 (
 	'Alg(R)',
@@ -56,8 +51,7 @@ VALUES
 	'algebras over a commutative ring $R \neq 0$',
 	'maps preserving the ring and module structure',
 	'This is a generalization of the category of rings, which we get for $R = \IZ$. We assume our rings (and algebras) to be unital. For $R = 0$ we would get the trivial category, which is why we exclude this here.',
-	'https://ncatlab.org/nlab/show/Alg',
-	NULL
+	'https://ncatlab.org/nlab/show/Alg'
 ),
 (
 	'CRing',
@@ -66,8 +60,7 @@ VALUES
 	'commutative rings',
 	'ring homomorphisms',
 	NULL,
-	'https://ncatlab.org/nlab/show/CRing',
-	NULL
+	'https://ncatlab.org/nlab/show/CRing'
 ),
 (
 	'CAlg(R)',
@@ -76,8 +69,7 @@ VALUES
 	'commutative algebras over a commutative ring $R \neq 0$',
 	'maps preserving the ring and module structure',
 	'This is a generalization of the category of commutative rings, which we get for $R = \IZ$. In general, $\CAlg(R) \cong R \,/\, \CRing$. We assume our rings (and algebras) to be unital. For $R = 0$ we would get the trivial category, which is why we exclude this here.',
-	'https://ncatlab.org/nlab/show/CommAlg',
-	NULL
+	'https://ncatlab.org/nlab/show/CommAlg'
 ),
 (
 	'Rng',
@@ -86,8 +78,7 @@ VALUES
 	'rngs, that is, non-unital rings',
 	'maps that preserve addition and multiplication',
 	NULL,
-	'https://ncatlab.org/nlab/show/Rng',
-	NULL
+	'https://ncatlab.org/nlab/show/Rng'
 ),
 (
 	'Mon',
@@ -96,8 +87,7 @@ VALUES
 	'monoids',
 	'monoid homomorphisms',
 	NULL,
-	'https://ncatlab.org/nlab/show/category+of+monoids',
-	NULL
+	'https://ncatlab.org/nlab/show/category+of+monoids'
 ),
 (
 	'CMon',
@@ -106,8 +96,7 @@ VALUES
 	'commutative monoids',
 	'monoid homomorphisms',
 	NULL,
-	'https://ncatlab.org/nlab/show/category+of+monoids',
-	NULL
+	'https://ncatlab.org/nlab/show/category+of+monoids'
 ),
 (
 	'M-Set',
@@ -116,8 +105,7 @@ VALUES
 	'sets with a left action of a monoid $M$',
 	'maps that are compatible with the $M$-action, meaning $f(m \cdot x)=m \cdot f(x)$, also called $M$-maps',
 	'Here, $M$ can be any monoid. But the most important special case is that of a group. To settle (future) non-properties, we assume that $M$ is non-trivial, since otherwise we just get the <a href="/category/Set">category of sets</a>.',
-	'https://ncatlab.org/nlab/show/MSet',
-	NULL
+	'https://ncatlab.org/nlab/show/MSet'
 ),
 (
 	'R-Mod',
@@ -127,8 +115,7 @@ VALUES
 	'$R$-linear maps',
 	'This is the prototype of an abelian category. The category of right modules is the same with the opposite ring $R^{\op}$, hence not listed here.<br>
 	To settle the unsatisfied properties, we make the assumption that $R$ is <i>not</i> semisimple: If $R$ is semisimple, then by the Artin-Wedderburn theorem, the category is equivalent to a finite direct product of categories $D{-}\Mod$ for division rings $D$, and the case of division rings is in a separate entry. In particular, $R \neq 0$ and $R$ is not a field.',
-	'https://ncatlab.org/nlab/show/module',
-	NULL
+	'https://ncatlab.org/nlab/show/module'
 ),
 (
 	'R-Mod_div',
@@ -137,8 +124,7 @@ VALUES
 	'left $R$-modules',
 	'$R$-linear maps',
 	'Here, we assume that $R$ is a non-commutative division ring, i.e. a skew-field which is not a field. The category of modules behaves mostly the same as in the commutative case.',
-	'https://ncatlab.org/nlab/show/module',
-	NULL
+	'https://ncatlab.org/nlab/show/module'
 ),
 (
 	'Fld',
@@ -147,8 +133,7 @@ VALUES
 	'fields',
 	'field homomorphisms (i.e., ring homomorphisms)',
 	'This is a typical example of a bad category of good objects.',
-	'https://ncatlab.org/nlab/show/Field',
-	NULL
+	'https://ncatlab.org/nlab/show/Field'
 ),
 (
 	'FinAb',
@@ -157,8 +142,7 @@ VALUES
 	'finite abelian groups',
 	'group homomorphisms',
 	NULL,
-	'https://ncatlab.org/nlab/show/finite+abelian+group',
-	NULL
+	'https://ncatlab.org/nlab/show/finite+abelian+group'
 ),
 (
 	'FinGrp',
@@ -167,8 +151,7 @@ VALUES
 	'finite groups',
 	'group homomorphisms',
 	NULL,
-	'https://ncatlab.org/nlab/show/finite+group',
-	NULL
+	'https://ncatlab.org/nlab/show/finite+group'
 ),
 (
 	'Ab_fg',
@@ -177,8 +160,7 @@ VALUES
 	'finitely generated abelian groups',
 	'group homomorphisms',
 	NULL,
-	'https://ncatlab.org/nlab/show/finitely+generated+module',
-	NULL
+	'https://ncatlab.org/nlab/show/finitely+generated+module'
 ),
 (
 	'FreeAb',
@@ -186,7 +168,6 @@ VALUES
 	'$\FreeAb$',
 	'free abelian groups',
 	'group homomorphisms',
-	NULL,
 	NULL,
 	NULL
 ),
@@ -197,8 +178,7 @@ VALUES
 	'torsion-free abelian groups',
 	'group homomorphisms',
 	'This is a typical example of a well-behaved additive category which is <i>not</i> abelian. It contains the category of free abelian groups.',
-	'https://ncatlab.org/nlab/show/torsion-free+module',
-	NULL
+	'https://ncatlab.org/nlab/show/torsion-free+module'
 ),
 (
 	'TorsAb',
@@ -207,8 +187,7 @@ VALUES
 	'torsion abelian groups',
 	'group homomorphisms',
 	'This is a Grothendieck abelian category containing all finite abelian groups.',
-	'https://ncatlab.org/nlab/show/torsion+subgroup',
-	NULL
+	'https://ncatlab.org/nlab/show/torsion+subgroup'
 ),
 (
 	'Cat',
@@ -217,8 +196,7 @@ VALUES
 	'small categories',
 	'functors',
 	'This is the category of small categories and functors between them. It is the prototype of a 2-category, but here we only treat it as a 1-category.',
-	'https://ncatlab.org/nlab/show/Cat',
-	NULL
+	'https://ncatlab.org/nlab/show/Cat'
 ),
 (
 	'J2',
@@ -227,6 +205,5 @@ VALUES
 	'pairs $(X,\alpha)$, where $X$ is a set and $\alpha : X \to X \times X$ is an isomorphism',
 	'A morphism $(X,\alpha) \to (Y,\beta)$ is a map $f : X \to Y$ satisfying $$(f \times f) \circ \alpha = \beta \circ f.$$',
 	'This is interesting example of a category in the intersection of topos theory and algebra.',
-	'https://ncatlab.org/nlab/show/J%C3%B3nsson-Tarski+algebra',
-	NULL
+	'https://ncatlab.org/nlab/show/J%C3%B3nsson-Tarski+algebra'
 );

--- a/databases/catdat/data/001_categories/003_analysis.sql
+++ b/databases/catdat/data/001_categories/003_analysis.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'Banach spaces over $\IC$',
 	'linear contractions, i.e. linear maps of norm $\leq 1$',
 	'The choice of morphisms is similar to that of $\Met$ which yields better categorical properties.',
-	'https://ncatlab.org/nlab/show/Banach+space',
-	NULL
+	'https://ncatlab.org/nlab/show/Banach+space'
 ),
 (
 	'Meas',
@@ -26,8 +24,7 @@ VALUES
 	'measurable spaces',
 	'measurable maps',
 	'This is very similar to the category of topological spaces. Accordingly, limits and colimits can be constructed in the same way.',
-	'https://ncatlab.org/nlab/show/Meas',
-	NULL
+	'https://ncatlab.org/nlab/show/Meas'
 ),
 (
 	'Met',
@@ -36,8 +33,7 @@ VALUES
 	'metric spaces',
 	'non-expansive maps $f$, meaning $d(f(x),f(y)) \leq d(x,y)$ for all $x,y$',
 	'In contrast to continuous maps, which only refer to the induced topology, non-expansive maps are closer related to the metrics themselves. This category is badly-behaved, though, especially when compared with $\Met_{\infty}$.',
-	'https://ncatlab.org/nlab/show/Met',
-	NULL
+	'https://ncatlab.org/nlab/show/Met'
 ),
 (
 	'PMet',
@@ -46,7 +42,6 @@ VALUES
 	'pseudo-metric spaces',
 	'non-expansive maps $f$, meaning $d(f(x),f(y)) \leq d(x,y)$ for all $x,y$',
 	'In contrast to metric spaces, we do not demand $d(x,y)=0 \implies x=y$ here.',
-	NULL,
 	NULL
 ),
 (
@@ -56,8 +51,7 @@ VALUES
 	'metric spaces, where the metric is allowed to assume the value $\infty$',
 	'non-expansive maps $f$, meaning $d(f(x),f(y)) \leq d(x,y)$ for all $x,y$',
 	'The fact that we allow $\infty$ means that universal constructions work much better when compared to $\Met$.',
-	'https://ncatlab.org/nlab/show/Met',
-	NULL
+	'https://ncatlab.org/nlab/show/Met'
 ),
 (
 	'Met_c',
@@ -66,6 +60,5 @@ VALUES
 	'metric spaces',
 	'continuous maps',
 	'This category is equivalent to the subcategory of $\Top$ (or $\Haus$) that consists of metrizable topological spaces. Hence, the metrics only play a secondary role here.',
-	'https://ncatlab.org/nlab/show/metrisable+topological+space',
-	NULL
+	'https://ncatlab.org/nlab/show/metrisable+topological+space'
 );

--- a/databases/catdat/data/001_categories/004_topology.sql
+++ b/databases/catdat/data/001_categories/004_topology.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'topological spaces',
 	'continuous functions',
 	'This is the most basic category of geometric objects.',
-	'https://ncatlab.org/nlab/show/Top',
-	NULL
+	'https://ncatlab.org/nlab/show/Top'
 ),
 (
 	'Top*',
@@ -26,8 +24,7 @@ VALUES
 	'pointed topological spaces',
 	'pointed continuous functions',
 	'This category plays an important role in algebraic topology and homotopy theory. Although it may appear similar to $\Top$, adding a base point drastically changes its categorical properties. In particular, it introduces a zero object.',
-	'https://ncatlab.org/nlab/show/pointed+topological+space',
-	NULL
+	'https://ncatlab.org/nlab/show/pointed+topological+space'
 ),
 (
 	'Haus',
@@ -36,8 +33,7 @@ VALUES
 	'Hausdorff spaces',
 	'continuous functions',
 	'This is the full subcategory of $\Top$ consisting of those spaces that are <a href="https://en.wikipedia.org/wiki/Hausdorff_space" target="_blank">Hausdorff</a>.',
-	'https://ncatlab.org/nlab/show/Hausdorff+space',
-	NULL
+	'https://ncatlab.org/nlab/show/Hausdorff+space'
 ),
 (
 	'sSet',
@@ -46,8 +42,7 @@ VALUES
 	'simplicial sets, i.e. functors $\Delta^{\op} \to \Set$ where $\Delta$ is the <a href="/category/Delta">simplex category</a>',
 	'natural transformations',
 	NULL,
-	'https://ncatlab.org/nlab/show/SimpSet',
-	NULL
+	'https://ncatlab.org/nlab/show/SimpSet'
 ),
 (
 	'Man',
@@ -56,8 +51,7 @@ VALUES
 	'smooth manifolds',
 	'smooth maps',
 	'Here, a smooth manifold is defined as a second-countable Hausdorff space with a smooth atlas. The dimension is locally constant, not necessarily constant.',
-	'https://ncatlab.org/nlab/show/Diff',
-	NULL
+	'https://ncatlab.org/nlab/show/Diff'
 ),
 (
 	'Delta',
@@ -66,6 +60,5 @@ VALUES
 	'the non-empty ordered sets $[n] := \{0 < \cdots < n\}$ for $n \in \IN$',
 	'order-preserving maps',
 	'The simplex category is a skeleton of $\FinOrd \setminus \{\varnothing\}$. It plays an important role in topology and is used to define the <a href="/category/sSet">category of simplicial sets</a>.',
-	'https://ncatlab.org/nlab/show/simplex+category',
-	NULL
+	'https://ncatlab.org/nlab/show/simplex+category'
 );

--- a/databases/catdat/data/001_categories/005_algebraic-geometry.sql
+++ b/databases/catdat/data/001_categories/005_algebraic-geometry.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'sheaves of sets on a topological space $X$',
 	'morphisms of sheaves',
 	'Here, we assume that the topological space $X$ is neither discrete nor indiscrete, since otherwise this category is just a product of copies of $\Set$. Another valid notation is $\Sh(X,\Set)$.',
-	'https://ncatlab.org/nlab/show/category+of+sheaves',
-	NULL
+	'https://ncatlab.org/nlab/show/category+of+sheaves'
 ),
 (
 	'Sh(X,Ab)',
@@ -26,8 +24,7 @@ VALUES
 	'sheaves of abelian groups on a topological space $X$',
 	'morphisms of sheaves',
 	'Here, we assume that the topological space $X$ is neither discrete nor indiscrete, since otherwise this category is just a product of copies of $\Ab$.',
-	'https://ncatlab.org/nlab/show/sheaf+of+abelian+groups',
-	NULL
+	'https://ncatlab.org/nlab/show/sheaf+of+abelian+groups'
 ),
 (
 	'LRS',
@@ -36,8 +33,7 @@ VALUES
 	'locally ringed spaces',
 	'morphisms of locally ringed spaces, thus consisting of a continuous map and a homomorphism of sheaves that induces local ring homomorphisms in the stalks',
 	NULL,
-	'https://ncatlab.org/nlab/show/locally+ringed+topological+space',
-	NULL
+	'https://ncatlab.org/nlab/show/locally+ringed+topological+space'
 ),
 (
 	'Sch',
@@ -46,8 +42,7 @@ VALUES
 	'schemes',
 	'morphisms of locally ringed spaces',
 	NULL,
-	'https://ncatlab.org/nlab/show/scheme',
-	NULL
+	'https://ncatlab.org/nlab/show/scheme'
 ),
 (
 	'Z',
@@ -56,6 +51,5 @@ VALUES
 	'Z-functors, i.e. functors from commutative rings to sets',
 	'natural transformations',
 	'This category is used in functorial algebraic geometry. It also provides a typical example of a functor category that is not locally small, but nevertheless relevant. Most of its properties are directly derived from the category of sets, so other functor categories $[\C, \Set]$ for large categories $\C$ will be similar.',
-	NULL,
 	NULL
 );

--- a/databases/catdat/data/001_categories/006_order-theory.sql
+++ b/databases/catdat/data/001_categories/006_order-theory.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'partially ordered sets (aka posets), i.e. sets equipped with a reflexive, transitive, antisymmetric relation',
 	'order-preserving functions',
 	'Even though there are many similarities with $\Prost$, the main difference is that the forgetful functor $\Pos \to \Set$ has no right adjoint.',
-	'https://ncatlab.org/nlab/show/Pos',
-	NULL
+	'https://ncatlab.org/nlab/show/Pos'
 ),
 (
 	'Prost',
@@ -26,8 +24,7 @@ VALUES
 	'preordered sets (aka prosets), i.e. sets equipped with a reflexive, transitive relation',
 	'order-preserving functions',
 	'Even though there are many similarities with $\Pos$, the main difference is that the forgetful functor $\Prost \to \Set$ has a right adjoint, mapping $X$ to $(X , X \times X)$ (chaotic preorder).',
-	'https://ncatlab.org/nlab/show/Prost',
-	NULL
+	'https://ncatlab.org/nlab/show/Prost'
 ),
 (
 	'FinOrd',
@@ -36,6 +33,5 @@ VALUES
 	'finite (totally) ordered sets',
 	'order-preserving maps',
 	'The finite ordered sets of the form $\{1 < \dotsc < n\}$ for $n \in \IN$ provide a skeleton (including the empty set for $n = 0$), the augmented simplex category.',
-	'https://ncatlab.org/nlab/show/total+order',
-	NULL
+	'https://ncatlab.org/nlab/show/total+order'
 );

--- a/databases/catdat/data/001_categories/007_combinatorics.sql
+++ b/databases/catdat/data/001_categories/007_combinatorics.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'finite sets',
 	'maps',
 	NULL,
-	'https://ncatlab.org/nlab/show/FinSet',
-	NULL
+	'https://ncatlab.org/nlab/show/FinSet'
 ),
 (
 	'B',
@@ -26,8 +24,7 @@ VALUES
 	'finite sets',
 	'bijective maps',
 	'This category is also known as the permutation groupoid. It appears in the definition of a combinatorial species.',
-	'https://ncatlab.org/nlab/show/permutation+groupoid',
-	NULL
+	'https://ncatlab.org/nlab/show/permutation+groupoid'
 ),
 (
 	'FI',
@@ -36,7 +33,6 @@ VALUES
 	'finite sets',
 	'injective maps',
 	'This category is badly-behaved in itself, but plays an important role in representation theory.',
-	NULL,
 	NULL
 ),
 (
@@ -46,7 +42,6 @@ VALUES
 	'finite sets',
 	'surjective maps',
 	'This category is badly-behaved in itself, but it appears in representation theory. It has two connected components, consisting of the empty set and the non-empty finite sets.',
-	NULL,
 	NULL
 ),
 (
@@ -56,6 +51,5 @@ VALUES
 	'combinatorial species, defined as functors $\IB \to \FinSet$, where $\IB$ is the category of finite sets and bijections',
 	'natural transformations',
 	'Most categorical properties are immediately inferred from $\FinSet$. Notice that this category is not locally small; it is just equivalent to a locally small category.',
-	'https://ncatlab.org/nlab/show/species',
-	NULL
+	'https://ncatlab.org/nlab/show/species'
 );

--- a/databases/catdat/data/001_categories/008_tiny.sql
+++ b/databases/catdat/data/001_categories/008_tiny.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'no objects',
 	'no morphisms',
 	'This is the category with no objects and no morphisms. It is the initial object in the category of small categories.',
-	'https://ncatlab.org/nlab/show/empty+category',
-	NULL
+	'https://ncatlab.org/nlab/show/empty+category'
 ),
 (
 	'1',
@@ -26,8 +24,7 @@ VALUES
 	'a single object $0$',
 	'only the identity morphism',
 	'This is the simplest category, consisting of a single object $0$ and its identity morphism $0 \to 0$. A concrete representation is the full subcategory of $\Set$ consisting of the empty set. It is the terminal object in the category of small categories.',
-	'https://ncatlab.org/nlab/show/terminal+category',
-	NULL
+	'https://ncatlab.org/nlab/show/terminal+category'
 ),
 (
 	'2',
@@ -36,7 +33,6 @@ VALUES
 	'two objects $0$ and $1$',
 	'only the two identity morphisms',
 	'A concrete representation is the full subcategory of $\CRing$ consisting of the two fields $\IF_2$ and $\IF_3$.',
-	NULL,
 	NULL
 ),
 (
@@ -46,8 +42,7 @@ VALUES
 	'$0$, $1$',
 	'the two identities and a single morphism from $0$ to $1$',
 	'This is also known as the interval category. It has the property that functors $\{0 \to 1\} \to \C$ are the same as morphisms in $\C$.',
-	'https://ncatlab.org/nlab/show/interval+category',
-	NULL
+	'https://ncatlab.org/nlab/show/interval+category'
 ),
 (
 	'walking_pair',
@@ -56,8 +51,7 @@ VALUES
 	'two objects $0$ and $1$',
 	'the two identities and two parallel morphisms from $0$ to $1$',
 	'The name of this category comes from the fact that it consists of two parallel morphisms, and a functor out of this category is the same as a parallel pair of morphisms in the target category.',
-	'https://ncatlab.org/nlab/show/walking+structure',
-	NULL
+	'https://ncatlab.org/nlab/show/walking+structure'
 ),
 (
 	'walking_isomorphism',
@@ -66,8 +60,7 @@ VALUES
 	'two objects $0$ and $1$',
 	'identities, and two morphisms $0 \to 1$ and $1 \to 0$ that are mutually inverse',
 	'The name of this category comes from the fact that it consists of two objects and an isomorphism between them, and a functor out of this category is the same as an isomorphism in the target category. The walking isomorphism is actually equivalent to the trivial category.',
-	'https://ncatlab.org/nlab/show/walking+isomorphism',
-	NULL
+	'https://ncatlab.org/nlab/show/walking+isomorphism'
 ),
 (
 	'walking_composable_pair',
@@ -76,8 +69,7 @@ VALUES
 	'three objects $0,1,2$',
 	'a single morphism from each natural number to one greater than or equal to it',
 	'The name of this category comes from the fact that a functor out of it is the same as a composable pair of morphisms.',
-	'https://ncatlab.org/nlab/show/composable+pair',
-	NULL
+	'https://ncatlab.org/nlab/show/composable+pair'
 ),
 (
 	'walking_fork',
@@ -86,7 +78,6 @@ VALUES
 	'three objects $0,1,2$',
 	'one morphism $i : 0 \to 1$, two morphisms $f,g : 1 \rightrightarrows 2$, one morphism $0 \to 2$ (namely, $f \circ i = g \circ i$), and the identities',
 	'The name of this category comes from the fact that a functor out of it is the same as a <a href="https://ncatlab.org/nlab/show/fork" target="_blank">fork</a>.',
-	NULL,
 	NULL
 ),
 (
@@ -98,8 +89,7 @@ VALUES
 	'This category consists of a commutative square:
 	$$\begin{CD} a @>>> b \\ @VVV @VVV \\ c @>>> d \end{CD}$$
 	Its name comes from the fact that a functor out of it is the same as a <a href="https://ncatlab.org/nlab/show/commutative+square" target="_blank">commutative square</a> in the target category. Notice that the category is isomorphic to the product category $\{0 \to 1\} \times \{0 \to 1\}$ of the <a href="/category/walking_morphism">walking morphism</a> with itself. Hence, most (but not all) properties are inherited from it. It is also isomorphic to the partial order of positive divisors of $6$.',
-	'https://ncatlab.org/nlab/show/commutative+square',
-	NULL
+	'https://ncatlab.org/nlab/show/commutative+square'
 ),
 (
 	'walking_span',
@@ -108,8 +98,7 @@ VALUES
 	'$0,1,2$',
 	'$0 \to 1$, $0 \to 2$, and the identities',
 	'The name of this category comes from the fact that a functor out of it is the same as a <a href="https://ncatlab.org/nlab/show/span" target="_blank">span</a> in the target category. It is isomorphic to the partial order of proper positive divisors of $6$.',
-	'https://ncatlab.org/nlab/show/span#the_walking_span',
-	NULL
+	'https://ncatlab.org/nlab/show/span#the_walking_span'
 ),
 (
 	'walking_idempotent',
@@ -118,7 +107,6 @@ VALUES
 	'a single object $0$',
 	'two morphisms $\id_0,e : 0 \to 0$ with $e^2=e$',
 	'The name of this category comes from the fact that a functor out of it is the same as an <a href="https://ncatlab.org/nlab/show/idempotent" target="_blank">idempotent morphism</a> in the target category. It can also be seen as the delooping of the monoid $\{1,e\}$ in which $e^2=e$.',
-	NULL,
 	NULL
 ),
 (
@@ -128,7 +116,6 @@ VALUES
 	'two objects $0$ and $1$',
 	'the identities, morphisms $i : 0 \to 1$, $p : 1 \to 0$ satisfying $pi = \id_0$, and the idempotent $ip : 1 \to 1$.',
 	'This category could also be called the "walking split idempotent" (or "walking section", "walking retraction"), but we chose a name that emphasizes that the splitting belongs to the data. Notice that the $5$ given morphisms are indeed closed under composition. For example, $p \circ ip = p$ and $ip \circ i = i$.<br>The walking splitting can be interpreted as a skeleton of the category of $\IF_2$-vector spaces of dimension $\leq 1$.',
-	NULL,
 	NULL
 ),
 (
@@ -140,6 +127,5 @@ VALUES
 	'This category is equal to the truncated simplex category $\Delta^{\leq 1}$, i.e. the full subcategory of $\Delta$ spanned by $[0] = \{0\}$ and $[1] = \{0 < 1\}$; this also explains our notation of the category and its objects.
 	$$[0] \begin{array}{c} \xhookrightarrow{~~i~~} \\ \xtwoheadleftarrow{~~p~~} \\ \xhookrightarrow{~~j~~} \end{array} [1]$$
 	The morphisms $i,j$ are the two inclusions, $p$ is their unique retraction, and $ip,jp : [1] \to [1]$ are the two constant maps. The name of this category comes from the fact that a functor out of it is the same as a <a href="https://ncatlab.org/nlab/show/reflexive+pair" target="_blank">coreflexive pair</a> in the target category. Its dual is therefore the walking reflexive pair.',
-	NULL,
 	NULL
 );

--- a/databases/catdat/data/001_categories/009_one-object.sql
+++ b/databases/catdat/data/001_categories/009_one-object.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,8 +15,7 @@ VALUES
 	'a single object',
 	'the elements of an infinite countable group $G$',
 	'Every group $G$ yields a groupoid $BG$ with a single object $*$, morphisms given by the elements of $G$, and composition given by the group operation. In this example, we consider the case of an infinite countable group $G$ (such as $G = \IZ$).',
-	'https://ncatlab.org/nlab/show/delooping',
-	NULL
+	'https://ncatlab.org/nlab/show/delooping'
 ),
 (
 	'BG_f',
@@ -26,8 +24,7 @@ VALUES
 	'a single object',
 	'the elements of a non-trivial finite group $G$',
 	'Every group $G$ yields a groupoid $BG$ with a single object $*$, morphisms given by the elements of $G$, and composition given by the group operation. In this example, we consider the case of a non-trivial finite group $G$ (such as $G = C_2$).',
-	'https://ncatlab.org/nlab/show/delooping',
-	NULL
+	'https://ncatlab.org/nlab/show/delooping'
 ),
 (
 	'BN',
@@ -36,7 +33,6 @@ VALUES
 	'a single object',
 	'the natural numbers, with addition serving as composition',
 	'Every monoid $M$ induces a category $BM$ with a single object $*$, morphisms given by the elements of $M$, and composition given by the monoid operation. Some of the properties of this category depend on the specific monoid. In this example, we take the commutative monoid $M = (\IN,+,0)$, so composition is $n \circ m = n + m$.',
-	NULL,
 	NULL
 ),
 (
@@ -46,6 +42,5 @@ VALUES
 	'a single object',
 	'ordinal numbers, with addition as composition',
 	'Every monoid $M$ induces a category $BM$ with a single object $*$. This also works when $M$ is large, in which case $BM$ is not locally small. In this example, we apply this construction to the large monoid of ordinal numbers with respect to addition, so composition is $\alpha \circ \beta = \alpha + \beta$.',
-	NULL,
 	NULL
 );

--- a/databases/catdat/data/001_categories/010_thin.sql
+++ b/databases/catdat/data/001_categories/010_thin.sql
@@ -5,8 +5,7 @@ INSERT INTO categories (
 	objects,
 	morphisms,
 	description,
-	nlab_link,
-	dual_category_id
+	nlab_link
 )
 VALUES
 (
@@ -16,7 +15,6 @@ VALUES
 	'natural numbers $0, 1, 2, \dotsc$',
 	'a unique morphism $(n,m) : n \to m$ if $n \leq m$',
 	'This can also be seen as the path category of the infinite linear graph $\bullet \to \bullet \to \bullet \to \cdots$.',
-	NULL,
 	NULL
 ),
 (
@@ -26,8 +24,7 @@ VALUES
 	'real numbers between $0$ and $1$',
 	'a unique morphism $(s,t) : s \to t$ when $s \leq t$',
 	'Every poset can be regarded as a small thin category. This is a specific example. This category is locally $\aleph_1$-presentable (in fact, <i>every</i> object is $\aleph_1$-presentable), but not locally finitely presentable (in fact, only $0$ is finitely presentable).',
-	'https://ncatlab.org/nlab/show/interval',
-	NULL
+	'https://ncatlab.org/nlab/show/interval'
 ),
 (
 	'Z_div',
@@ -36,7 +33,6 @@ VALUES
 	'integers',
 	'a unique morphism $(a,b) : a \to b$ if $a$ divides $b$',
 	'This is a proset, not a poset, because $a$ and $-a$ divide each other, but are not equal for $a \neq 0$. Notice that this category is equivalent (but not isomorphic) to $(\IN,\mid)$.',
-	NULL,
 	NULL
 ),
 (
@@ -45,7 +41,6 @@ VALUES
 	'$(\IN_\infty, \leq)$',
 	'natural numbers and $\infty$',
 	'a unique morphism $(n, m) : n \to m$ if $n \leq m$, where of course $n \leq \infty$ for all $n$',
-	NULL,
 	NULL,
 	NULL
 ),
@@ -56,6 +51,5 @@ VALUES
 	'ordinal numbers',
 	'a unique morphism $(\alpha,\beta): \alpha \to \beta$ if $\alpha \leq \beta$',
 	'This is a large variant of the poset of natural numbers.',
-	NULL,
 	NULL
 );

--- a/databases/catdat/data/001_categories/400_dual-categories.sql
+++ b/databases/catdat/data/001_categories/400_dual-categories.sql
@@ -1,0 +1,2 @@
+UPDATE categories SET dual_category_id = 'Set_op' where id = 'Set';
+UPDATE categories SET dual_category_id = 'Set' where id = 'Set_op';


### PR DESCRIPTION
This PR makes it a bit easier to insert new categories. Since 99% of them don't have a dual category in the db, it makes sense to not always write `NULL` for the `dual_category_id` and instead just omit this information. The dual pairs can be defined in a separate file. Currently, these are only **Set** and **Set**<sup>op</sup> anyway.