### PR TITLE
Fix update script

### DIFF
--- a/.github/workflows/_deploy-reusable.yaml
+++ b/.github/workflows/_deploy-reusable.yaml
@@ -59,7 +59,9 @@ jobs:
               env:
                   APP_DB_URL: ${{ secrets.APP_DB_URL }}
                   APP_DB_AUTH_TOKEN: ${{ secrets.APP_DB_AUTH_TOKEN }}
-              run: pnpm db:update
+              run: |
+                  pnpm db:setup
+                  pnpm db:update
 
             - name: Build app
               env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,5 +29,7 @@ jobs:
             - name: Install Dependencies
               run: pnpm i
 
-            - name: Update and Test database
-              run: pnpm db:update:catdat
+            - name: Test database
+              run: |
+                  pnpm db:setup:catdat
+                  pnpm db:update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,9 @@ You need to have [Git](https://git-scm.com/), [NodeJS](https://nodejs.org/) and 
 3. Change into the directory with `cd CatDat`.
 4. Install dependencies with `pnpm install`.
 5. Create a local `.env` file from `.env.example`.
-6. Create the local database with `pnpm db:update`.
-7. Start the local development server with `pnpm dev`.
+6. Create the local database with `pnpm db:setup`.
+7. Update the local database with `pnpm db:update`.
+8. Start the local development server with `pnpm dev`.
 
 **For Maintainers:** Redis is required for admin features and submissions. Start a local instance on port 6379 via `redis-server --port 6379`.
 
@@ -73,7 +74,7 @@ to continuously run this update when a file in the subfolder [/databases/catdat/
 
 ### Troubleshooting
 
-- If the local database is corrupted, recreate it using `pnpm db:update`.
+- If the local database is corrupted, or its schema has changed, recreate it using `pnpm db:setup`.
 - If the `pnpm db:update` command fails, examine the error message to determine the cause. It could be due to malformed SQL, a contradictory property, or a failing test in the `pnpm db:test` script (which also runs as part of the update command), as explained below.
 
 ### Tests for Data Quality

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -44,7 +44,7 @@ For functors there are similar tables, such as:
 
 ## Schema vs. Data
 
-The schema defines the structure of the database: tables, views, indexes, and triggers. It is specified in several SQL files located in the subfolder [/databases/catdat/schema](/databases/catdat/schema/). The command `pnpm db:setup` deletes the old database file (if it exists) and creates a new one using this schema.
+The schema defines the structure of the database: tables, views, indexes, and triggers. It is specified in several SQL files located in the subfolder [/databases/catdat/schema](/databases/catdat/schema/). The command `pnpm db:setup` deletes the old database file (if it exists) and creates a new one using this schema. This is required when the schema changes, so it is recommended to run it periodically.
 
 Database entries (categories, properties, implications, etc.) are defined in SQL files located in the subfolder [/databases/catdat/data](/databases/catdat/data/). The command `pnpm db:seed` replaces the current contents of the database by clearing all existing data and inserting the entries defined in these SQL files.
 
@@ -60,7 +60,7 @@ The command `pnpm db:test` executes some tests and verifies that the data behave
 
 ## One command for everything
 
-Use `pnpm db:update` to run all the commands in sequence: `pnpm db:setup`, `pnpm db:seed`,`pnpm db:deduce`, and `pnpm db:test`.
+Use `pnpm db:update` to run all the commands in sequence: `pnpm db:seed`,`pnpm db:deduce`, and `pnpm db:test`.
 
 Use `pnpm db:watch` to run this command automatically every time a file in the subfolder [/databases/catdat/data](/databases/catdat/data) changes. This is useful in particular during development.
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ You need to have [Git](https://git-scm.com/), [NodeJS](https://nodejs.org/) and 
 3. Change into the directory with `cd CatDat`.
 4. Install dependencies with `pnpm install`.
 5. Create a local `.env` file from `.env.example`.
-6. Create the local database with `pnpm db:update`.
-7. Start the local development server with `pnpm dev`.
+6. Create the local database with `pnpm db:setup`.
+7. Update the local database with `pnpm db:update`.
+8. Start the local development server with `pnpm dev`.
 
 **For Maintainers:** Redis is required for admin features and submissions. Start a local instance on port 6379 via `redis-server --port 6379`.
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,8 @@
 		"db:deduce": "tsx databases/catdat/scripts/deduce.ts",
 		"db:test": "tsx databases/catdat/scripts/test.ts",
 		"db:snapshot": "cp databases/catdat/catdat.db static/databases/catdat-snapshot.db",
-		"db:update": "pnpm db:setup && pnpm db:seed && pnpm db:deduce && pnpm db:test && pnpm db:snapshot",
-		"db:watch": "tsx databases/catdat/scripts/watch.ts",
-		"db:update:catdat": "pnpm db:setup:catdat && pnpm db:seed && pnpm db:deduce && pnpm db:test && pnpm db:snapshot"
+		"db:update": "pnpm db:seed && pnpm db:deduce && pnpm db:test && pnpm db:snapshot",
+		"db:watch": "tsx databases/catdat/scripts/watch.ts"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-netlify": "^6.0.4",


### PR DESCRIPTION
The development server stopped showing data changes after the database was updated with `pnpm db:update`. The cause was #138, and specifically 1772e4b9fcef006fe0d1dd15645a7a493eed6e95 (removal of migrations). In this change, the script was modified to also delete the local database file before rebuilding it from scratch.

I assume this breaks the database connection in the development server, which is why it no longer reacts to changes.

This PR fixes this issue by excluding the setup step from the update command. A downside is that the setup command now has to be run manually by maintainers whenever the schema changes, with no automatic mechanism in place (since migrations have been removed*). For now, I think this is acceptable, as only a small number of people are actively working on CatDat and they can be informed when schema changes occur.

*Maybe I should bring them back.