### PR TITLE
Record schema changes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+schema.json

--- a/databases/.gitignore
+++ b/databases/.gitignore
@@ -2,3 +2,4 @@
 **/*.db-wal
 **/*.db-shm
 **/*.db-journal
+**/schema.json

--- a/databases/catdat/scripts/schema.utils.ts
+++ b/databases/catdat/scripts/schema.utils.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const schema_folder = path.join(process.cwd(), 'databases', 'catdat', 'schema')
+
+export function create_schema_hash(): string {
+	const schema = fs
+		.readdirSync(schema_folder, 'utf8')
+		.filter((file) => file.endsWith('.sql'))
+		.sort()
+		.map((file) => fs.readFileSync(path.join(schema_folder, file), 'utf8'))
+		.join('\n')
+	return sha256_hex(schema)
+}
+
+export function write_schema_hash(hash: string) {
+	fs.writeFileSync(
+		path.join(schema_folder, 'schema.json'),
+		JSON.stringify({ hash }),
+		'utf8',
+	)
+}
+
+export function get_saved_schema_hash() {
+	try {
+		const txt = fs.readFileSync(path.join(schema_folder, 'schema.json'), 'utf8')
+		const json = JSON.parse(txt) as { hash: string }
+		return json.hash
+	} catch (_) {
+		return ''
+	}
+}
+
+export function sha256_hex(input: string): string {
+	return createHash('sha256').update(input).digest('hex')
+}

--- a/databases/catdat/scripts/seed.ts
+++ b/databases/catdat/scripts/seed.ts
@@ -1,12 +1,23 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { get_client } from './shared'
+import { create_schema_hash, get_saved_schema_hash } from './schema.utils'
+
+seed()
 
 /**
  * Seeds the data recorded in SQL files into the database.
  */
 function seed() {
 	console.info('\n--- Seed CatDat database ---')
+
+	const schema_hash = get_saved_schema_hash()
+	const actual_hash = create_schema_hash()
+	if (schema_hash !== actual_hash) {
+		console.error(`❌ Your schema is outdated. Run first pnpm db:setup.`)
+		process.exit(1)
+	}
+
 	const db = get_client()
 	const data_folder = path.join(process.cwd(), 'databases', 'catdat', 'data')
 
@@ -53,5 +64,3 @@ function seed() {
 		process.exit(1)
 	}
 }
-
-seed()

--- a/databases/catdat/scripts/setup.ts
+++ b/databases/catdat/scripts/setup.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { get_client } from './shared'
+import { create_schema_hash, write_schema_hash } from './schema.utils'
+
+const schema_folder = path.join(process.cwd(), 'databases', 'catdat', 'schema')
 
 setup()
 
@@ -12,8 +15,6 @@ function setup() {
 
 	const db = get_client()
 	db.pragma('foreign_keys = ON')
-
-	const schema_folder = path.join(process.cwd(), 'databases', 'catdat', 'schema')
 
 	const files = fs
 		.readdirSync(schema_folder, 'utf8')
@@ -35,6 +36,9 @@ function setup() {
 			process.exit(1)
 		}
 	}
+
+	const hash = create_schema_hash()
+	write_schema_hash(hash)
 
 	console.info('Setup complete')
 }


### PR DESCRIPTION
After #159, when the schema is changed, developers working on CatDat had to be informed manually to run `pnpm db:setup` again. This PR changes this and improves the DX by automatically alerting the developer. This is done as follows:

1. The setup script creates a JSON file containing a hash of the entire database schema. It looks like this:

```json
{"hash":"712371c3e37176898209aa8bad6bbd6be309a251037bf4882365c368c9f5a225"}
```

2. This JSON file is listed in`.gitignore`, i.e. it is local to each developer. This means that changes to the schema in the repository do not directly update this file. 
3. When the seed script runs (in particular, during the update script), the current schema hash is computed and compared with the stored hash. If there is a mismatch, the process stops and logs the error message `❌ Your schema is outdated. Run pnpm db:setup first`.

Thus, when the schema is updated and another developer pulls the latest changes and runs the update command, they immediately see in the terminal that the schema has changed and that they need to update it.

Of course, another approach would be to use proper migrations (again), but they turned out to be too unflexible (in particular, when working with SQLite). I will check if the solution in this PR is sufficient.