### PR TITLE
Use IDs to order tags, special objects, and special morphisms

### DIFF
--- a/databases/catdat/data/000_setup/002_tags.sql
+++ b/databases/catdat/data/000_setup/002_tags.sql
@@ -1,14 +1,14 @@
-INSERT INTO tags (position, tag)
+INSERT INTO tags (tag)
 VALUES
-(1, 'algebra'),
-(2, 'algebraic geometry'),
-(3, 'analysis'),
-(4, 'category theory'),
-(5, 'combinatorics'),
-(6, 'number theory'),
-(7, 'order theory'),
-(8, 'set theory'),
-(9, 'topology'),
-(10, 'finite'),
-(11, 'thin'),
-(12, 'single object');
+    ('algebra'),
+    ('algebraic geometry'),
+    ('analysis'),
+    ('category theory'),
+    ('combinatorics'),
+    ('number theory'),
+    ('order theory'),
+    ('set theory'),
+    ('topology'),
+    ('finite'),
+    ('thin'),
+    ('single object');

--- a/databases/catdat/data/005_special-objects/001_special_object_types.sql
+++ b/databases/catdat/data/005_special-objects/001_special_object_types.sql
@@ -1,6 +1,6 @@
-INSERT INTO special_object_types (type, dual, position)
+INSERT INTO special_object_types (type, dual)
 VALUES
-('terminal object', 'initial object', 0),
-('initial object', 'terminal object', 1),
-('products', 'coproducts', 2),
-('coproducts', 'products', 3);
+    ('terminal object', 'initial object'),
+    ('initial object', 'terminal object'),
+    ('products', 'coproducts'),
+    ('coproducts', 'products');

--- a/databases/catdat/data/006_special-morphisms/001_special_morphism_types.sql
+++ b/databases/catdat/data/006_special-morphisms/001_special_morphism_types.sql
@@ -1,7 +1,7 @@
-INSERT INTO special_morphism_types (type, dual, position)
+INSERT INTO special_morphism_types (type, dual)
 VALUES
-('isomorphisms', 'isomorphisms', 0),
-('monomorphisms', 'epimorphisms', 1),
-('epimorphisms', 'monomorphisms', 2),
-('regular monomorphisms', 'regular epimorphisms', 3),
-('regular epimorphisms', 'regular monomorphisms', 4);
+    ('isomorphisms', 'isomorphisms'),
+    ('monomorphisms', 'epimorphisms'),
+    ('epimorphisms', 'monomorphisms'),
+    ('regular monomorphisms', 'regular epimorphisms'),
+    ('regular epimorphisms', 'regular monomorphisms');

--- a/databases/catdat/schema/002_tags.sql
+++ b/databases/catdat/schema/002_tags.sql
@@ -1,6 +1,6 @@
 CREATE TABLE tags (
-    tag TEXT PRIMARY KEY,
-    position INTEGER DEFAULT 0
+    id INTEGER PRIMARY KEY,
+    tag TEXT NOT NULL UNIQUE
 );
 
 CREATE TABLE category_tag_assignments (

--- a/databases/catdat/schema/007_special_objects.sql
+++ b/databases/catdat/schema/007_special_objects.sql
@@ -1,7 +1,7 @@
 CREATE TABLE special_object_types (
-    type TEXT PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL UNIQUE,
     dual TEXT,
-    position INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (dual) REFERENCES special_object_types (type) ON DELETE SET NULL
 );
 

--- a/databases/catdat/schema/008_special-morphisms.sql
+++ b/databases/catdat/schema/008_special-morphisms.sql
@@ -1,7 +1,7 @@
 CREATE TABLE special_morphism_types (
-    type TEXT PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL UNIQUE,
     dual TEXT,
-    position INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (dual) REFERENCES special_morphism_types (type) ON DELETE SET NULL
 );
 

--- a/src/routes/categories/+page.server.ts
+++ b/src/routes/categories/+page.server.ts
@@ -6,7 +6,7 @@ import sql from 'sql-template-tag'
 export const load = async () => {
 	const { results, err } = batch<[CategoryShort, TagObject]>([
 		sql`SELECT id, name FROM categories ORDER BY lower(name)`,
-		sql`SELECT tag FROM tags ORDER BY position`,
+		sql`SELECT tag FROM tags ORDER BY id`,
 	])
 
 	if (err) error(500, 'Categories could not be loaded')

--- a/src/routes/category/[id]/+page.server.ts
+++ b/src/routes/category/[id]/+page.server.ts
@@ -65,7 +65,7 @@ export const load = async (event) => {
 			FROM category_tag_assignments ct
 			INNER JOIN tags t ON t.tag = ct.tag
 			WHERE ct.category_id = ${id}
-			ORDER BY t.position
+			ORDER BY t.id
 		`,
 		// properties
 		sql`
@@ -105,7 +105,7 @@ export const load = async (event) => {
 			FROM special_objects s
 			INNER JOIN special_object_types t ON t.type = s.type
 			WHERE s.category_id = ${id}
-			ORDER BY t.position
+			ORDER BY t.id
 		`,
 		// special morphisms
 		sql`
@@ -113,7 +113,7 @@ export const load = async (event) => {
 			FROM special_morphism_types t
 			LEFT JOIN special_morphisms s
 				ON s.type = t.type AND s.category_id = ${id}
-			ORDER BY t.position
+			ORDER BY t.id
 		`,
 		// undistinguishable categories
 		sql`


### PR DESCRIPTION
This is a continuation of #134 where the `position` column has been removed from the category property assignments and instead an autoincrementing ID was used to order them on the website. In this PR, the `position` column is also removed from the other tables:

- `tags`
- `special_object_types`
- `special_morphism_types`
 
Instead, an autoincrementing ID is used. This makes the code and inserting the data cleaner. I noticed this while working on #164.

ℹ️  This requires a schema change.