### PR TITLE
Add sticky headings in long lists

### DIFF
--- a/src/components/Popup.svelte
+++ b/src/components/Popup.svelte
@@ -94,6 +94,7 @@ an issue when clicking two reasons in a row. So it's a <div> then.
 	.popup {
 		--speed: 120ms;
 		position: fixed;
+		z-index: 5;
 		bottom: 0;
 		left: 0;
 		right: 0;

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -91,6 +91,15 @@ h2 {
 h3 {
 	font-size: 1.45rem;
 	margin-block: 2rem 1rem;
+
+	&.sticky-heading {
+		position: sticky;
+		top: 0;
+		background-color: var(--bg-color);
+		z-index: 1;
+		margin-block: 1rem 0rem;
+		padding-block: 1rem;
+	}
 }
 
 /* various elements */

--- a/src/routes/category-property/[id]/+page.svelte
+++ b/src/routes/category-property/[id]/+page.svelte
@@ -56,14 +56,14 @@
 	</ul>
 {/if}
 
-<h3>Relevant implications</h3>
+<h3 class="sticky-heading">Relevant implications</h3>
 
 <ImplicationList
 	implications={data.relevant_implications}
 	highlighted_property={data.property.id}
 />
 
-<h3>Examples</h3>
+<h3 class="sticky-heading">Examples</h3>
 
 <p class="hint">
 	{pluralize(data.examples.length, {
@@ -74,7 +74,7 @@
 
 <CategoryList categories={data.examples} />
 
-<h3>Counterexamples</h3>
+<h3 class="sticky-heading">Counterexamples</h3>
 
 <p class="hint">
 	{pluralize(data.counterexamples.length, {
@@ -85,7 +85,7 @@
 
 <CategoryList categories={data.counterexamples} />
 
-<h3>Unknown</h3>
+<h3 class="sticky-heading">Unknown</h3>
 
 <p class="hint">
 	{pluralize(data.unknown_categories.length, {

--- a/src/routes/category/[id]/+page.svelte
+++ b/src/routes/category/[id]/+page.svelte
@@ -82,7 +82,7 @@
 
 <div class="two-columns">
 	<section>
-		<h3>Satisfied Properties</h3>
+		<h3 class="sticky-heading">Satisfied Properties</h3>
 
 		{#if category_detail_level.value === 'all'}
 			<p class="hint">Properties from the database</p>
@@ -107,7 +107,7 @@
 	</section>
 
 	<section>
-		<h3>Unsatisfied Properties</h3>
+		<h3 class="sticky-heading">Unsatisfied Properties</h3>
 
 		{#if category_detail_level.value === 'all'}
 			<p class="hint">Properties from the database</p>
@@ -135,7 +135,7 @@
 </div>
 
 <section>
-	<h3>Unknown properties</h3>
+	<h3 class="sticky-heading">Unknown properties</h3>
 
 	{#if data.unknown_properties.length > 0}
 		<p class="hint">

--- a/src/routes/functor-property/[id]/+page.svelte
+++ b/src/routes/functor-property/[id]/+page.svelte
@@ -45,14 +45,14 @@
 	</ul>
 {/if}
 
-<h3>Relevant implications</h3>
+<h3 class="sticky-heading">Relevant implications</h3>
 
 <FunctorImplicationList
 	implications={data.relevant_implications}
 	highlighted_property={data.property.id}
 />
 
-<h3>Examples</h3>
+<h3 class="sticky-heading">Examples</h3>
 
 <p class="hint">
 	{pluralize(data.examples.length, {
@@ -63,7 +63,7 @@
 
 <FunctorList functors={data.examples} />
 
-<h3>Counterexamples</h3>
+<h3 class="sticky-heading">Counterexamples</h3>
 
 <p class="hint">
 	{pluralize(data.counterexamples.length, {
@@ -74,7 +74,7 @@
 
 <FunctorList functors={data.counterexamples} />
 
-<h3>Unknown</h3>
+<h3 class="sticky-heading">Unknown</h3>
 
 <p class="hint">
 	{pluralize(data.unknown_functors.length, {

--- a/src/routes/functor/[id]/+page.svelte
+++ b/src/routes/functor/[id]/+page.svelte
@@ -38,7 +38,7 @@
 {#key functor.id}
 	<div class="two-columns">
 		<section>
-			<h3>Satisfied Properties</h3>
+			<h3 class="sticky-heading">Satisfied Properties</h3>
 
 			{#if category_detail_level.value === 'all'}
 				<p class="hint">Properties from the database</p>
@@ -66,7 +66,7 @@
 		</section>
 
 		<section>
-			<h3>Unsatisfied Properties</h3>
+			<h3 class="sticky-heading">Unsatisfied Properties</h3>
 
 			{#if category_detail_level.value === 'all'}
 				<p class="hint">Properties from the database</p>
@@ -97,7 +97,7 @@
 	</div>
 
 	<section>
-		<h3>Unknown properties</h3>
+		<h3 class="sticky-heading">Unknown properties</h3>
 
 		{#if data.unknown_properties.length}
 			<p class="hint">


### PR DESCRIPTION
This small PR adds sticky headings to long lists on detail pages for categories, functors, and their properties. This is useful to remember the context when scrolling, in particular on mobile devices.


https://github.com/user-attachments/assets/fb0aed42-3111-429f-9fcb-121aef190872

