### PR TITLE
Display contradiction proofs on the search results page

### DIFF
--- a/src/lib/server/consistency.ts
+++ b/src/lib/server/consistency.ts
@@ -15,8 +15,7 @@ export function get_contradiction(
 	unsatisfied_properties: Set<string>,
 ): string[] | null {
 	for (const p of satisfied_properties) {
-		if (unsatisfied_properties.has(p))
-			return [`${p} cannot be both satisfied and unsatisfied`]
+		if (unsatisfied_properties.has(p)) return [`${p} ⟹ ${p}`]
 	}
 
 	const implications = get_normalized_category_implications()
@@ -34,73 +33,62 @@ function contradiction_worker(
 	implications: NormalizedCategoryImplication[],
 ): string[] | null {
 	for (const p of satisfied_properties) {
-		if (unsatisfied_properties.has(p)) {
-			return [`${p} cannot be both satisfied and unsatisfied`]
-		}
+		if (unsatisfied_properties.has(p)) return [`${p} ⟹ ${p}`]
 	}
+
+	const deduction_dict: Record<string, NormalizedCategoryImplication> = {}
+	const deduced_satisfied_properties = new Set(satisfied_properties)
+
+	// bfs to find contradiction
 
 	let contradictory_property: string | null = null
 
-	const used_implications: {
-		implication: NormalizedCategoryImplication
-		relevant: boolean
-	}[] = []
+	while (!contradictory_property) {
+		const new_properties = new Set<string>()
 
-	const deduced_satisfied_properties = new Set(satisfied_properties)
-
-	function get_next_implication() {
 		for (const implication of implications) {
 			const is_valid =
 				is_subset(implication.assumptions, deduced_satisfied_properties) &&
-				!deduced_satisfied_properties.has(implication.conclusion)
-			if (is_valid) return implication
+				!deduced_satisfied_properties.has(implication.conclusion) &&
+				!new_properties.has(implication.conclusion)
+			if (!is_valid) continue
+
+			new_properties.add(implication.conclusion)
+			deduction_dict[implication.conclusion] = implication
+
+			if (unsatisfied_properties.has(implication.conclusion)) {
+				contradictory_property = implication.conclusion
+				break
+			}
 		}
-		return null
-	}
 
-	while (true) {
-		const implication = get_next_implication()
-		if (!implication) break
+		if (!new_properties.size) break
 
-		used_implications.push({ implication, relevant: false })
-		deduced_satisfied_properties.add(implication.conclusion)
-
-		if (unsatisfied_properties.has(implication.conclusion)) {
-			contradictory_property = implication.conclusion
-			break
-		}
+		for (const p of new_properties) deduced_satisfied_properties.add(p)
 	}
 
 	if (!contradictory_property) return null
 
-	// remove irrelevant implications
-
-	const relevant_properties = new Set([contradictory_property])
-
-	for (let i = used_implications.length - 1; i >= 0; i--) {
-		const { implication } = used_implications[i]
-		const is_relevant = relevant_properties.has(implication.conclusion)
-
-		if (is_relevant) {
-			used_implications[i].relevant = is_relevant
-			for (const p of implication.assumptions) {
-				if (!satisfied_properties.has(p)) relevant_properties.add(p)
-			}
-		}
-	}
-
-	const relevant_implications = used_implications
-		.filter((item) => item.relevant)
-		.map((item) => item.implication)
+	// build minimal contradiction proof
 
 	const contradiction: string[] = []
 
-	for (let i = 0; i < relevant_implications.length; i++) {
-		const implication = relevant_implications[i]
-		let segment = `${[...implication.assumptions].join(' ∧ ')} ⟹ ${implication.conclusion}`
-		if (i === relevant_implications.length - 1) segment += ` ↯`
-		contradiction.push(segment)
+	const visited_properties = new Set<string>()
+
+	function build_proof(property: string) {
+		if (visited_properties.has(property)) return
+		if (satisfied_properties.has(property)) return
+		visited_properties.add(property)
+
+		const implication = deduction_dict[property]
+		if (!implication) throw new Error(`Missing deduction for property: ${property}`)
+
+		for (const p of implication.assumptions) build_proof(p)
+
+		contradiction.push(stringify_implication(implication))
 	}
+
+	build_proof(contradictory_property)
 
 	return contradiction
 }
@@ -143,6 +131,10 @@ function get_normalized_category_implications() {
 	}
 
 	return implications
+}
+
+function stringify_implication(implication: NormalizedCategoryImplication) {
+	return `${[...implication.assumptions].join(' ∧ ')} ⟹ ${implication.conclusion}`
 }
 
 export function get_missing_combinations() {

--- a/src/lib/server/consistency.ts
+++ b/src/lib/server/consistency.ts
@@ -69,13 +69,23 @@ function contradiction_worker(
 
 	if (!contradictory_property) return null
 
-	// build minimal contradiction proof
+	return build_shortest_proof(
+		satisfied_properties,
+		deduction_dict,
+		contradictory_property,
+	)
+}
 
-	const contradiction: string[] = []
+function build_shortest_proof(
+	satisfied_properties: Set<string>,
+	deduction_dict: Record<string, NormalizedCategoryImplication>,
+	target_property: string,
+) {
+	const proof: string[] = []
 
 	const visited_properties = new Set<string>()
 
-	function build_proof(property: string) {
+	function derive(property: string) {
 		if (visited_properties.has(property)) return
 		if (satisfied_properties.has(property)) return
 		visited_properties.add(property)
@@ -83,14 +93,14 @@ function contradiction_worker(
 		const implication = deduction_dict[property]
 		if (!implication) throw new Error(`Missing deduction for property: ${property}`)
 
-		for (const p of implication.assumptions) build_proof(p)
+		for (const p of implication.assumptions) derive(p)
 
-		contradiction.push(stringify_implication(implication))
+		proof.push(stringify_implication(implication))
 	}
 
-	build_proof(contradictory_property)
+	derive(target_property)
 
-	return contradiction
+	return proof
 }
 
 function get_normalized_category_implications() {

--- a/src/lib/server/consistency.ts
+++ b/src/lib/server/consistency.ts
@@ -39,7 +39,12 @@ function contradiction_worker(
 		}
 	}
 
-	let contradiction: string[] = []
+	let contradictory_property: string | null = null
+
+	const used_implications: {
+		implication: NormalizedCategoryImplication
+		relevant: boolean
+	}[] = []
 
 	const deduced_satisfied_properties = new Set(satisfied_properties)
 
@@ -57,19 +62,47 @@ function contradiction_worker(
 		const implication = get_next_implication()
 		if (!implication) break
 
-		let segment = `${[...implication.assumptions].join(' ∧ ')} ⟹ ${implication.conclusion}`
+		used_implications.push({ implication, relevant: false })
+		deduced_satisfied_properties.add(implication.conclusion)
 
 		if (unsatisfied_properties.has(implication.conclusion)) {
-			segment += ` ↯`
-			contradiction.push(segment)
-			return contradiction
+			contradictory_property = implication.conclusion
+			break
 		}
-
-		contradiction.push(segment)
-		deduced_satisfied_properties.add(implication.conclusion)
 	}
 
-	return null
+	if (!contradictory_property) return null
+
+	// remove irrelevant implications
+
+	const relevant_properties = new Set([contradictory_property])
+
+	for (let i = used_implications.length - 1; i >= 0; i--) {
+		const { implication } = used_implications[i]
+		const is_relevant = relevant_properties.has(implication.conclusion)
+
+		if (is_relevant) {
+			used_implications[i].relevant = is_relevant
+			for (const p of implication.assumptions) {
+				if (!satisfied_properties.has(p)) relevant_properties.add(p)
+			}
+		}
+	}
+
+	const relevant_implications = used_implications
+		.filter((item) => item.relevant)
+		.map((item) => item.implication)
+
+	const contradiction: string[] = []
+
+	for (let i = 0; i < relevant_implications.length; i++) {
+		const implication = relevant_implications[i]
+		let segment = `${[...implication.assumptions].join(' ∧ ')} ⟹ ${implication.conclusion}`
+		if (i === relevant_implications.length - 1) segment += ` ↯`
+		contradiction.push(segment)
+	}
+
+	return contradiction
 }
 
 function get_normalized_category_implications() {

--- a/src/lib/server/consistency.ts
+++ b/src/lib/server/consistency.ts
@@ -10,31 +10,36 @@ type NormalizedCategoryImplication = {
 	conclusion: string
 }
 
-export function check_consistency(
+export function get_contradiction(
 	satisfied_properties: Set<string>,
 	unsatisfied_properties: Set<string>,
-): { consistent: boolean } {
+): string[] | null {
 	for (const p of satisfied_properties) {
-		if (unsatisfied_properties.has(p)) return { consistent: false }
+		if (unsatisfied_properties.has(p))
+			return [`${p} cannot be both satisfied and unsatisfied`]
 	}
 
 	const implications = get_normalized_category_implications()
 
-	return check_consistency_worker(
+	return contradiction_worker(
 		satisfied_properties,
 		unsatisfied_properties,
 		implications,
 	)
 }
 
-function check_consistency_worker(
+function contradiction_worker(
 	satisfied_properties: Set<string>,
 	unsatisfied_properties: Set<string>,
 	implications: NormalizedCategoryImplication[],
-): { consistent: boolean } {
+): string[] | null {
 	for (const p of satisfied_properties) {
-		if (unsatisfied_properties.has(p)) return { consistent: false }
+		if (unsatisfied_properties.has(p)) {
+			return [`${p} cannot be both satisfied and unsatisfied`]
+		}
 	}
+
+	let contradiction: string[] = []
 
 	const deduced_satisfied_properties = new Set(satisfied_properties)
 
@@ -52,14 +57,19 @@ function check_consistency_worker(
 		const implication = get_next_implication()
 		if (!implication) break
 
+		let segment = `${[...implication.assumptions].join(' ∧ ')} ⟹ ${implication.conclusion}`
+
 		if (unsatisfied_properties.has(implication.conclusion)) {
-			return { consistent: false }
+			segment += ` ↯`
+			contradiction.push(segment)
+			return contradiction
 		}
 
+		contradiction.push(segment)
 		deduced_satisfied_properties.add(implication.conclusion)
 	}
 
-	return { consistent: true }
+	return null
 }
 
 function get_normalized_category_implications() {
@@ -143,13 +153,13 @@ export function get_missing_combinations() {
 				continue
 			}
 
-			const { consistent } = check_consistency_worker(
+			const contradiction = contradiction_worker(
 				new Set([p.id]),
 				new Set([q.id]),
 				implications,
 			)
 
-			if (consistent) missing_pairs.push([p.id, q.id])
+			if (!contradiction) missing_pairs.push([p.id, q.id])
 		}
 	}
 

--- a/src/lib/server/consistency.ts
+++ b/src/lib/server/consistency.ts
@@ -13,13 +13,12 @@ type NormalizedCategoryImplication = {
 export function check_consistency(
 	satisfied_properties: Set<string>,
 	unsatisfied_properties: Set<string>,
-): { consistent: boolean } | null {
+): { consistent: boolean } {
 	for (const p of satisfied_properties) {
 		if (unsatisfied_properties.has(p)) return { consistent: false }
 	}
 
 	const implications = get_normalized_category_implications()
-	if (!implications) return null
 
 	return check_consistency_worker(
 		satisfied_properties,
@@ -63,9 +62,7 @@ function check_consistency_worker(
 	return { consistent: true }
 }
 
-export function get_normalized_category_implications():
-	| NormalizedCategoryImplication[]
-	| null {
+function get_normalized_category_implications() {
 	const { rows, err } = query<{
 		id: string
 		assumptions: string
@@ -75,7 +72,7 @@ export function get_normalized_category_implications():
 		sql`SELECT id, assumptions, conclusions, is_equivalence FROM category_implications_view`,
 	)
 
-	if (err) return null
+	if (err) throw err
 
 	const implications: NormalizedCategoryImplication[] = []
 
@@ -107,14 +104,13 @@ export function get_normalized_category_implications():
 
 export function get_missing_combinations() {
 	const implications = get_normalized_category_implications()
-	if (!implications) return null
 
 	const { rows: properties, err } = query<{
 		id: string
 		dual_property_id: string | null
 	}>(sql`SELECT id, dual_property_id FROM category_properties ORDER BY lower(id)`)
 
-	if (err) return null
+	if (err) throw err
 
 	const { rows: existing, err: err_existing } = query<{
 		p: string
@@ -127,7 +123,7 @@ export function get_missing_combinations() {
 		WHERE cp.is_satisfied = TRUE AND cnp.is_satisfied = FALSE
 	`)
 
-	if (err_existing) return null
+	if (err_existing) throw err_existing
 
 	const witnessed_pairs = new Set(existing.map(({ p, q }) => `${p}|${q}`))
 

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -4,7 +4,7 @@ import { query } from '$lib/server/db.catdat'
 import { error } from '@sveltejs/kit'
 import sql from 'sql-template-tag'
 import { SEARCH_SEPARATOR } from '$lib/commons/search.config'
-import { check_consistency } from '$lib/server/consistency'
+import { get_contradiction } from '$lib/server/consistency'
 
 type NamedObject = {
 	id: string
@@ -72,19 +72,19 @@ export function search_handler(event: RequestEvent, type: 'category' | 'functor'
 	// TODO: implement this for functors as well
 	if (type === 'category') {
 		try {
-			const { consistent } = check_consistency(
+			const contradiction = get_contradiction(
 				new Set(satisfied_properties),
 				new Set(unsatisfied_properties),
 			)
 
-			if (!consistent) {
+			if (contradiction) {
 				event.setHeaders({
 					// shared cache for 30min
 					'cache-control': 'public, max-age=0, s-maxage=1800',
 				})
 
 				return {
-					is_consistent: false,
+					contradiction,
 					all_properties,
 					satisfied_properties,
 					unsatisfied_properties,
@@ -125,7 +125,7 @@ export function search_handler(event: RequestEvent, type: 'category' | 'functor'
 	})
 
 	return {
-		is_consistent: true,
+		contradiction: null,
 		all_properties,
 		satisfied_properties,
 		unsatisfied_properties,

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -71,29 +71,31 @@ export function search_handler(event: RequestEvent, type: 'category' | 'functor'
 
 	// TODO: implement this for functors as well
 	if (type === 'category') {
-		const check = check_consistency(
-			new Set(satisfied_properties),
-			new Set(unsatisfied_properties),
-		)
+		try {
+			const { consistent } = check_consistency(
+				new Set(satisfied_properties),
+				new Set(unsatisfied_properties),
+			)
 
-		if (!check) error(500, 'Consistency check failed')
+			if (!consistent) {
+				event.setHeaders({
+					// shared cache for 30min
+					'cache-control': 'public, max-age=0, s-maxage=1800',
+				})
 
-		if (!check.consistent) {
-			event.setHeaders({
-				// shared cache for 30min
-				'cache-control': 'public, max-age=0, s-maxage=1800',
-			})
-
-			return {
-				is_consistent: false,
-				all_properties,
-				satisfied_properties,
-				unsatisfied_properties,
-				found_objects: [],
-				dual_satisfied_properties,
-				dual_unsatisfied_properties,
-				dual_search_available,
+				return {
+					is_consistent: false,
+					all_properties,
+					satisfied_properties,
+					unsatisfied_properties,
+					found_objects: [],
+					dual_satisfied_properties,
+					dual_unsatisfied_properties,
+					dual_search_available,
+				}
 			}
+		} catch (err) {
+			error(500, 'Consistency check failed')
 		}
 	}
 

--- a/src/routes/category-search/results/+page.svelte
+++ b/src/routes/category-search/results/+page.svelte
@@ -63,7 +63,7 @@
 	</div>
 {/if}
 
-{#if data.is_consistent}
+{#if !data.contradiction}
 	<p class="hint">
 		{pluralize(data.found_objects.length, {
 			one: 'Found {count} category',
@@ -73,8 +73,14 @@
 	<CategoryList categories={data.found_objects ?? []} />
 {:else}
 	<p class="hint">
-		<Fa icon={faWarning} /> No categories found because the requirements are inconsistent.
+		<Fa icon={faWarning} /> No categories found because the requirements are inconsistent:
 	</p>
+
+	<ol class="hint">
+		{#each data.contradiction as segment}
+			<li>{segment}</li>
+		{/each}
+	</ol>
 {/if}
 
 <menu>

--- a/src/routes/missing/+page.server.ts
+++ b/src/routes/missing/+page.server.ts
@@ -87,18 +87,18 @@ export const load = async () => {
 		0,
 	)
 
-	const missing_combinations = get_missing_combinations()
+	try {
+		const missing_combinations = get_missing_combinations()
 
-	if (!missing_combinations) {
+		return {
+			categories_with_unknown_properties,
+			total_unknown_pairs,
+			categories_with_missing_morphisms,
+			undistinguishable_category_pairs,
+			functors_with_unknown_properties,
+			missing_combinations,
+		}
+	} catch (err) {
 		error(500, 'Failed to load missing combinations')
-	}
-
-	return {
-		categories_with_unknown_properties,
-		total_unknown_pairs,
-		categories_with_missing_morphisms,
-		undistinguishable_category_pairs,
-		functors_with_unknown_properties,
-		missing_combinations,
 	}
 }


### PR DESCRIPTION
On the category search results page, there was already a check to determine whether the satisfied and unsatisfied properties are consistent. However, in the case of an inconsistency, it was not explained *why* the requirements were contradictory. This PR now computes and displays the corresponding deduction, allowing users to understand the reason of the contradiction.

More precisely, when a contradiction occurs, a shortest deduction is generated showing that one of the specified unsatisfied properties follows from the specified satisfied properties. Internally, the deduction is computed using a **breadth-first search** on the implication hypergraph, ensuring that the generated contradiction has minimal length.

## Examples

<img width="500" alt="proof 1" src="https://github.com/user-attachments/assets/b441b2a4-caf4-497f-92de-585aa97d6901" /><br />

<img width="500" alt="proof 2" src="https://github.com/user-attachments/assets/8c505d0d-f18a-4b42-bcea-1b011e0ae73d" /><br />

<img width="500" alt="proof 2" src="https://github.com/user-attachments/assets/45e04010-93ab-4dbd-a5bd-2e3f92985ee4" />

## Thoughts

This feature does more than merely check whether a set of properties is consistent. It computes a shortest proof of $p_1 \wedge \cdots \wedge p_n \to q$ whenever such a proof exists. This may be useful in future work for extending the search functionality or improving the deduction system.