### PR TITLE
Add help messages for new users

### DIFF
--- a/src/components/HelpMessage.svelte
+++ b/src/components/HelpMessage.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { browser } from '$app/environment'
+	import { faLightbulb } from '@fortawesome/free-solid-svg-icons'
+	import type { Snippet } from 'svelte'
+	import Fa from 'svelte-fa'
+
+	type Props = {
+		id: string
+		children: Snippet
+	}
+
+	let { id, children }: Props = $props()
+
+	let show_message = $derived(browser && !window.localStorage.getItem(`help:${id}`))
+
+	function hide_message() {
+		show_message = false
+		if (!browser) return
+		window.localStorage.setItem(`help:${id}`, 'hide')
+	}
+</script>
+
+{#if show_message}
+	<div class="message">
+		<Fa icon={faLightbulb} color="var(--accent-color)" />&nbsp;
+		{@render children()}
+		<button onclick={hide_message}>Hide this message</button>
+	</div>
+{/if}
+
+<style>
+	.message {
+		margin-block: 1rem;
+		font-size: 1rem;
+		background-color: var(--secondary-bg-color);
+		padding: 0.5rem 1rem;
+		border-radius: 1rem;
+	}
+
+	button {
+		text-decoration: underline;
+	}
+</style>

--- a/src/routes/category-implications/+page.svelte
+++ b/src/routes/category-implications/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import { browser } from '$app/environment'
+	import HelpMessage from '$components/HelpMessage.svelte'
 	import ImplicationList from '$components/ImplicationList.svelte'
 	import MetaData from '$components/MetaData.svelte'
 	import SearchFilter from '$components/SearchFilter.svelte'
 	import SuggestionForm from '$components/SuggestionForm.svelte'
 	import { normalize_text, pluralize } from '$lib/client/utils'
+	import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+	import Fa from 'svelte-fa'
 
 	let { data } = $props()
 
@@ -46,6 +49,10 @@
 		other: 'Found {count} implications*',
 	})}
 </p>
+
+<HelpMessage id="implication-link">
+	New here? Click any <Fa icon={faInfoCircle} /> icon to view the proof for that implication.
+</HelpMessage>
 
 <ImplicationList implications={filtered_implications} />
 

--- a/src/routes/category-property/[id]/+page.svelte
+++ b/src/routes/category-property/[id]/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import CategoryList from '$components/CategoryList.svelte'
+	import HelpMessage from '$components/HelpMessage.svelte'
 	import ImplicationList from '$components/ImplicationList.svelte'
 	import MetaData from '$components/MetaData.svelte'
 	import SuggestionForm from '$components/SuggestionForm.svelte'
 	import { pluralize } from '$lib/client/utils'
 	import { get_property_url } from '$lib/commons/property.url'
+	import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+	import Fa from 'svelte-fa'
 
 	let { data } = $props()
 </script>
@@ -55,6 +58,10 @@
 		{/if}
 	</ul>
 {/if}
+
+<HelpMessage id="implication-link">
+	New here? Click any <Fa icon={faInfoCircle} /> icon to view the proof for that implication.
+</HelpMessage>
 
 <h3 class="sticky-heading">Relevant implications</h3>
 

--- a/src/routes/category/[id]/+page.svelte
+++ b/src/routes/category/[id]/+page.svelte
@@ -7,9 +7,10 @@
 	import TextWithReason from '$components/TextWithReason.svelte'
 	import { filter_by_tag, pluralize } from '$lib/client/utils'
 	import CategoryList from '$components/CategoryList.svelte'
-	import { faQuestion } from '@fortawesome/free-solid-svg-icons'
+	import { faCommentDots, faQuestion } from '@fortawesome/free-solid-svg-icons'
 	import Fa from 'svelte-fa'
 	import SuggestionForm from '$components/SuggestionForm.svelte'
+	import HelpMessage from '$components/HelpMessage.svelte'
 
 	let { data } = $props()
 
@@ -79,6 +80,11 @@
 		<p>{@html category.description}</p>
 	{/if}
 </section>
+
+<HelpMessage id="proof-bubble">
+	New here? Click any <Fa icon={faCommentDots} scale={0.825} /> icon to view the proof for
+	that property.
+</HelpMessage>
 
 <div class="two-columns">
 	<section>


### PR DESCRIPTION
This PR adds help messages for new users. These messages explain parts of the UI whose behavior may not be immediately obvious. For example, users can expand property proofs by clicking the small speech bubble icon. (One user mentioned that this was not clear to them.) The same applies to implications.

Once "Hide this message" is clicked, the message will no longer be shown. This information is saved in the browser's `localStorage`.<br /><br />

<img width="300" alt="screenshot with help message for property" src="https://github.com/user-attachments/assets/0b33f169-6cbb-4faa-bf16-b7ecb9997431" /> &nbsp;&nbsp;&nbsp; <img width="300" alt="screenshot with help message for implication" src="https://github.com/user-attachments/assets/f2ececdb-1bb2-4c16-a079-8aacbce3bf7f" />


