### PR TITLE
Add focus to the given property in list of relevant implications

### DIFF
--- a/databases/catdat/data/category-implications/products.yaml
+++ b/databases/catdat/data/category-implications/products.yaml
@@ -5,7 +5,6 @@
     - products
   conclusions:
     - countable products
-    - finite products
     - powers
   reason: This is trivial.
   is_equivalence: false

--- a/src/routes/category-property/[id]/+page.server.ts
+++ b/src/routes/category-property/[id]/+page.server.ts
@@ -100,6 +100,12 @@ export const load = async (event) => {
 
 	const relevant_implications = relevant_implications_db.map(display_implication)
 
+	for (const impl of relevant_implications) {
+		if (!impl.is_equivalence && impl.conclusions.includes(id)) {
+			impl.conclusions = [id]
+		}
+	}
+
 	return render_nested_formulas({
 		property,
 		related_properties,


### PR DESCRIPTION
On the property detail page, all relevant implications for that property are listed. However, they are currently displayed in their full form, which means that conclusions unrelated to the given property are also shown. This PR removes those irrelevant conclusions.

Specifically, if an implication (that is not an equivalence) has P among its conclusions, then only P is shown as the conclusion. The remaining conclusions are omitted, since they are not relevant in this context. Of course, the detail page for that implication still has all conclusions.

### Examples

On the detail page for epi-regular, the implication `elementary topos -> disjoint finite coproducts + effective congruences + epi-regular + finitely cocomplete` is abbreviated to `elementary topos -> epi-regular`.

On the detail page for products, the implication `CIP -> coproducts + products + zero morphisms` is abbreviated to `CIP -> products`.

On the detail page for powers, the implication* `products -> countable products  + powers` is abbreviated to `products -> powers`.


---

*This implication was listed as `products => countable products + finite products + powers`. I removed the "finite products" since this is a consequence of "countable products" already.