### PR TITLE
Small groupoids are generalized varieties and finitely accessible

### DIFF
--- a/content/sifted-colimits-in-groupoids.md
+++ b/content/sifted-colimits-in-groupoids.md
@@ -1,0 +1,83 @@
+---
+title: Sifted colimits in groupoids
+description: A description of sifted colimits in groupoids, yielding a proof that every essentially small groupoid is a generalized variety.
+author: Martin Brandenburg
+---
+
+## Sifted colimits in groupoids
+
+While the combination of [this result](http://localhost:5173/category-implication/groupoid_consequence) and [this result](http://localhost:5173/category-implication/sifted_colimits_criterion) already implies that groupoids have sifted colimits, we can make these colimits more explicit and also prove their existence without using any non-trivial theorem. We also generalize the situation as follows.
+
+::: Lemma 1
+Let $\C$ be a category. Let $D : \I \to \C$ be a [sifted](/category-property/sifted) diagram such that for every morphism $f$ in $\I$, the morphism $D(f)$ is an isomorphism. Then $D$ has a colimit. Moreover, any object $D(i_0)$ is a colimit object. In particular, every groupoid has sifted colimits.
+:::
+
+_Proof._
+Choose any $i_0 \in \I$. For every $i \in \I$, define a morphism $u_i : D(i) \to D(i_0)$ as follows. Choose a cospan
+
+$$i \xrightarrow{a} k \xleftarrow{b} i_0,$$
+
+and set
+
+$$u_i \coloneqq D(b)^{-1} D(a) : D(i) \to D(k) \to D(i_0).$$
+
+This does not depend on the chosen cospan: since the category of cospans is connected, it suffices to check this for any morphism of cospans
+
+$$
+\begin{CD}
+i @>a>> k @<b<< i_0 \\
+@V{=}VV @VV{f}V @VV{=}V \\
+i @>>{a'}> k' @<<{b'}< i_0
+\end{CD}
+$$
+
+We compute:
+
+$$D(b)^{-1} D(a) = D(b)^{-1} D(f)^{-1} D(f) D(a) = D(fb)^{-1} D(fa) = D(b')^{-1} D(a').$$
+
+Thus, $u_i : D(i) \to D(i_0)$ is well defined. Note that $u_{i_0}$ is the identity of $D(i_0)$.
+
+To show that this defines a cocone, let $f : j \to i$ be a morphism in $\I$, and choose a cospan $i \xrightarrow{a} k \xleftarrow{b} i_0$ as above to compute $u_i$. We may then use the cospan $j \xrightarrow{af} k \xleftarrow{b} i_0$ to compute $u_j$. Hence,
+
+$$u_j = D(b)^{-1} D(af) = D(b)^{-1} D(a) D(f) = u_i D(f),$$
+
+which proves the claim.
+
+Finally, we verify the universal property. Let $(v_i : D(i) \to T)$ be another cocone, and set $h \coloneqq v_{i_0} : D(i_0) \to T$. (Since $\C$ is not assumed to be a groupoid, the morphisms $v_i$ need not be isomorphisms; the argument does not use this.)
+
+We check that $v_i = h u_i$ for every $i \in \I$. Choose a cospan $i \xrightarrow{a} k \xleftarrow{b} i_0$ as above. Then
+
+$$h u_i = v_{i_0} D(b)^{-1} D(a) = v_k D(a) = v_i.$$
+
+Moreover, $h$ is uniquely determined: if $v_i = h u_i$ for all $i \in \I$, then for $i = i_0$ we obtain $v_{i_0} = h$. <span class="qed">$\square$</span>
+
+::: Corollary 2
+If $\C$ is a groupoid, every object $X \in \C$ is strongly finitely presentable, i.e. the functor $\Hom(X,-) : \C \to \Set$ preserves sifted colimits.
+:::
+
+_Proof._
+Let $D : \I \to \C$ be a diagram and choose any $i_0 \in \I$. We obtain a commutative diagram:
+
+$$
+\begin{CD}
+\Hom(X,D(i_0)) @>{=}>> \Hom(X,D(i_0)) \\
+@VVV @VVV \\
+\colim_{i \in \I} \Hom(X,D(i)) @>>> \Hom(X,\colim_{i \in \I} D(i))
+\end{CD}
+$$
+
+The top horizontal map is the identity. By Lemma 1 applied to $D$, the right vertical map is an isomorphism. By Lemma 2 applied to the diagram $\Hom(X,D(-))$ in $\Set$, the left vertical map is an isomorphism. Hence the bottom horizontal map is an isomorphism. <span class="qed">$\square$</span>
+
+::: Corollary 3
+Any essentially small groupoid is a [generalized variety](/category-property/generalized_variety).
+:::
+
+_Proof._
+This follows directly from Lemma 1 and Corollary 2. <span class="qed">$\square$</span>
+
+::: Corollary 4
+Any essentially small groupoid is [finitely accessible](/category-property/finitely_accessible).
+:::
+
+_Proof._
+Since sifted colimits exist, filtered colimits also exist. Moreover, every object is strongly finitely presentable and therefore also finitely presentable. <span class="qed">$\square$</span>

--- a/databases/catdat/data/categories/0.yaml
+++ b/databases/catdat/data/categories/0.yaml
@@ -29,9 +29,6 @@ satisfied_properties:
   - property: preadditive
     reason: This is vacuously true.
 
-  - property: multi-algebraic
-    reason: The terminal category $\1$ becomes an FPC-sketch by selecting the unique empty cone and cocone. Then, a $\Set$-valued model of this sketch is a functor $\1 \to \Set$ sending the unique object to a terminal and initial object, which never exists. Hence, $\0$ is the category of models of this FPC-sketch.
-
 unsatisfied_properties:
   - property: inhabited
     reason: This is trivial.

--- a/databases/catdat/data/categories/2.yaml
+++ b/databases/catdat/data/categories/2.yaml
@@ -26,9 +26,6 @@ satisfied_properties:
   - property: inhabited
     reason: This is trivial.
 
-  - property: multi-algebraic
-    reason: There is an FPC-sketch whose $\Set$-model is precisely a pair $(X,Y)$ of sets such that the coproduct $X+Y$ is a singleton. Any $\Set$-model of such a sketch is isomorphic to either $(\varnothing, 1)$ or $(1, \varnothing)$, hence the category of models is equivalent to $\2$.
-
 unsatisfied_properties:
   - property: connected
     reason: The objects $0$, $1$ have no zig-zag path between them.

--- a/databases/catdat/data/category-implications/algebraic.yaml
+++ b/databases/catdat/data/category-implications/algebraic.yaml
@@ -40,6 +40,16 @@
   reason: See <a href="http://www.tac.mta.ca/tac/volumes/8/n3/8-03abs.html" target="_blank">[AR01, Remark 4.8(2)]</a>.
   is_equivalence: false
 
+- id: groupoids_are_generalized_varieties
+  assumptions:
+    - groupoid
+    - essentially small
+  conclusions:
+    - generalized variety
+    - finitely accessible
+  reason: This is proven <a href="/content/sifted-colimits-in-groupoids">here</a>.
+  is_equivalence: false
+
 - id: multi-algebraic_implies_locally_finitely_multi-presentable
   assumptions:
     - multi-algebraic


### PR DESCRIPTION
This PR adds the (easy) proof that every essentially small groupoid is a generalized variety, and also finitely accessible.

This result brings the number of unknown properties for **B** (finite sets and bijections) and the two entries of **BG** down to zero.

This result also makes it possible to remove the assignments that **0** and **2** are multi-algebraic, which are now redundant: they are multi-cocomplete, and are small groupoids, hence generalized varieties, and hence multi-algebraic.

- unknown (category, property)-pairs before this PR: 151
- unknown (category, property)-pairs after this PR: 145