### PR TITLE
Decide multi-completeness for remaining categories

### DIFF
--- a/databases/catdat/data/categories/Delta.yaml
+++ b/databases/catdat/data/categories/Delta.yaml
@@ -81,6 +81,17 @@ unsatisfied_properties:
   - property: pushouts
     reason: Assume that the two inclusions $\{0 < 1\} \leftarrow \{0\} \rightarrow \{0 < 2\}$ have a pushout in $\FinOrd \setminus \{\varnothing\}$. This would be a universal non-empty finite ordered set $X$ with three elements $0,1,2$ satisfying $0 \leq 1$ and $0 \leq 2$. Assume w.l.o.g. $1 \leq 2$ (the case $2 \leq 1$ is similar). The universal property yields an order-preserving map $X \to \{a < b < c\}$ with $0 \mapsto a$, $1 \mapsto c$, $2 \mapsto b$. But then $c \leq b$, which is a contradiction.
 
+  - property: multi-complete
+    reason: >-
+      We will prove that the multi-product of $I \coloneqq \{0 < 1\}$ with itself does not exist in $\FinOrd \setminus \{\varnothing\}$. Assume that it does, i.e. there is a family of spans
+      $$X_s = (I \xleftarrow{a_s} P_s \xrightarrow{b_s} I)$$
+      such that every span admits a unique morphism into exactly one of these. Now consider the following three spans:
+      $$\begin{align*} A & \coloneqq (I \xleftarrow{0} \{0\} \xrightarrow{0} I) \\
+      B & \coloneqq (I \xleftarrow{0} I \xrightarrow{\id} I) \\
+      C & \coloneqq (I \xleftarrow{\id} I \xrightarrow{0} I)
+      \end{align*}$$
+      There are morphisms of spans $0 : A \to B$ and $0 : A \to C$. This shows that  $B,C$ are in the same connected component. Thus, there is some index $s$ such that $B$ and $C$ admit a unique morphism to $X_s$. The morphism $B \to X_s$ maps $1 \in I$ to an element $u \in P_s$ with $a_s(u)=0$, $b_s(u)=1$. Likewise, the morphism $C \to X_s$ maps $1 \in I$ to an element $v \in P_s$ with $a_s(v)=1$, $b_s(v)=0$. But now neither $u \leq v$ nor $v \leq u$ can be true, contradicting that $P_s$ is linearly ordered.
+
 special_objects: {}
 
 special_morphisms:

--- a/databases/catdat/data/categories/FS.yaml
+++ b/databases/catdat/data/categories/FS.yaml
@@ -40,8 +40,11 @@ satisfied_properties:
   - property: epi-regular
     reason: 'If $f : X \to Y$ is a surjective map of finite sets, it is the coequalizer of the two projections $p_1, p_2 : X \times_Y X \rightrightarrows X$ in <a href="/category/FinSet">$\FinSet$</a>, but also in $\FS$. Notice that $p_1,p_2$ are surjective. Even though $X \times_Y X$ is not a pullback in $\FS$, we can use this finite set here.'
 
-  - property: multi-terminal object
-    reason: The empty set and a singleton give a multi-terminal object.
+  - property: multi-complete
+    reason: >-
+      Let $D : \I \to \FS$ be a small diagram. Let $L \subseteq \prod_{i \in \I} D(i)$ be the limit object of the corresponding diagram in $\Set$. Consider the set of all finite subsets $R \subseteq L$ with the property that $p_i(R) = D(i)$ for every $i \in \I$. For each of these, $(R \xrightarrow{p_i|_R} D(i))_{i \in \I}$ is a cone in $\FS$. We claim that the set of these cones is universal:
+      Let $(f_i : T \to D(i))_{i \in \I}$ be any cone in $\FS$. Let $R \subseteq L$ be the image of the induced map of sets $f : T \to \prod_{i \in \I} D(i)$ defined by $p_i f = f_i$. Then $R$ is finite, since $T$ is finite, and we have $p_i(R) = p_i(f(T)) = f_i(T) = D(i)$. Moreover, the map $f$ corestricts to a map $f' : T \to R$ with $p_i|_R  \, f' = f_i$. Therefore, $f'$ is a morphism of cones.
+      Conversely, let $h : T \to R$ be a morphism of cones, i.e. $p_i|_R \, h = f_i$, where $R$ is not known yet. Then $h$ equals the corestriction of the map into the product induced by the $f_i$, and $h$ is surjective as a morphism in $\FS$. This shows that both $R$ and the morphism of cones are unique.
 
 unsatisfied_properties:
   - property: small

--- a/databases/catdat/data/category-implications/completeness.yaml
+++ b/databases/catdat/data/category-implications/completeness.yaml
@@ -62,11 +62,11 @@
   reason: Let $(T_i)_{i\in I}$ be a multi-terminal object in a connected category $\C$. By definition of multi-terminal objects, for each object $C$, there are a unique index $i_C\in I$ and a unique morphism $C \to T_{i_C}$. Since the index $i_C$ is invariant under connected components, $I$ must be a singleton. The converse is trivial.
   is_equivalence: true
 
-- id: multi-complete_with_finite_coproducts
+- id: multi-complete_with_initial_object
   assumptions:
-    - finite coproducts
+    - initial object
     - multi-complete
   conclusions:
     - complete
-  reason: 'Let $D : \S \to \C$ be a small diagram in a category $\C$. Since $\C$ has finite coproducts, the category $\Cone(D)$ of cones over $D$ has finite coproducts. In particular, $\Cone(D)$ is connected, hence a multi-terminal object in it automatically becomes a terminal object.'
+  reason: 'Let $\C$ be a category with an initial object, and let $D : \I \to \C$ be a small diagram in $\C$. Since $\C$ has an initial object, the category $\Cone(D)$ of cones over $D$ also has an initial object. In particular, $\Cone(D)$ is connected, hence a multi-terminal object in it automatically becomes a terminal object. In other words, a multi-limit of $D$ is automatically a limit of $D$.'
   is_equivalence: false


### PR DESCRIPTION
This PR decides the property of being multi-complete for all the 6 remaining categories in the database.

For **FinGrp**, **FinOrd**, **Met**, and **PMet** a previous result on multi-completeness could be strengthened: 

`initial object + multi-complete ===> complete`

In particular, all of these categories are not multi-complete.

For **FS**, the category of finite sets and surjections (which is surprisingly multi-complete) and the simplex category **Delta** (which does not have multi-products) direct proofs have been added.

- unknown (category, property)-pairs before this PR: 145
- unknown (category, property)-pairs after this PR: 139
