### PR TITLE
Add new properties: ℵ₂-small products / coproducts / powers / copowers

### DIFF
--- a/databases/catdat/data/categories/Grp_c.yaml
+++ b/databases/catdat/data/categories/Grp_c.yaml
@@ -76,6 +76,9 @@ unsatisfied_properties:
   - property: countable powers
     reason: Since the forgetful functor $\Grp_\c \to \Set$ is representable, it preserves products. Therefore, if the power $\IZ^{\IN}$ exists in $\Grp_\c$, its underlying set must be the ordinary cartesian product, which however is uncountable.
 
+  - property: ℵ₂-small copowers
+    reason: 'Assume that the copower $G \coloneqq I \otimes \IZ$ exists in $\Grp_\c$. We will prove that $I$ is countable; in particular, $\aleph_1 \otimes \IZ$ does not exist. The copower is a countable group $G$ with a universal family of elements $(x_i)_{i \in I}$. For every $i \in I$ there is a homomorphism $G \to \IZ$ defined by $x_i \mapsto 1$ and $x_j \mapsto 0$ for $j \neq i$. In particular, $x_i \neq x_j$ whenever $i \neq j$. Thus, $x : I \to G$ is an injective map, which proves that $I$ is countable.'
+
   - property: regular quotient object classifier
     reason: We can copy the proof from <a href="/category/Grp">$\Grp$</a>.
 

--- a/databases/catdat/data/categories/Man.yaml
+++ b/databases/catdat/data/categories/Man.yaml
@@ -74,6 +74,9 @@ unsatisfied_properties:
   - property: ℵ₁-filtered colimits
     reason: 'We already know that <a href="/category/Set_c">$\Set_\c$</a> does not have $\aleph_1$-filtered colimits. The functor $\pi_0: \Man \to \Set_\c$ is well-defined (because manifolds are second-countable), and it admits a fully faithful right adjoint (regarding a countable set as a discrete manifold). Therefore, $\Man$ does not have $\aleph_1$-filtered colimits.'
 
+  - property: ℵ₂-small copowers
+    reason: A proof can be found at <a href="https://math.stackexchange.com/a/5083683/1650" target="_blank">MSE/5083641</a> (ignore the arguments regarding equal dimension).
+
   - property: quotients of congruences
     reason: If $\Man$ had quotients of congruences, then by <a href="/content/pushouts-of-monos-via-congruence-quotients">this lemma</a>, it would have a pushout of $\IR \leftarrow \{ 0 \} \rightarrow \IR$.  This contradicts <a href="https://mathoverflow.net/questions/19116">MO/19916</a>.
 

--- a/databases/catdat/data/categories/Met_c.yaml
+++ b/databases/catdat/data/categories/Met_c.yaml
@@ -57,7 +57,7 @@ unsatisfied_properties:
   - property: balanced
     reason: The inclusion $\IQ \hookrightarrow \IR$ provides a counterexample.
 
-  - property: powers
+  - property: ℵ₂-small powers
     reason: See <a href="https://math.stackexchange.com/questions/139168" target="_blank">MSE/139168</a> for a proof that uncountable powers do not exist.
 
   - property: Malcev

--- a/databases/catdat/data/categories/Set_c.yaml
+++ b/databases/catdat/data/categories/Set_c.yaml
@@ -69,6 +69,9 @@ unsatisfied_properties:
   - property: countable powers
     reason: Since the forgetful functor $\Set_\c \to \Set$ is representable, it preserves (countable) products. Therefore, if the power $\{0,1\}^{\IN}$ exists in $\Set_\c$, it must be the ordinary cartesian product, which however is uncountable.
 
+  - property: ℵ₂-small copowers
+    reason: 'Assume that the copower $X \coloneqq I \otimes 1$ exists in $\Set_\c$. We will prove that $I$ is countable; in particular, $\aleph_1 \otimes 1$ does not exist. The copower is a countable set $X$ with a universal family of elements $(x_i)_{i \in I}$. For every $i \in I$ there is a map $X \to \{0,1\}$ defined by $x_i \mapsto 1$ and $x_j \mapsto 0$ for $j \neq i$. In particular, $x_i \neq x_j$ whenever $i \neq j$. Thus, $x : I \to X$ is an injective map, which proves that $I$ is countable.'
+
   - property: ℵ₁-filtered colimits
     reason: 'Fix an uncountable set $X$, let $P_\c(X)$ be the poset of countable subsets of $X$, which is $\aleph_1$-filtered, and consider the functor $P_\c(X) \to \Set_\c$ taking a subset $Y \subseteq X$ to $Y$. The colimit of this diagram in $\Set$ is given by $X$ itself, so if $X_c$ were a colimit in $\Set_\c$, then $\Hom(X_c, \{0,1\}) \cong \Hom(X, \{0,1\})$. But the former has cardinality at most $2^{\aleph_0}$ and the latter has cardinality $2^{\card(X)}$, so we have obtained a contradiction if we pick $X$ large enough (e.g. $\card(X)=2^{\aleph_0}$).'
 

--- a/databases/catdat/data/category-implications/products.yaml
+++ b/databases/catdat/data/category-implications/products.yaml
@@ -1,11 +1,27 @@
 # results on products and powers
 
-- id: products_consequences
+- id: products_include_powers
   assumptions:
     - products
   conclusions:
-    - countable products
     - powers
+  reason: This is trivial.
+  is_equivalence: false
+
+- id: products_include_aleph2-small_products
+  assumptions:
+    - products
+  conclusions:
+    - ℵ₂-small products
+  reason: This is trivial.
+  is_equivalence: false
+
+- id: aleph2-small_products_consequences
+  assumptions:
+    - ℵ₂-small products
+  conclusions:
+    - ℵ₂-small powers
+    - countable products
   reason: This is trivial.
   is_equivalence: false
 
@@ -70,9 +86,17 @@
   reason: This is trivial.
   is_equivalence: false
 
-- id: powers_include_countable_powers
+- id: powers_include_aleph2-small_powers
   assumptions:
     - powers
+  conclusions:
+    - ℵ₂-small powers
+  reason: This is trivial.
+  is_equivalence: false
+
+- id: aleph2-small-powers_include_countable_powers
+  assumptions:
+    - ℵ₂-small powers
   conclusions:
     - countable powers
   reason: This is trivial.

--- a/databases/catdat/data/category-properties/aleph2-small copowers.yaml
+++ b/databases/catdat/data/category-properties/aleph2-small copowers.yaml
@@ -1,0 +1,14 @@
+id: ℵ₂-small copowers
+relation: has
+description: |-
+  A category has <i>$\aleph_2$-small copowers</i> if for every object $X$ and every set $I$ with cardinality $< \aleph_2$, the copower $I \otimes X$ exists. In particular, this includes copowers of the form $\aleph_1 \otimes X$. Here, $\aleph_1$ denotes the first uncountable cardinal, and $\aleph_2$ the next larger cardinal.
+  Notice that finite copowers are just $\aleph_0$-small copowers, and countable copowers are $\aleph_1$-small copowers.
+nlab_link: https://ncatlab.org/nlab/show/copower
+dual_property: ℵ₂-small powers
+invariant_under_equivalences: true
+
+related_properties:
+  - copowers
+  - countable copowers
+  - finite copowers
+  - ℵ₂-small coproducts

--- a/databases/catdat/data/category-properties/aleph2-small coproducts.yaml
+++ b/databases/catdat/data/category-properties/aleph2-small coproducts.yaml
@@ -1,0 +1,14 @@
+id: ℵ₂-small coproducts
+relation: has
+description: |-
+  A category has <i>$\aleph_2$-small coproducts</i> if it has coproducts of families of objects indexed by sets of cardinality $< \aleph_2$. In particular, this includes coproducts indexed by sets of cardinality $\aleph_1$. Here, $\aleph_1$ denotes the first uncountable cardinal, and $\aleph_2$ the next larger cardinal.
+  Notice that finite coproducts are just $\aleph_0$-small coproducts, and countable coproducts are $\aleph_1$-small coproducts.
+nlab_link: https://ncatlab.org/nlab/show/coproduct
+dual_property: ℵ₂-small products
+invariant_under_equivalences: true
+
+related_properties:
+  - cocomplete
+  - countable coproducts
+  - finite coproducts
+  - ℵ₂-small powers

--- a/databases/catdat/data/category-properties/aleph2-small powers.yaml
+++ b/databases/catdat/data/category-properties/aleph2-small powers.yaml
@@ -1,0 +1,14 @@
+id: ℵ₂-small powers
+relation: has
+description: |-
+  A category has <i>$\aleph_2$-small powers</i> if for every object $X$ and every set $I$ of cardinality $< \aleph_2$, the power $X^I$ exists. In particular, this includes powers of the form $X^{\aleph_1}$. Here, $\aleph_1$ denotes the first uncountable cardinal, and $\aleph_2$ the next larger cardinal.
+  Notice that finite powers are just $\aleph_0$-small powers, and countable powers are $\aleph_1$-small powers.
+nlab_link: https://ncatlab.org/nlab/show/powering
+dual_property: ℵ₂-small copowers
+invariant_under_equivalences: true
+
+related_properties:
+  - powers
+  - countable powers
+  - finite powers
+  - ℵ₂-small products

--- a/databases/catdat/data/category-properties/aleph2-small products.yaml
+++ b/databases/catdat/data/category-properties/aleph2-small products.yaml
@@ -1,0 +1,14 @@
+id: ℵ₂-small products
+relation: has
+description: |-
+  A category has <i>$\aleph_2$-small products</i> if it has products indexed by sets of cardinality $< \aleph_2$. In particular, this includes products indexed by sets of cardinality $\aleph_1$. Here, $\aleph_1$ denotes the first uncountable cardinal, and $\aleph_2$ the next larger cardinal.
+  Notice that finite products are just $\aleph_0$-small products, and countable products are $\aleph_1$-small products.
+nlab_link: https://ncatlab.org/nlab/show/cartesian+product
+dual_property: ℵ₂-small coproducts
+invariant_under_equivalences: true
+
+related_properties:
+  - complete
+  - countable products
+  - finite products
+  - ℵ₂-small powers

--- a/databases/catdat/data/category-properties/countable copowers.yaml
+++ b/databases/catdat/data/category-properties/countable copowers.yaml
@@ -9,3 +9,4 @@ related_properties:
   - copowers
   - countable coproducts
   - finite copowers
+  - ℵ₂-small copowers

--- a/databases/catdat/data/category-properties/countable coproducts.yaml
+++ b/databases/catdat/data/category-properties/countable coproducts.yaml
@@ -6,5 +6,6 @@ invariant_under_equivalences: true
 
 related_properties:
   - coproducts
-  - countable copowers
   - finite coproducts
+  - countable copowers
+  - ℵ₂-small coproducts

--- a/databases/catdat/data/category-properties/countable powers.yaml
+++ b/databases/catdat/data/category-properties/countable powers.yaml
@@ -9,3 +9,4 @@ related_properties:
   - countable products
   - finite powers
   - powers
+  - ℵ₂-small powers

--- a/databases/catdat/data/category-properties/countable products.yaml
+++ b/databases/catdat/data/category-properties/countable products.yaml
@@ -5,6 +5,7 @@ dual_property: countable coproducts
 invariant_under_equivalences: true
 
 related_properties:
-  - countable powers
-  - finite products
   - products
+  - finite products
+  - countable powers
+  - ℵ₂-small products

--- a/databases/catdat/scripts/expected-data/Ab.json
+++ b/databases/catdat/scripts/expected-data/Ab.json
@@ -110,6 +110,10 @@
 	"effective cocongruences": true,
 	"Barr-coexact": true,
 	"Barr-exact": true,
+	"ℵ₂-small products": true,
+	"ℵ₂-small coproducts": true,
+	"ℵ₂-small powers": true,
+	"ℵ₂-small copowers": true,
 
 	"cartesian closed": false,
 	"locally cartesian closed": false,

--- a/databases/catdat/scripts/expected-data/Set.json
+++ b/databases/catdat/scripts/expected-data/Set.json
@@ -105,6 +105,10 @@
 	"effective cocongruences": true,
 	"Barr-coexact": true,
 	"Barr-exact": true,
+	"ℵ₂-small products": true,
+	"ℵ₂-small coproducts": true,
+	"ℵ₂-small powers": true,
+	"ℵ₂-small copowers": true,
 
 	"Grothendieck abelian": false,
 	"Malcev": false,

--- a/databases/catdat/scripts/expected-data/Top.json
+++ b/databases/catdat/scripts/expected-data/Top.json
@@ -75,6 +75,10 @@
 	"filtered-colimit-stable monomorphisms": true,
 	"quotients of congruences": true,
 	"coquotients of cocongruences": true,
+	"ℵ₂-small products": true,
+	"ℵ₂-small coproducts": true,
+	"ℵ₂-small powers": true,
+	"ℵ₂-small copowers": true,
 
 	"abelian": false,
 	"additive": false,

--- a/src/lib/commons/property.url.ts
+++ b/src/lib/commons/property.url.ts
@@ -1,11 +1,15 @@
 const ENCODE_MAP: Record<string, string> = {
 	' ': '_',
+	'ℵ₀': 'aleph0',
 	'ℵ₁': 'aleph1',
+	'ℵ₂': 'aleph2',
 }
 
 const DECODE_MAP: Record<string, string> = {
 	_: ' ',
+	aleph0: 'ℵ₀',
 	aleph1: 'ℵ₁',
+	aleph2: 'ℵ₂',
 }
 
 export function encode_property_ID(id: string): string {


### PR DESCRIPTION
This PR adds four new properties, which are very analoguous to their $\aleph_1$-small and $\aleph_0$-small counterparts that are already in the database.

- $\aleph_2$-small products
- $\aleph_2$-small coproducts
- $\aleph_2$-small powers
- $\aleph_2$-small copowers

These properties are useful to decide other properties which are currently open – hence this addition. They also "refine" the size of **Set**<sub>c</sub>, **Grp**<sub>c</sub>, and **Man**.

All categories have been decided.

- unknown (category, property)-pairs before this PR: 136
- unknown (category, property)-pairs after this PR: 136



