### PR TITLE
Some coaccessibility proofs

### DIFF
--- a/databases/catdat/data/categories/Haus.yaml
+++ b/databases/catdat/data/categories/Haus.yaml
@@ -74,6 +74,9 @@ unsatisfied_properties:
       $$(-\infty, -1/n] \cup [1/n, \infty) \hookrightarrow \IR$$
       with itself. That is, $X_n$ is the union of two lines $\IR \times \{1\}$ and $\IR \times \{2\}$ where we identify $(x,1) \equiv (x,2)$ when $|x| \geq 1/n$. Then $X_n$ is Hausdorff, and there is a canonical surjective continuous map $X_n \to X_{n+1}$. The colimit in $\Top$ is the union of two lines where we identify $(x,1) \equiv (x,2)$ when $|x| \geq 1/n$ for some $n$, i.e. when $x \neq 0$. This is the line with the double origin, which is not Hausdorff. Its Hausdorff reflection is the line $\IR$ where all points of both lines are identified, and it provides the colimit in $\Haus$. Now, the injective continuous maps $\{1,2\} \to X_n$, $i \mapsto (0,i)$ (where $\{1,2\}$ is discrete) become the constant map $0 : \{1,2\} \to \IR$ in the colimit, which is not a monomorphism.
 
+  - property: accessible
+    reason: In fact, it does not have any small colimit-dense subcategory by <a href="https://math.stackexchange.com/questions/4097315/" target="_blank">MSE/4097315</a>.
+
 special_objects:
   initial object:
     description: empty space

--- a/databases/catdat/data/categories/Set.yaml
+++ b/databases/catdat/data/categories/Set.yaml
@@ -16,6 +16,7 @@ related_categories:
   - Set_c
   - Set_f
   - SetxSet
+  - Setne
 
 satisfied_properties:
   - property: locally small

--- a/databases/catdat/data/categories/Set_f.yaml
+++ b/databases/catdat/data/categories/Set_f.yaml
@@ -57,9 +57,6 @@ unsatisfied_properties:
   - property: skeletal
     reason: This is trivial.
 
-  - property: essentially small
-    reason: This is obvious.
-
   - property: locally finite
     reason: If $X$ is an infinite set, there are infinitely many maps $1 \to X$. They are injective and hence finite-to-one.
 
@@ -77,6 +74,9 @@ unsatisfied_properties:
 
   - property: sequential limits
     reason: Consider the set $[n] \coloneqq \{0,\dotsc,n\}$ for $n \in \IN$. The forgetful functor to $\Set$ is representable (by the singleton set), hence preserves all limits. Thus, if the diagram of truncation maps $\cdots \twoheadrightarrow [2] \twoheadrightarrow [1] \twoheadrightarrow [0]$ has a limit in $\Set_\f$, its underlying set is isomorphic to the limit taken in $\Set$, which is $\IN \cup \{\infty\}$. But there is no finite-to-one map $\IN \cup \{\infty\} \to [0]$.
+
+  - property: coaccessible
+    reason: 'Assume that $\Set_\f$ is $\lambda$-coaccessible for some regular cardinal. Then there is an infinite cardinal $\kappa$ such that every $X \in \Set_\f$ is a $\lambda$-cofiltered limit of sets of cardinality $\leq \kappa$. In particular, since every $\lambda$-cofiltered category is non-empty, there is some set $Y$ of cardinality $\leq \kappa$ that admits a morphism $f : X \to Y$ in $\Set_f$. Since $f$ has finite fibers, this implies $\card(X) \leq \card(Y) \cdot \aleph_0 \leq \kappa$. Since $X$ was an arbitrary set, this is a contradiction.'
 
 special_objects:
   initial object:

--- a/databases/catdat/data/categories/Setne.yaml
+++ b/databases/catdat/data/categories/Setne.yaml
@@ -74,6 +74,9 @@ unsatisfied_properties:
   - property: effective cocongruences
     reason: The two maps $\{0\} \rightrightarrows \{0,1\}$ form a cocongruence on $\{0\}$ &mdash; namely the cofull cocongruence on $\{0\}$ &mdash; but there is no map $Z \to \{0\}$ making the required commutative diagram, much less a cocartesian square.
 
+  - property: coaccessible
+    reason: If $\Setne$ is coaccessible, then by the dual of Cor. 2.44 in <a href="https://ncatlab.org/nlab/show/Locally+Presentable+and+Accessible+Categories" target="_blank">Adamek-Rosicky</a> also the coslice category $\{\ast\} / \Setne$ would be coaccessible. But this category is isomorphic to <a href="/category/Set*">$\Set_*$</a>, from which we know that it is not coaccessible (namely, because of Thm. 1.64 in loc. cit.).
+
 special_objects:
   terminal object:
     description: singleton set

--- a/databases/catdat/data/categories/Top.yaml
+++ b/databases/catdat/data/categories/Top.yaml
@@ -65,8 +65,8 @@ unsatisfied_properties:
   - property: regular
     reason: See Example 3.14 at the <a href="https://ncatlab.org/nlab/show/regular+category" target="_blank">nLab</a>.
 
-  - property: locally presentable
-    reason: In fact, it does not have any small dense subcategory by <a href="https://math.stackexchange.com/questions/4097315/" target="_blank">MSE/4097315</a>. For a related result, see <a href="https://mathoverflow.net/questions/288648" target="_blank">MO/288648</a>.
+  - property: accessible
+    reason: In fact, it does not have any small colimit-dense subcategory by <a href="https://math.stackexchange.com/questions/4097315/" target="_blank">MSE/4097315</a>. For a related result, see <a href="https://mathoverflow.net/questions/288648" target="_blank">MO/288648</a>.
 
   - property: Malcev
     reason: This is clear since <a href="/category/Set">$\Set$</a> is not Malcev and can be interpreted as the subcategory of discrete spaces.

--- a/databases/catdat/data/categories/Top_pointed.yaml
+++ b/databases/catdat/data/categories/Top_pointed.yaml
@@ -76,8 +76,8 @@ unsatisfied_properties:
   - property: regular
     reason: See Example 3.14 at the <a href="https://ncatlab.org/nlab/show/regular+category" target="_blank">nLab</a>. The proof also works for pointed spaces (resp. posets) by using the base points $a$ and $0$.
 
-  - property: locally presentable
-    reason: In fact, it does not have any small dense subcategory by <a href="https://math.stackexchange.com/questions/4097315/" target="_blank">MSE/4097315</a>. The proof easily adapts to pointed spaces.
+  - property: accessible
+    reason: In fact, it does not have any small colimit-dense subcategory by <a href="https://math.stackexchange.com/questions/4097315/" target="_blank">MSE/4097315</a>. The proof easily adapts to pointed spaces.
 
   - property: cartesian filtered colimits
     reason: 'The functor $\IQ \times - : \Top_* \to \Top_*$ does not preserve colimits, see <a href="https://math.stackexchange.com/questions/2969372" target="_blank">MSE/2969372</a>. The counterexample also works for pointed spaces.'


### PR DESCRIPTION
This PR adds some of the missing (co-)accessibility proofs. (There are still many other cases missing.)

- $Set_f$ is not coaccessible
- $Set_{\neq \emptyset}$ is not coaccessible
- $Haus$ is not accessible (this has decided 6 properties at once)
 
---

- unknown (category, property)-pairs before this PR: 133
- unknown (category, property)-pairs before this PR: 125