### PR TITLE
Add some functors

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -80,6 +80,7 @@
 		"colimits",
 		"comonad",
 		"comonadic",
+		"comonadicity",
 		"compactification",
 		"conormal",
 		"copower",
@@ -174,6 +175,7 @@
 		"Malcev",
 		"Marra",
 		"Mathoverflow",
+		"Mesablishvili",
 		"metrizable",
 		"Moerdijk",
 		"monadicity",
@@ -291,5 +293,8 @@
 		"todo.txt",
 		"*.svg"
 	],
-	"ignoreRegExpList": ["\\$[^$]*\\$", "\\$\\$[^$]*\\$\\$"]
+	"ignoreRegExpList": [
+		"\\$[^$]*\\$",
+		"\\$\\$[^$]*\\$\\$"
+	]
 }

--- a/databases/catdat/data/categories/Top.yaml
+++ b/databases/catdat/data/categories/Top.yaml
@@ -5,6 +5,7 @@ objects: topological spaces
 morphisms: continuous functions
 description: This is the most basic category of geometric objects.
 nlab_link: https://ncatlab.org/nlab/show/Top
+dual_category: Top_op
 
 tags:
   - topology

--- a/databases/catdat/data/categories/Top_op.yaml
+++ b/databases/catdat/data/categories/Top_op.yaml
@@ -1,0 +1,21 @@
+id: Top_op
+name: dual of the category of topological spaces
+notation: $\Top^{\op}$
+objects: topological spaces
+morphisms: a morphism $X \to Y$ is a continuous map $Y \to X$
+description: By definition, this category is the dual (or opposite) of the category <a href="/category/Top">$\Top$</a>.
+nlab_link: https://ncatlab.org/nlab/show/opposite+category
+dual_category: Top
+
+tags:
+  - topology
+
+related_categories: []
+
+satisfied_properties: []
+
+unsatisfied_properties: []
+
+special_objects: {}
+
+special_morphisms: {}

--- a/databases/catdat/data/config.yaml
+++ b/databases/catdat/data/config.yaml
@@ -14,7 +14,9 @@ category_tags:
   - thin
   - single object
 
-functor_tags: []
+functor_tags:
+  - forgetful
+  - free
 
 relations:
   - relation: is

--- a/databases/catdat/data/functor-implications/equivalences.yaml
+++ b/databases/catdat/data/functor-implications/equivalences.yaml
@@ -16,8 +16,6 @@
   source_assumptions: []
   target_assumptions: []
   conclusions:
-    - continuous
     - monadic
-    - right adjoint
   reason: This is easy.
   is_equivalence: false

--- a/databases/catdat/data/functor-implications/limits preservation.yaml
+++ b/databases/catdat/data/functor-implications/limits preservation.yaml
@@ -5,8 +5,8 @@
   target_assumptions: []
   conclusions:
     - cofinitary
-    - equalizer-preserving
     - product-preserving
+    - left exact
   reason: This is trivial.
   is_equivalence: false
 
@@ -84,8 +84,12 @@
   target_assumptions: []
   conclusions:
     - finite-product-preserving
-    - terminal-object-preserving
-  reason: Both finite products and terminal objects are special cases of finite limits.
+    - equalizer-preserving
+    - monomorphism-preserving
+  reason: >-
+    Finite products and equalizers are special cases of finite limits. Moreover, a morphism $f : X \to Y$ is a monomorphism if and only the square
+    $$\begin{CD} X @>{\id_X}>> X \\ @V{\id_X}VV @VV{f}V \\ X @>>{f}> Y \end{CD}$$
+    is a pullback square, and pullbacks are special cases of finite limits.
   is_equivalence: false
 
 - id: left_exact_criterion
@@ -108,14 +112,4 @@
   conclusions:
     - continuous
   reason: This is standard, see <a href="https://ncatlab.org/nlab/show/Categories+for+the+Working+Mathematician" target="_blank">Mac Lane</a>, Ch. V, Theorem 4.1.
-  is_equivalence: false
-
-- id: left_exact_preserves_mono
-  assumptions:
-    - left exact
-  source_assumptions: []
-  target_assumptions: []
-  conclusions:
-    - monomorphism-preserving
-  reason: 'This is because $f : X \to Y$ is a monomorphism if and only the square displaying $\id_Y \circ f = \id_Y \circ f$ is a pullback square.'
   is_equivalence: false

--- a/databases/catdat/data/functors/abelianization.yaml
+++ b/databases/catdat/data/functors/abelianization.yaml
@@ -8,6 +8,7 @@ nlab_link: https://ncatlab.org/nlab/show/abelianization
 
 tags:
   - algebra
+  - free
 
 related_functors: []
 

--- a/databases/catdat/data/functors/abelianization.yaml
+++ b/databases/catdat/data/functors/abelianization.yaml
@@ -12,21 +12,27 @@ tags:
 related_functors: []
 
 satisfied_properties:
-  - property: essentially surjective
-    reason: For abelian groups $G$ we have $G \cong G^{\ab}$.
-  - property: finite-product-preserving
-    reason: See <a href="https://mathoverflow.net/questions/386144">MO/386144</a>.
   - property: left adjoint
     reason: This functor is left adjoint to the forgetful functor.
 
+  - property: essentially surjective
+    reason: For abelian groups $G$ we have $G \cong G^{\ab}$.
+
+  - property: finite-product-preserving
+    reason: See <a href="https://mathoverflow.net/questions/386144">MO/386144</a>.
+
 unsatisfied_properties:
-  - property: conservative
-    reason: The proper inclusion $S_3 \hookrightarrow S_4$ gets mapped to the trivial homomorphism $1 \to 1$, which is an isomorphism.
   - property: faithful
     reason: Both the inclusion $A_3 \hookrightarrow S_3$ and the trivial homomorphism $A_3 \to S_3$ are mapped to the trivial homomorphism $A_3 \to 1$.
+
   - property: full
     reason: See <a href="https://math.stackexchange.com/questions/716686" target="_blank">MSE/716686</a>.
+
+  - property: conservative
+    reason: The proper inclusion $S_3 \hookrightarrow S_4$ gets mapped to the trivial homomorphism $1 \to 1$, which is an isomorphism.
+
   - property: monomorphism-preserving
     reason: The monomorphism $A_3 \hookrightarrow S_3$ is mapped to $A_3 \to 1$.
+
   - property: product-preserving
     reason: 'If $G$ is a group, the canonical homomorphism $(G^{\IN})^{\ab} \to (G^{\ab})^{\IN}$ is surjective, but does not need to be an isomorphism: otherwise, the inclusion $[G^{\IN}, G^{\IN}] \subseteq [G,G]^{\IN}$ would be an equality. But this requires the commutator width of $G$ to be finite, which fails for $G = F_2$ for instance. See also <a href="https://arxiv.org/abs/1608.02220">The abelianization of inverse limits of groups</a>, Remark 0.0.7.'

--- a/databases/catdat/data/functors/continuous-functions.yaml
+++ b/databases/catdat/data/functors/continuous-functions.yaml
@@ -1,0 +1,56 @@
+id: continuous_functions
+name: functor of continuous functions
+notation: $C$
+source: Top_op
+target: CAlg(R) # TODO: specify R := IR
+description: 'This functor maps a topological space $X$ to the commutative $\IR$-algebra $C(X)$ of continuous functions $X \to \IR$. A continuous map $f : X \to Y$ is mapped to the algebra homomorphism $f^* : C(Y) \to C(X)$, $u \mapsto u \circ f$.'
+nlab_link: null
+
+tags:
+  - topology
+
+related_functors: []
+
+satisfied_properties:
+  - property: continuous
+    reason: 'Since the forgetful functor $U : \CAlg(\IR) \to \Set$ is conservative and continuous, it suffices to prove that $U \circ C : \Top^{\op} \to \Set$ is continuous. But this functor is representable.'
+
+  - property: initial-object-preserving
+    reason: The initial object in $\Top^{\op}$ is the singleton space, which is mapped to $\IR$, the initial commutative $\IR$-algebra.
+
+unsatisfied_properties:
+  - property: essentially surjective
+    reason: The algebra $C(X)$ is <a href="https://en.wikipedia.org/wiki/Reduced_ring" target="_blank">reduced</a>, whereas there exist non-reduced algebras such as $\IR[T]/\langle T^2 \rangle$.
+
+  - property: representable
+    # TODO: automate this
+    reason: Its target is not $\Set$.
+
+  - property: finite-coproduct-preserving
+    reason: 'The canonical homomorphism $C(X) \otimes_{\IR} C(Y) \to C(X \times Y)$ need not be surjective. For example, for $X = Y = \IR$ one can show that $(x,y) \mapsto \exp(xy)$ is not contained in its image.'
+
+  - property: conservative
+    reason: 'If $X$ is a non-empty indiscrete space, every continuous map on $X$ is constant. This implies that the unique map $X \to 1$ induces an isomorphism $\IR \cong C(1) \to C(X)$.'
+
+  - property: full
+    reason: >-
+      Every continuous function $\omega_1 \to \IR$ is eventually constant, where $\omega_1$ denotes the first uncountable ordinal equipped with the order topology. We obtain a homomorphism
+      $$\varphi : C(\omega_1) \to \IR \cong C(1)$$
+      mapping each continuous function $\omega_1 \to \IR$ to its eventual value. Assume that it is induced by a continuous map $1 \to \omega_1$. This corresponds to an ordinal $\alpha < \omega_1$ such that $\varphi(u) = u(\alpha)$ for all $u \in C(\omega_1)$. But the continuous function
+      $$u(\beta) \coloneqq \begin{cases} 0 & \beta \leq \alpha \\ 1 & \beta > \alpha \end{cases}$$
+      satisfies $\varphi(u) = u(\alpha + 1) \neq u(\alpha)$.
+
+  - property: faithful
+    reason: 'If $X,Y$ are non-empty indiscrete spaces, there is only one homomorphism of $\IR$-algebras $C(Y) \to C(X)$ (since both are isomorphic to $\IR$), but there can be many maps $X \to Y$.'
+
+  - property: coequalizer-preserving
+    reason: 'A functor that preserves coequalizers also preserves regular epimorphisms. In this situation, this would mean that for every embedding $i : Y \hookrightarrow X$, the induced map $i^* : C(X) \to C(Y)$ is surjective. For a counterexample, consider the embedding $i : \IR \setminus \{0\} \hookrightarrow \IR$ and the continuous map $x \mapsto x^{-1}$.'
+
+  - property: epimorphism-preserving
+    reason: 'If $i : X \to Y$ is an injective continuous map, the induced homomorphism $C(Y) \to C(X)$ need not be surjective (consider the inclusion $i : \IR \setminus \{0\} \hookrightarrow \IR$ and the map $x \mapsto x^{-1}$). However, we need an example where it is not even an epimorphism in $\CAlg(\IR)$. A simple counterexample can again be constructed using (in)discrete spaces. Namely, if $X$ is any finite set with at least two elements, we have a continuous bijection $D(X) \to I(X)$, $x \mapsto x$, where $D(X)$ (resp. $I(X)$) denotes the discrete (resp. indiscrete) space on $X$. It induces the algebra homomorphism $\IR \cong C(I(X)) \to C(D(X)) \cong \IR^X$, which is not an epimorphism since $\IR^X \otimes_\IR \IR^X \not\cong \IR^X$.'
+
+  - property: finitary
+    reason: >-
+      For $n \geq 0$ consider the discrete space $X_n \coloneqq \{0,\dotsc,n\}$. Using the evident truncation maps $X_{n+1} \twoheadrightarrow X_n$, their limit is isomorphic to $\IN \cup \{\infty\}$, the one-point compactification of the discrete space $\IN$. The canonical homomorphism
+      $$\textstyle \colim_n C(X_n) \to C(\lim_n X_n)$$
+      can then be identified with the inclusion of the algebra of eventually constant sequences in $\IR$ into the algebra of convergent sequences in $\IR$. Thus, it is not surjective.

--- a/databases/catdat/data/functors/forget_group.yaml
+++ b/databases/catdat/data/functors/forget_group.yaml
@@ -1,0 +1,41 @@
+id: forget_group
+name: forgetful functor for groups
+notation: $U_{\Grp}$
+source: Grp
+target: Set
+description: This functor maps a group $G$ to its underlying set $U_{\Grp}(G)$.
+nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
+
+tags:
+  - algebra
+  - forgetful
+
+related_functors:
+  - forget_vector
+  - forget_ring
+
+satisfied_properties:
+  - property: representable
+    reason: This functor is represented by the additive group $\IZ$.
+
+  - property: monadic
+    reason: For every algebraic category the forgetful functor to the category of sets is monadic.
+
+  - property: conservative
+    reason: It is standard that the inverse of a bijective homomorphism is also a homomorphism.
+
+  - property: finitary
+    reason: For every algebraic category the forgetful functor to the category of sets preserves filtered colimits.
+
+  - property: epimorphism-preserving
+    reason: This follows from the classifications of epimorphisms in <a href="/category/Grp">$\Grp$</a> and in <a href="/category/Set">$\Set$</a>.
+
+unsatisfied_properties:
+  - property: essentially surjective
+    reason: The empty set has has no group structure.
+
+  - property: initial-object-preserving
+    reason: The underlying set of a trivial group is not empty.
+
+  - property: coequalizer-preserving
+    reason: 'The coequalizer of $1,2 : \IZ \rightrightarrows \IZ$ is the trivial group in $\Grp$, but the coequalizer of these maps in $\Set$ is infinite.'

--- a/databases/catdat/data/functors/forget_ring.yaml
+++ b/databases/catdat/data/functors/forget_ring.yaml
@@ -1,0 +1,41 @@
+id: forget_ring
+name: forgetful functor for rings
+notation: $U_{\Ring}$
+source: Ring
+target: Set
+description: This functor maps a ring $R$ to its underlying set $U_{\Ring}(R)$.
+nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
+
+tags:
+  - algebra
+  - forgetful
+
+related_functors:
+  - forget_group
+  - forget_vector
+
+satisfied_properties:
+  - property: representable
+    reason: This functor is represented by the polynomial ring $\IZ[T]$.
+
+  - property: monadic
+    reason: For every algebraic category the forgetful functor to the category of sets is monadic.
+
+  - property: conservative
+    reason: It is standard that the inverse of a bijective homomorphism is also a homomorphism.
+
+  - property: finitary
+    reason: For every algebraic category the forgetful functor to the category of sets preserves filtered colimits.
+
+unsatisfied_properties:
+  - property: essentially surjective
+    reason: The empty set has has no ring structure.
+
+  - property: epimorphism-preserving
+    reason: This follows from the classifications of epimorphisms in <a href="/category/Ring">$\Ring$</a> and in <a href="/category/Set">$\Set$</a>. Namely, the unique homomorphism $\IZ \to \IQ$ is an epimorphism in $\Ring$, but its underlying map of sets is not surjective, and hence no epimorphism in $\Set$.
+
+  - property: initial-object-preserving
+    reason: The initial object of $\Ring$ is $\IZ$, whose underlying set is not empty.
+
+  - property: coequalizer-preserving
+    reason: Consider the two ring homomorphisms $\IZ[X] \rightrightarrows \IZ[X,Y]$ defined by $X \mapsto X$ resp. $X \mapsto 0$. Their coequalizer in $\Ring$ (and also $\CRing$) is $\IZ[Y]$. Every multiple of $X$ becomes zero. However, the $\Set$-coequalizer does not identify $XY$ with $0$. In fact, polynomials in $U(\IZ[X,Y]) \setminus U(\IZ[X])$ are only equivalent to themselves.

--- a/databases/catdat/data/functors/forget_topology.yaml
+++ b/databases/catdat/data/functors/forget_topology.yaml
@@ -1,0 +1,33 @@
+id: forget_topology
+name: forgetful functor for topological spaces
+notation: $U_{\Top}$
+source: Top
+target: Set
+description: This functor maps a topological space $X$ to its underlying set $U_{\Top}(X)$.
+nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
+
+tags:
+  - topology
+  - forgetful
+
+related_functors: []
+
+satisfied_properties:
+  - property: faithful
+    reason: This is trivial.
+
+  - property: representable
+    reason: This functor is represented by the singleton space.
+
+  - property: essentially surjective
+    reason: Every set can be equipped with the discrete topology.
+
+  - property: right adjoint
+    reason: 'The discrete topology defines a functor $D : \Set \to \Top$ which is left adjoint to $U_{\Top}$.'
+
+  - property: left adjoint
+    reason: 'The indiscrete topology defines a functor $I : \Set \to \Top$ which is right adjoint to $U_{\Top}$.'
+
+unsatisfied_properties:
+  - property: conservative
+    reason: If $X$ is a set, the map $D(X) \to I(X)$, $x \mapsto x$ is bijective and continuous (where $D(-)$ denotes the discrete topological space and $I()$ the indiscrete topological space), but not an isomorphism (unless $X$ has at most one element).

--- a/databases/catdat/data/functors/forget_vector.yaml
+++ b/databases/catdat/data/functors/forget_vector.yaml
@@ -10,7 +10,9 @@ tags:
   - algebra
   - forgetful
 
-related_functors: []
+related_functors:
+  - forget_group
+  - forget_ring
 
 satisfied_properties:
   - property: representable
@@ -30,7 +32,7 @@ satisfied_properties:
 
 unsatisfied_properties:
   - property: essentially surjective
-    reason: The empty has has no vector space structure.
+    reason: The empty set has has no vector space structure.
 
   - property: initial-object-preserving
     reason: The underlying set of a trivial vector space is not empty.

--- a/databases/catdat/data/functors/forget_vector.yaml
+++ b/databases/catdat/data/functors/forget_vector.yaml
@@ -12,21 +12,27 @@ tags:
 related_functors: []
 
 satisfied_properties:
-  - property: conservative
-    reason: It is standard that the inverse of a bijective linear map is also linear.
-  - property: epimorphism-preserving
-    reason: This follows from the classifications of epimorphisms in <a href="/category/Vect">$\Vect$</a> and in <a href="/category/Set">$\Set$</a>.
-  - property: finitary
-    reason: For every algebraic category the forgetful functor to the category of sets preserves filtered colimits.
-  - property: monadic
-    reason: For every algebraic category the forgetful functor to the category of sets is monadic.
   - property: representable
     reason: This functor is represented by any $1$-dimensional vector space.
 
+  - property: monadic
+    reason: For every algebraic category the forgetful functor to the category of sets is monadic.
+
+  - property: conservative
+    reason: It is standard that the inverse of a bijective linear map is also linear.
+
+  - property: finitary
+    reason: For every algebraic category the forgetful functor to the category of sets preserves filtered colimits.
+
+  - property: epimorphism-preserving
+    reason: This follows from the classifications of epimorphisms in <a href="/category/Vect">$\Vect$</a> and in <a href="/category/Set">$\Set$</a>.
+
 unsatisfied_properties:
-  - property: coequalizer-preserving
-    reason: 'The coequalizer of $0,i_1 : K \to K^2$ in $\Vect$ is $p_2 : K^2 \to K$, but the coequalizer in $\Set$ is $(K \times K^*) \cup \{(0,0)\}$.'
   - property: essentially surjective
     reason: The empty has has no vector space structure.
+
   - property: initial-object-preserving
     reason: The underlying set of a trivial vector space is not empty.
+
+  - property: coequalizer-preserving
+    reason: 'The coequalizer of $0,i_1 : K \to K^2$ in $\Vect$ is $p_2 : K^2 \to K$, but the coequalizer in $\Set$ is $(K \times K^*) \cup \{(0,0)\}$.'

--- a/databases/catdat/data/functors/forget_vector.yaml
+++ b/databases/catdat/data/functors/forget_vector.yaml
@@ -8,6 +8,7 @@ nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 
 tags:
   - algebra
+  - forgetful
 
 related_functors: []
 

--- a/databases/catdat/data/functors/free_group.yaml
+++ b/databases/catdat/data/functors/free_group.yaml
@@ -8,6 +8,7 @@ nlab_link: https://ncatlab.org/nlab/show/free+functor
 
 tags:
   - algebra
+  - free
 
 related_functors: []
 

--- a/databases/catdat/data/functors/free_group.yaml
+++ b/databases/catdat/data/functors/free_group.yaml
@@ -3,7 +3,7 @@ name: free group functor
 notation: $F_{\Grp}$
 source: Set
 target: Grp
-description: This functor maps a set $X$ to the free group $F_{\Grp}(X)$ on that set. We abbreviate $F \coloneqq F_{\Grp}$.
+description: This functor maps a set $X$ to the free group $F_{\Grp}(X)$ on that set. In the proofs, we abbreviate $F \coloneqq F_{\Grp}$.
 nlab_link: https://ncatlab.org/nlab/show/free+functor
 
 tags:
@@ -13,14 +13,8 @@ tags:
 related_functors: []
 
 satisfied_properties:
-  - property: left adjoint
-    reason: This functor is left adjoint to the forgetful functor.
-
-  - property: faithful
-    reason: A left adjoint is faithful if and only if its unit consists of monomorphisms. So we only need to check that every set <i>embeds</i> into (the underlying set of) its free group. But this is clear since $X$ already embeds into the free abelian group $\IZ^{\oplus X}$, which is a quotient of the free group.
-
-  - property: conservative
-    reason: 'Let $f : X \to Y$ be a map of sets such that $F(f) : F(X) \to F(Y)$ is an isomorphism of groups. We know that $F$ is faithful, so that it reflects monomorphisms. Thus, $f$ is injective. Choose a complement $U \subseteq Y$ of $f(X) \subseteq Y$. Then $F(X) \to F(Y) = F(X) \sqcup F(U)$ is an isomorphism. This implies $F(U)=1$ and hence $U = \varnothing$.'
+  - property: comonadic
+    reason: This follows from Proposition 6.13 in Mesablishvili, <a href="http://www.tac.mta.ca/tac/volumes/16/1/16-01abs.html" target="_blank">Monads of effective descent type and comonadicity</a>.
 
   - property: monomorphism-preserving
     reason: 'This can be deduced from the description of the elements of a free group, but here is an abstract argument: Split monomorphisms are preserved by any functor. The only injective maps in $\Set$ that are not split are $\varnothing \hookrightarrow X$ (for non-empty $X$), and $F(\varnothing) \to F(X)$ is injective since $F(\varnothing)$ is the trivial group.'
@@ -37,3 +31,10 @@ unsatisfied_properties:
 
   - property: equalizer-preserving
     reason: 'Let $f,g : \{a,b\} \rightrightarrows \{c,d\}$ be the two constant maps, $f \equiv c$, $g \equiv d$. Their equalizer is empty, and the free group on that equalizer is trivial. Now consider the induced group homomorphisms $F(f), F(g) : F(\{a,b\}) \rightrightarrows F(\{c,d\})$ and observe that $a \cdot b^{-1}$ lies in the kernel of both homomorphisms, hence in their equalizer.'
+
+  - property: cofinitary
+    reason: >-
+      Consider the sets $X_n \coloneqq \{y,x_1,\dotsc,x_n\}$ for $n \geq 0$ with the canonical truncation maps $X_{n+1} \to X_n$, $x_i \mapsto x_i$, $x_{n+1} \mapsto y$, $y \mapsto y$. The limit $\lim_n X_n$ of this sequence is the set $L \coloneqq \{y,x_1,x_2,\dotsc\}$ with the canonical truncation maps $L \to X_n$.
+      The canonical map $F(L) \to \lim_n F(X_n)$ is not surjective: For $n \geq 0$ define $w_n \in F(X_n)$ by
+      $$w_n \coloneqq x_1 y^{-1} \cdots x_n y^{-1}.$$
+      Since $X_{n+1} \to X_n$ maps $w_{n+1} \mapsto w_n$, these elements yield a unique element $w \in \lim_n F(X_n)$. Notice that the word length of $w_n$ is unbounded in $n$. However, every element in $F(L)$ is contained already in $F(\{y,x_1,\dotsc,x_m\})$ for some $m$ and hence maps to an element with bounded word length. Hence, $w$ is not contained in the image.

--- a/databases/catdat/data/functors/free_group.yaml
+++ b/databases/catdat/data/functors/free_group.yaml
@@ -12,21 +12,27 @@ tags:
 related_functors: []
 
 satisfied_properties:
-  - property: conservative
-    reason: 'Let $f : X \to Y$ be a map of sets such that $F(f) : F(X) \to F(Y)$ is an isomorphism of groups. We know that $F$ is faithful, so that it reflects monomorphisms. Thus, $f$ is injective. Choose a complement $U \subseteq Y$ of $f(X) \subseteq Y$. Then $F(X) \to F(Y) = F(X) \sqcup F(U)$ is an isomorphism. This implies $F(U)=1$ and hence $U = \varnothing$.'
-  - property: faithful
-    reason: A left adjoint is faithful if and only if its unit consists of monomorphisms. So we only need to check that every set <i>embeds</i> into (the underlying set of) its free group. But this is clear since $X$ already embeds into the free abelian group $\IZ^{\oplus X}$, which is a quotient of the free group.
   - property: left adjoint
     reason: This functor is left adjoint to the forgetful functor.
+
+  - property: faithful
+    reason: A left adjoint is faithful if and only if its unit consists of monomorphisms. So we only need to check that every set <i>embeds</i> into (the underlying set of) its free group. But this is clear since $X$ already embeds into the free abelian group $\IZ^{\oplus X}$, which is a quotient of the free group.
+
+  - property: conservative
+    reason: 'Let $f : X \to Y$ be a map of sets such that $F(f) : F(X) \to F(Y)$ is an isomorphism of groups. We know that $F$ is faithful, so that it reflects monomorphisms. Thus, $f$ is injective. Choose a complement $U \subseteq Y$ of $f(X) \subseteq Y$. Then $F(X) \to F(Y) = F(X) \sqcup F(U)$ is an isomorphism. This implies $F(U)=1$ and hence $U = \varnothing$.'
+
   - property: monomorphism-preserving
     reason: 'This can be deduced from the description of the elements of a free group, but here is an abstract argument: Split monomorphisms are preserved by any functor. The only injective maps in $\Set$ that are not split are $\varnothing \hookrightarrow X$ (for non-empty $X$), and $F(\varnothing) \to F(X)$ is injective since $F(\varnothing)$ is the trivial group.'
 
 unsatisfied_properties:
-  - property: equalizer-preserving
-    reason: 'Let $f,g : \{a,b\} \rightrightarrows \{c,d\}$ be the two constant maps, $f \equiv c$, $g \equiv d$. Their equalizer is empty, and the free group on that equalizer is trivial. Now consider the induced group homomorphisms $F(f), F(g) : F(\{a,b\}) \rightrightarrows F(\{c,d\})$ and observe that $a \cdot b^{-1}$ lies in the kernel of both homomorphisms, hence in their equalizer.'
   - property: essentially surjective
     reason: Not every group is free (consider $\IZ/2$).
+
   - property: full
     reason: The map $1 = \Hom(1,1) \to \Hom(F(1),F(1)) = \Hom(\IZ,\IZ) = \IZ$ is not surjective.
+
   - property: terminal-object-preserving
     reason: The free group of rank $1$ is not the trivial group.
+
+  - property: equalizer-preserving
+    reason: 'Let $f,g : \{a,b\} \rightrightarrows \{c,d\}$ be the two constant maps, $f \equiv c$, $g \equiv d$. Their equalizer is empty, and the free group on that equalizer is trivial. Now consider the induced group homomorphisms $F(f), F(g) : F(\{a,b\}) \rightrightarrows F(\{c,d\})$ and observe that $a \cdot b^{-1}$ lies in the kernel of both homomorphisms, hence in their equalizer.'

--- a/databases/catdat/data/functors/id_Set.yaml
+++ b/databases/catdat/data/functors/id_Set.yaml
@@ -14,6 +14,7 @@ related_functors: []
 satisfied_properties:
   - property: equivalence
     reason: This is trivial.
+
   - property: representable
     reason: This functor is represented by any singleton set.
 

--- a/databases/catdat/data/functors/power_set_contravariant.yaml
+++ b/databases/catdat/data/functors/power_set_contravariant.yaml
@@ -13,21 +13,27 @@ related_functors:
   - power_set_covariant
 
 satisfied_properties:
-  - property: epimorphism-preserving
-    reason: 'If $f : X \to Y$ is injective, then $f^* : P(Y) \to P(X)$ is surjective, since for all $A \subseteq X$ we have $A = f^*(f_*(A))$.'
-  - property: monadic
-    reason: See <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Theorem 2.2.7.
   - property: representable
     reason: This is because there are natural bijections $P(X) \cong \Hom(X,2)$, sending a subset to its characteristic function.
 
+  - property: epimorphism-preserving
+    reason: 'If $f : X \to Y$ is injective, then $f^* : P(Y) \to P(X)$ is surjective, since for all $A \subseteq X$ we have $A = f^*(f_*(A))$.'
+
+  - property: monadic
+    reason: See <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Theorem 2.2.7.
+
 unsatisfied_properties:
-  - property: coequalizer-preserving
-    reason: 'The power set functor preserves reflexive coequalizers, but not all coequalizers, i.e. there are maps $f,g : Y \to X$ with equalizer $E \subseteq Y$ such that $P(Y) \twoheadrightarrow P(E)$ is not the coequalizer of $f^*,g^* : P(X) \to P(Y)$: Let $X=\{0,1\}$ and $Y=\{a,b,c\}$. Define maps $f,g:Y\to X$ by $f(a)=0$, $f(b)=0$, $f(c)=1$ and $g(a)=0$, $g(b)=1$, $g(c)=0$. Their equalizer is $E = \{a\}$, so that $P(E)$ has $2$ elements. For $S=\{0\}$ one has $f^*(S)=\{a,b\}$, $g^*(S)=\{a,c\}$, and for $S=\{1\}$ one has $f^*(S)=\{c\}$, $g^*(S)=\{b\}$. Thus the coequalizer of $f^*,g^*$ is obtained from $P(Y)$ by imposing the two relations $\{a,b\} \sim \{a,c\}$ and $\{c\} \sim \{b\}$. But then it as $8-2 = 6$ elements.'
-  - property: essentially surjective
-    reason: The initial object does not lie in the essential image since $P(X) \neq 0$ for all $X$.
-  - property: finitary
-    reason: Consider the sequence of projections $\cdots \twoheadrightarrow \{0,1\}^2 \twoheadrightarrow \{0,1\}^1$. Its limit in $\Set$ (i.e. colimit in $\Set^{\op}$) is $\{0,1\}^{\IN}$, which is uncountable, so that $P(\{0,1\}^{\IN})$ is also uncountable. But the colimit of the induced diagram $P(\{0,1\}^1) \hookrightarrow P(\{0,1\}^2) \hookrightarrow \cdots$ is countable since each $P(\{0,1\}^n)$ is finite.
   - property: full
     reason: 'The maps $f^* : P(Y) \to P(X)$ preserve the empty set, so take the constant map $P(X) \to P(X)$, $T \mapsto X$ for instance (where $X$ is non-empty).'
+
   - property: initial-object-preserving
     reason: In fact, the initial object does not even lie in the essential image since $P(X) \neq 0$ for all $X$.
+
+  - property: essentially surjective
+    reason: The initial object does not lie in the essential image since $P(X) \neq 0$ for all $X$.
+
+  - property: coequalizer-preserving
+    reason: 'The power set functor preserves reflexive coequalizers, but not all coequalizers, i.e. there are maps $f,g : Y \to X$ with equalizer $E \subseteq Y$ such that $P(Y) \twoheadrightarrow P(E)$ is not the coequalizer of $f^*,g^* : P(X) \to P(Y)$: Let $X=\{0,1\}$ and $Y=\{a,b,c\}$. Define maps $f,g:Y\to X$ by $f(a)=0$, $f(b)=0$, $f(c)=1$ and $g(a)=0$, $g(b)=1$, $g(c)=0$. Their equalizer is $E = \{a\}$, so that $P(E)$ has $2$ elements. For $S=\{0\}$ one has $f^*(S)=\{a,b\}$, $g^*(S)=\{a,c\}$, and for $S=\{1\}$ one has $f^*(S)=\{c\}$, $g^*(S)=\{b\}$. Thus the coequalizer of $f^*,g^*$ is obtained from $P(Y)$ by imposing the two relations $\{a,b\} \sim \{a,c\}$ and $\{c\} \sim \{b\}$. But then it as $8-2 = 6$ elements.'
+
+  - property: finitary
+    reason: Consider the sequence of projections $\cdots \twoheadrightarrow \{0,1\}^2 \twoheadrightarrow \{0,1\}^1$. Its limit in $\Set$ (i.e. colimit in $\Set^{\op}$) is $\{0,1\}^{\IN}$, which is uncountable, so that $P(\{0,1\}^{\IN})$ is also uncountable. But the colimit of the induced diagram $P(\{0,1\}^1) \hookrightarrow P(\{0,1\}^2) \hookrightarrow \cdots$ is countable since each $P(\{0,1\}^n)$ is finite.

--- a/databases/catdat/data/functors/power_set_covariant.yaml
+++ b/databases/catdat/data/functors/power_set_covariant.yaml
@@ -46,3 +46,6 @@ unsatisfied_properties:
 
   - property: finitary
     reason: The filtered colimit $\IN = \bigcup_{n \geq 0} \IN_{\leq n}$ is not preserved by $P$, since $\bigcup_{n \geq 0} P(\IN_{\leq n})$ just consists of the <i>finite</i> subsets of $\IN$.
+
+  - property: cofinitary
+    reason: 'The canonical map $P(\lim_i X_i) \to \lim_i P(X_i)$ is typically not injective already for cardinality reasons: Consider for example the sequential diagram $X_n \coloneqq \{0,1\}^n$ with the truncation maps $X_{n+1} \to X_n$. The limit is $\{0,1\}^{\IN}$ with cardinality $c \coloneqq 2^{\aleph_0}$, so that its power set has cardinality $2^c$. However, the limit of the power sets $P(X_n)$ is a subset of a countable product of finite sets, hence has cardinality $\leq c$, which is strictly smaller than $2^c$.'

--- a/databases/catdat/data/functors/power_set_covariant.yaml
+++ b/databases/catdat/data/functors/power_set_covariant.yaml
@@ -13,27 +13,36 @@ related_functors:
   - power_set_contravariant
 
 satisfied_properties:
-  - property: conservative
-    reason: 'Assume that $f : X \to Y$ is a map such that $f_* : P(X) \to P(Y)$ is an isomorphism. There is some $A \subseteq X$ with $Y = f_*(A)$, this proves that $f$ is surjective. It is also injective: If $x,y \in X$ satisfy $f(x) = f(y)$, then $f_*(\{x\}) = f_*(\{y\})$, and hence $\{x\} = \{y\}$, i.e. $x = y$.'
-  - property: epimorphism-preserving
-    reason: 'If $f : X \to Y$ is surjective, then $f_* \circ f^* = \id_{P(Y)}$, so that $f^*$ is surjective.'
   - property: faithful
     reason: 'Let $f,g : X \rightrightarrows Y$ be two maps with $f_* = g_* : P(X) \rightrightarrows P(Y)$. Then $\{f(x)\} = f_*(\{x\}) = g_*(\{x\}) = \{g(x)\}$ and hence $f(x) = g(x)$ for all $x \in X$.'
+
+  - property: epimorphism-preserving
+    reason: 'If $f : X \to Y$ is surjective, then $f_* \circ f^* = \id_{P(Y)}$, so that $f^*$ is surjective.'
+
   - property: monomorphism-preserving
     reason: 'If $f : X \to Y$ is injective, then $f^* \circ f_* = \id_{P(X)}$, so that $f_*$ is injective.'
 
+  - property: conservative
+    reason: 'Assume that $f : X \to Y$ is a map such that $f_* : P(X) \to P(Y)$ is an isomorphism. There is some $A \subseteq X$ with $Y = f_*(A)$, this proves that $f$ is surjective. It is also injective: If $x,y \in X$ satisfy $f(x) = f(y)$, then $f_*(\{x\}) = f_*(\{y\})$, and hence $\{x\} = \{y\}$, i.e. $x = y$.'
+
 unsatisfied_properties:
-  - property: coequalizer-preserving
-    reason: 'Let $X \coloneqq \{x,y\}$. Consider the two maps $x,y : \{0\} \rightrightarrows X$. Their coequalizer $Q = X / (x = y)$ has just one element, so that $P(Q)$ has two elements. The induced maps $x_*,y_* : P(\{0\}) \rightrightarrows P(X)$ (which already agree on the empty set) have coequalizer $P(X) / (\{x\} = \{y\})$, which has $3$ elements. So it cannot be $P(Q)$.'
-  - property: equalizer-preserving
-    reason: 'Any pair of distinct surjective maps $f,g : X \rightrightarrows Y$ provides a counterexample: Their equalizer $E$ is a proper subset of $X$, so that $P(E)$ cannot contain $X$. But $f_*(X) = Y = g_*(X)$ shows that $X$ is contained in the equalizer of $f_*,g_* : P(X) \rightrightarrows P(Y)$.'
   - property: essentially surjective
     reason: Every power set is non-empty.
-  - property: finitary
-    reason: The filtered colimit $\IN = \bigcup_{n \geq 0} \IN_{\leq n}$ is not preserved by $P$, since $\bigcup_{n \geq 0} P(\IN_{\leq n})$ just consists of the <i>finite</i> subsets of $\IN$.
-  - property: full
-    reason: Take any map $P(X) \to P(X)$ that does not preserve the empty set, say the constant map with value $X$ (for $X \neq \varnothing$).
+
   - property: initial-object-preserving
     reason: We have $2^0 \neq 0$.
+
   - property: terminal-object-preserving
     reason: We have $2^1 \neq 1$.
+
+  - property: full
+    reason: Take any map $P(X) \to P(X)$ that does not preserve the empty set, say the constant map with value $X$ (for $X \neq \varnothing$).
+
+  - property: coequalizer-preserving
+    reason: 'Let $X \coloneqq \{x,y\}$. Consider the two maps $x,y : \{0\} \rightrightarrows X$. Their coequalizer $Q = X / (x = y)$ has just one element, so that $P(Q)$ has two elements. The induced maps $x_*,y_* : P(\{0\}) \rightrightarrows P(X)$ (which already agree on the empty set) have coequalizer $P(X) / (\{x\} = \{y\})$, which has $3$ elements. So it cannot be $P(Q)$.'
+
+  - property: equalizer-preserving
+    reason: 'Any pair of distinct surjective maps $f,g : X \rightrightarrows Y$ provides a counterexample: Their equalizer $E$ is a proper subset of $X$, so that $P(E)$ cannot contain $X$. But $f_*(X) = Y = g_*(X)$ shows that $X$ is contained in the equalizer of $f_*,g_* : P(X) \rightrightarrows P(Y)$.'
+
+  - property: finitary
+    reason: The filtered colimit $\IN = \bigcup_{n \geq 0} \IN_{\leq n}$ is not preserved by $P$, since $\bigcup_{n \geq 0} P(\IN_{\leq n})$ just consists of the <i>finite</i> subsets of $\IN$.


### PR DESCRIPTION
- The remaining properties of the existing functors have been determined (namely, that $P$ is not cofinitary, that the free group functor is not cofinitary either, and that the free group functor is comonadic).
- Several new functors have been added: the forgetful functors from **Ring**, **Grp**, and **Top** to **Set**, as well as the functor of continuous functions **Top<sup>op</sup>** &rarr; **CAlg**.
- All their properties have been decided.
- Two functor-specific tags have been added: `free` and `forgetful`.
- The implications have been improved: add missing ones, removed redundancies.

I plan to add more functors soon.