### PR TITLE
Redundancy check for functor property assignments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,9 +134,9 @@ When contributing new data (categories, functors, properties, implications), ple
 
 ### Redundancy Script
 
-As noted above, avoid redundant property assignments to a category. To detect redundancies, run `pnpm db:redundancies`.
+As noted above, avoid redundant property assignments to a category (or functor). To detect redundancies, run `pnpm db:redundancies`.
 
-The script reports at most one redundant assignment per category for each of satisfied and unsatisfied properties, even if multiple exist. After removing an assignment, run the script again to ensure that all remaining redundancies are handled.
+The script reports at most one redundant assignment per category (or functor) for each of satisfied and unsatisfied properties, even if multiple exist. After removing an assignment, run the script again to ensure that all remaining redundancies are handled.
 
 Removing redundant assignments is not required, but it is recommended, especially for all unsatisfied properties. For satisfied properties, removal depends on context: keep them if the proof is meaningful, otherwise consider removing them if it is purely technical or uninformative.
 

--- a/databases/catdat/data/functors/abelianization.yaml
+++ b/databases/catdat/data/functors/abelianization.yaml
@@ -29,9 +29,6 @@ unsatisfied_properties:
   - property: full
     reason: See <a href="https://math.stackexchange.com/questions/716686" target="_blank">MSE/716686</a>.
 
-  - property: conservative
-    reason: The proper inclusion $S_3 \hookrightarrow S_4$ gets mapped to the trivial homomorphism $1 \to 1$, which is an isomorphism.
-
   - property: monomorphism-preserving
     reason: The monomorphism $A_3 \hookrightarrow S_3$ is mapped to $A_3 \to 1$.
 

--- a/databases/catdat/data/functors/continuous-functions.yaml
+++ b/databases/catdat/data/functors/continuous-functions.yaml
@@ -29,9 +29,6 @@ unsatisfied_properties:
   - property: finite-coproduct-preserving
     reason: 'The canonical homomorphism $C(X) \otimes_{\IR} C(Y) \to C(X \times Y)$ need not be surjective. For example, for $X = Y = \IR$ one can show that $(x,y) \mapsto \exp(xy)$ is not contained in its image.'
 
-  - property: conservative
-    reason: 'If $X$ is a non-empty indiscrete space, every continuous map on $X$ is constant. This implies that the unique map $X \to 1$ induces an isomorphism $\IR \cong C(1) \to C(X)$.'
-
   - property: full
     reason: >-
       Every continuous function $\omega_1 \to \IR$ is eventually constant, where $\omega_1$ denotes the first uncountable ordinal equipped with the order topology. We obtain a homomorphism

--- a/databases/catdat/data/functors/forget_abelian.yaml
+++ b/databases/catdat/data/functors/forget_abelian.yaml
@@ -37,9 +37,6 @@ satisfied_properties:
     reason: 'Since the forgetful functor $U_{\Grp} : \Grp \to \Set$ is finitary and conservative, it suffices to prove that the composition $U_{\Ab,\Grp} \circ U_{\Grp} : \Ab \to \Set$ is finitary. This is just the forgetful functor $U_{\Ab} : \Ab \to \Set$ and therefore finitary.'
 
 unsatisfied_properties:
-  - property: essentially surjective
-    reason: Not every group is abelian (e.g. $S_3$).
-
   - property: finite-coproduct-preserving
     reason: The coproduct of two non-trivial cyclic groups in $\Ab$ is just their direct sum, which is finite, but the coproduct of these groups in $\Grp$, also called the free product, is an infinite group.
 

--- a/databases/catdat/data/functors/forget_group.yaml
+++ b/databases/catdat/data/functors/forget_group.yaml
@@ -23,9 +23,6 @@ satisfied_properties:
   - property: monadic
     reason: For every algebraic category the forgetful functor to the category of sets is monadic.
 
-  - property: conservative
-    reason: It is standard that the inverse of a bijective homomorphism is also a homomorphism.
-
   - property: finitary
     reason: For every algebraic category the forgetful functor to the category of sets preserves filtered colimits.
 

--- a/databases/catdat/data/functors/forget_ring.yaml
+++ b/databases/catdat/data/functors/forget_ring.yaml
@@ -21,9 +21,6 @@ satisfied_properties:
   - property: monadic
     reason: For every algebraic category the forgetful functor to the category of sets is monadic.
 
-  - property: conservative
-    reason: It is standard that the inverse of a bijective homomorphism is also a homomorphism.
-
   - property: finitary
     reason: For every algebraic category the forgetful functor to the category of sets preserves filtered colimits.
 

--- a/databases/catdat/data/functors/forget_topology.yaml
+++ b/databases/catdat/data/functors/forget_topology.yaml
@@ -23,9 +23,6 @@ satisfied_properties:
   - property: essentially surjective
     reason: Every set can be equipped with the discrete topology.
 
-  - property: right adjoint
-    reason: 'The discrete topology defines a functor $D : \Set \to \Top$ which is left adjoint to $U_{\Top}$.'
-
   - property: left adjoint
     reason: 'The indiscrete topology defines a functor $I : \Set \to \Top$ which is right adjoint to $U_{\Top}$.'
 

--- a/databases/catdat/data/functors/forget_vector.yaml
+++ b/databases/catdat/data/functors/forget_vector.yaml
@@ -21,9 +21,6 @@ satisfied_properties:
   - property: monadic
     reason: For every algebraic category the forgetful functor to the category of sets is monadic.
 
-  - property: conservative
-    reason: It is standard that the inverse of a bijective linear map is also linear.
-
   - property: finitary
     reason: For every algebraic category the forgetful functor to the category of sets preserves filtered colimits.
 

--- a/databases/catdat/data/functors/free_group.yaml
+++ b/databases/catdat/data/functors/free_group.yaml
@@ -23,9 +23,6 @@ unsatisfied_properties:
   - property: essentially surjective
     reason: Not every group is free (consider $\IZ/2$).
 
-  - property: full
-    reason: The map $1 = \Hom(1,1) \to \Hom(F(1),F(1)) = \Hom(\IZ,\IZ) = \IZ$ is not surjective.
-
   - property: terminal-object-preserving
     reason: The free group of rank $1$ is not the trivial group.
 

--- a/databases/catdat/data/functors/power_set_contravariant.yaml
+++ b/databases/catdat/data/functors/power_set_contravariant.yaml
@@ -23,9 +23,6 @@ satisfied_properties:
     reason: See <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, Theorem 2.2.7.
 
 unsatisfied_properties:
-  - property: full
-    reason: 'The maps $f^* : P(Y) \to P(X)$ preserve the empty set, so take the constant map $P(X) \to P(X)$, $T \mapsto X$ for instance (where $X$ is non-empty).'
-
   - property: initial-object-preserving
     reason: In fact, the initial object does not even lie in the essential image since $P(X) \neq 0$ for all $X$.
 

--- a/databases/catdat/schema/010_functor-properties.sql
+++ b/databases/catdat/schema/010_functor-properties.sql
@@ -29,6 +29,8 @@ CREATE TABLE functor_property_assignments (
     reason TEXT NOT NULL CHECK (length(reason) > 0),
     is_deduced INTEGER NOT NULL DEFAULT FALSE
         CHECK (is_deduced in (TRUE, FALSE)),
+    check_redundancy INTEGER NOT NULL DEFAULT TRUE
+        CHECK (check_redundancy in (TRUE, FALSE)),
     UNIQUE (functor_id, property_id),
     FOREIGN KEY (functor_id) REFERENCES functors (id) ON DELETE CASCADE,
     FOREIGN KEY (property_id) REFERENCES functor_properties (id) ON DELETE CASCADE

--- a/databases/catdat/scripts/redundancies.ts
+++ b/databases/catdat/scripts/redundancies.ts
@@ -1,7 +1,6 @@
 import { get_client } from './utils/helpers'
 import {
 	get_categories,
-	get_ignored_redundant_properties,
 	get_normalized_category_implications,
 	type NormalizedCategoryImplication,
 } from './utils/categories'
@@ -9,7 +8,9 @@ import {
 	get_deduced_satisfied_properties,
 	get_deduced_unsatisfied_properties,
 } from './deduce-structure-properties'
-import { get_property_assignments_by_deduction } from './utils/deduction'
+import { get_property_assignments_by_deduction, StructureMeta } from './utils/deduction'
+import { get_functors, get_normalized_functor_implications } from './utils/functors'
+import { StructureType } from './types'
 
 const db = get_client()
 
@@ -17,23 +18,32 @@ check_redundancies()
 
 /**
  * Checks for redundancies in the database.
+ * No error is thrown intentionally.
  */
 function check_redundancies() {
-	check_redundant_category_property_assignments()
+	check_redundant_property_assignments('category')
+	check_redundant_property_assignments('functor')
 }
 
 /**
- * Checks for redundant (category, property)-assignments and logs
- * one per category if any are found (satisfied or unsatisfied).
+ * Checks for redundant (structure, property)-assignments and logs
+ * one per functor if any are found (satisfied or unsatisfied).
  * No error is thrown intentionally.
  */
-function check_redundant_category_property_assignments() {
-	console.info('\n--- Check redundant category property assignments ---')
+function check_redundant_property_assignments(type: StructureType) {
+	console.info(`\n--- Check redundant ${type} property assignments ---`)
 
-	const implications = get_normalized_category_implications(db)
-	const categories = get_categories(db)
-	const assignments = get_property_assignments_by_deduction(db, categories, 'category')
-	const ignore_dict = get_ignored_redundant_properties(db)
+	// TODO: refactor this when > 2 types of structures are available
+	const implications =
+		type === 'category'
+			? get_normalized_category_implications(db)
+			: get_normalized_functor_implications(db)
+
+	const structures: StructureMeta[] =
+		type === 'category' ? get_categories(db) : get_functors(db)
+
+	const assignments = get_property_assignments_by_deduction(db, structures, type)
+	const ignore_dict = get_ignored_redundant_assignments(type)
 
 	const ignore_count = Object.keys(ignore_dict).reduce(
 		(count, id) => count + ignore_dict[id].size,
@@ -42,36 +52,38 @@ function check_redundant_category_property_assignments() {
 
 	let redundancy_count = 0
 
-	for (const category of categories) {
+	for (const structure of structures) {
 		const redundant_satisfied_property = get_redundant_satisfied_property(
-			assignments[category.id].satisfied.non_deduced,
+			assignments[structure.id].satisfied.non_deduced,
 			implications,
-			ignore_dict[category.id],
+			ignore_dict[structure.id],
+			structure.associated_satisfied_properties,
 		)
 
 		if (redundant_satisfied_property) {
 			console.warn(
-				`🟠 Redundant satisfied property for ${category.id}: "${redundant_satisfied_property}" is implied by others.`,
+				`🟠 Redundant satisfied property for ${structure.id}: "${redundant_satisfied_property}" is implied by others.`,
 			)
 
 			redundancy_count++
 		}
 
 		const all_satisfied_properties = new Set([
-			...assignments[category.id].satisfied.non_deduced,
-			...assignments[category.id].satisfied.deduced,
+			...assignments[structure.id].satisfied.non_deduced,
+			...assignments[structure.id].satisfied.deduced,
 		])
 
 		const redundant_unsatisfied_property = get_redundant_unsatisfied_property(
 			all_satisfied_properties,
-			assignments[category.id].unsatisfied.non_deduced,
+			assignments[structure.id].unsatisfied.non_deduced,
 			implications,
-			ignore_dict[category.id],
+			ignore_dict[structure.id],
+			structure.associated_satisfied_properties,
 		)
 
 		if (redundant_unsatisfied_property) {
 			console.warn(
-				`🟡 Redundant unsatisfied property for ${category.id}: "${redundant_unsatisfied_property}" is implied by others.`,
+				`🟡 Redundant unsatisfied property for ${structure.id}: "${redundant_unsatisfied_property}" is implied by others.`,
 			)
 
 			redundancy_count++
@@ -99,6 +111,7 @@ function get_redundant_satisfied_property(
 	satisfied_properties: Set<string>,
 	implications: NormalizedCategoryImplication[],
 	ignored: Set<string> = new Set(),
+	associated_satisfied_properties?: Record<string, Set<string>>,
 ) {
 	for (const p of [...satisfied_properties]) {
 		if (ignored.has(p)) continue
@@ -108,6 +121,7 @@ function get_redundant_satisfied_property(
 			implications,
 			{ stop_when_found: p },
 			'category',
+			associated_satisfied_properties,
 		)
 		if (deduced_satisfied_properties.has(p)) return p
 		satisfied_properties.add(p)
@@ -126,6 +140,7 @@ function get_redundant_unsatisfied_property(
 	unsatisfied_properties: Set<string>,
 	implications: NormalizedCategoryImplication[],
 	ignored: Set<string> = new Set(),
+	associated_satisfied_properties?: Record<string, Set<string>>,
 ) {
 	for (const p of [...unsatisfied_properties]) {
 		if (ignored.has(p)) continue
@@ -136,9 +151,34 @@ function get_redundant_unsatisfied_property(
 			implications,
 			{ stop_when_found: p },
 			'category',
+			associated_satisfied_properties,
 		)
 		if (deduced_unsatisfied_properties.has(p)) return p
 		unsatisfied_properties.add(p)
 	}
 	return null
+}
+
+/**
+ * Returns a dictionary mapping a structure to the set of its assigned
+ * properties (satisfied or unsatisfied) that should not be checked
+ * by the redundancy check script.
+ */
+function get_ignored_redundant_assignments(type: StructureType) {
+	const rows = db
+		.prepare(
+			`SELECT ${type}_id as structure_id, property_id
+			FROM ${type}_property_assignments
+			WHERE check_redundancy = FALSE`,
+		)
+		.all() as { structure_id: string; property_id: string }[]
+
+	const grouped: Record<string, Set<string>> = {}
+
+	for (const { structure_id, property_id } of rows) {
+		grouped[structure_id] ??= new Set()
+		grouped[structure_id].add(property_id)
+	}
+
+	return grouped
 }

--- a/databases/catdat/scripts/seed.ts
+++ b/databases/catdat/scripts/seed.ts
@@ -556,8 +556,8 @@ function seed_functors() {
 
 	const property_assignment_insert = db.prepare(
 		`INSERT INTO functor_property_assignments (
-			functor_id, property_id, is_satisfied, reason
-		) VALUES (?, ?, ?, ?)`,
+			functor_id, property_id, is_satisfied, reason, check_redundancy
+		) VALUES (?, ?, ?, ?, ?)`,
 	)
 
 	function insert_functor(functor: FunctorYaml) {
@@ -588,15 +588,33 @@ function seed_functors() {
 		}
 
 		for (const entry of functor.satisfied_properties) {
-			property_assignment_insert.run(functor.id, entry.property, 1, entry.reason)
+			property_assignment_insert.run(
+				functor.id,
+				entry.property,
+				1,
+				entry.reason,
+				entry.check_redundancy === false ? 0 : 1,
+			)
 		}
 
 		for (const entry of functor.unsatisfied_properties) {
-			property_assignment_insert.run(functor.id, entry.property, 0, entry.reason)
+			property_assignment_insert.run(
+				functor.id,
+				entry.property,
+				0,
+				entry.reason,
+				entry.check_redundancy === false ? 0 : 1,
+			)
 		}
 
 		for (const entry of functor.undecidable_properties ?? []) {
-			property_assignment_insert.run(functor.id, entry.property, null, entry.reason)
+			property_assignment_insert.run(
+				functor.id,
+				entry.property,
+				null,
+				entry.reason,
+				entry.check_redundancy === false ? 0 : 1,
+			)
 		}
 	}
 

--- a/databases/catdat/scripts/utils/categories.ts
+++ b/databases/catdat/scripts/utils/categories.ts
@@ -72,27 +72,3 @@ export function get_normalized_category_implications(
 
 	return implications
 }
-
-/**
- * Returns a dictionary mapping a category to the set of its assigned
- * properties (satisfied or unsatisfied) that should not be checked
- * by the redundancy check script.
- */
-export function get_ignored_redundant_properties(db: Database) {
-	const rows = db
-		.prepare(
-			`SELECT category_id, property_id
-			FROM category_property_assignments
-			WHERE check_redundancy = FALSE`,
-		)
-		.all() as { category_id: string; property_id: string }[]
-
-	const grouped: Record<string, Set<string>> = {}
-
-	for (const { category_id, property_id } of rows) {
-		grouped[category_id] ??= new Set()
-		grouped[category_id].add(property_id)
-	}
-
-	return grouped
-}


### PR DESCRIPTION
The redundancy script for categories (#155) is extended to functors.

Afterwards, several redundant assignments have been identified and removed.