### PR TITLE
Improve styling of lists

### DIFF
--- a/src/components/CommentList.svelte
+++ b/src/components/CommentList.svelte
@@ -12,7 +12,7 @@
 	<section>
 		<h3>Comments</h3>
 
-		<ul>
+		<ul class="with-margins">
 			{#each comments as { id, comment } (id)}
 				<li class="hint">{@html comment}</li>
 			{/each}

--- a/src/components/ImplicationItem.svelte
+++ b/src/components/ImplicationItem.svelte
@@ -23,63 +23,72 @@
 	)
 </script>
 
-<a href="/{type}-implication/{implication.id}" aria-label="details">
-	<Fa icon={faInfoCircle} color="var(--secondary-text-color)" />
-</a>
-
-{#each implication.assumptions as assumption, i}
-	<a
-		class="property"
-		href={get_property_url(assumption, type)}
-		class:highlighted={assumption === highlighted_property}
-	>
-		{assumption}
+<div class="implication-container">
+	<a href="/{type}-implication/{implication.id}" aria-label="details">
+		<Fa icon={faInfoCircle} color="var(--secondary-text-color)" />
 	</a>
 
-	{#if i < implication.assumptions.length - 1}
-		<span class="operator">
-			<Fa icon={faPlus} class="operator" />
-			<span class="visually-hidden">and</span>
+	<div>
+		{#each implication.assumptions as assumption, i}
+			<a
+				class="property"
+				href={get_property_url(assumption, type)}
+				class:highlighted={assumption === highlighted_property}
+			>
+				{assumption}
+			</a>
+
+			{#if i < implication.assumptions.length - 1}
+				<span class="operator">
+					<Fa icon={faPlus} class="operator" />
+					<span class="visually-hidden">and</span>
+				</span>
+			{/if}
+		{/each}
+
+		<span aria-hidden="true" class="operator">
+			{#if has_additional_assumptions}
+				<span class="bracket">(</span>
+			{/if}<Fa
+				icon={implication.is_equivalence ? faArrowsLeftRight : faArrowRight}
+			/>{#if has_additional_assumptions}
+				<span class="bracket">)</span>
+			{/if}
 		</span>
-	{/if}
-{/each}
 
-<span aria-hidden="true" class="operator">
-	{#if has_additional_assumptions}
-		<span class="bracket">(</span>
-	{/if}<Fa
-		icon={implication.is_equivalence ? faArrowsLeftRight : faArrowRight}
-	/>{#if has_additional_assumptions}
-		<span class="bracket">)</span>
-	{/if}
-</span>
-
-<span class="visually-hidden">
-	{#if implication.is_equivalence}
-		is equivalent to
-	{:else}
-		implies
-	{/if}
-</span>
-
-{#each implication.conclusions as conclusion, i}
-	<a
-		class="property"
-		href={get_property_url(conclusion, type)}
-		class:highlighted={conclusion === highlighted_property}
-	>
-		{conclusion}
-	</a>
-
-	{#if i < implication.conclusions.length - 1}
-		<span class="operator">
-			<Fa icon={faPlus} />
-			<span class="visually-hidden">and</span>
+		<span class="visually-hidden">
+			{#if implication.is_equivalence}
+				is equivalent to
+			{:else}
+				implies
+			{/if}
 		</span>
-	{/if}
-{/each}
+
+		{#each implication.conclusions as conclusion, i}
+			<a
+				class="property"
+				href={get_property_url(conclusion, type)}
+				class:highlighted={conclusion === highlighted_property}
+			>
+				{conclusion}
+			</a>
+
+			{#if i < implication.conclusions.length - 1}
+				<span class="operator">
+					<Fa icon={faPlus} />
+					<span class="visually-hidden">and</span>
+				</span>
+			{/if}
+		{/each}
+	</div>
+</div>
 
 <style>
+	.implication-container {
+		display: inline-flex;
+		gap: 0.5rem;
+	}
+
 	.property:not(.highlighted) {
 		text-decoration: none;
 	}

--- a/src/components/ImplicationList.svelte
+++ b/src/components/ImplicationList.svelte
@@ -12,7 +12,7 @@
 </script>
 
 {#if implications.length}
-	<ul class="no-bullets">
+	<ul class="no-bullets with-margins">
 		{#each implications as implication}
 			<li>
 				<ImplicationItem {implication} {highlighted_property} {type} />

--- a/src/components/ImplicationList.svelte
+++ b/src/components/ImplicationList.svelte
@@ -12,7 +12,7 @@
 </script>
 
 {#if implications.length}
-	<ul>
+	<ul class="no-bullets">
 		{#each implications as implication}
 			<li>
 				<ImplicationItem {implication} {highlighted_property} {type} />

--- a/src/components/PropertyAssignmentList.svelte
+++ b/src/components/PropertyAssignmentList.svelte
@@ -42,20 +42,23 @@
 			<PropertyList
 				properties={satisfied_properties.filter((p) => !p.is_deduced)}
 				{type}
+				no_bullets={true}
 			/>
 
 			<p class="hint">Deduced properties</p>
 			<PropertyList
 				properties={satisfied_properties.filter((p) => p.is_deduced)}
 				{type}
+				no_bullets={true}
 			/>
 		{:else if assignment_level.value === 'merged'}
-			<PropertyList properties={satisfied_properties} {type} />
+			<PropertyList properties={satisfied_properties} {type} no_bullets={true} />
 		{:else if assignment_level.value === 'basic'}
 			<p class="hint">Assigned properties; further properties can be deduced.</p>
 			<PropertyList
 				properties={satisfied_properties.filter((p) => !p.is_deduced)}
 				{type}
+				no_bullets={true}
 			/>
 		{/if}
 	</section>
@@ -68,22 +71,25 @@
 			<PropertyList
 				properties={unsatisfied_properties.filter((p) => !p.is_deduced)}
 				{type}
+				no_bullets={true}
 			/>
 
 			<p class="hint">Deduced properties*</p>
 			<PropertyList
 				properties={unsatisfied_properties.filter((p) => p.is_deduced)}
 				{type}
+				no_bullets={true}
 			/>
 
 			<p class="hint">*This also uses the deduced satisfied properties.</p>
 		{:else if assignment_level.value === 'merged'}
-			<PropertyList properties={unsatisfied_properties} {type} />
+			<PropertyList properties={unsatisfied_properties} {type} no_bullets={true} />
 		{:else if assignment_level.value === 'basic'}
 			<p class="hint">Assigned properties; further properties can be deduced.</p>
 			<PropertyList
 				properties={unsatisfied_properties.filter((p) => !p.is_deduced)}
 				{type}
+				no_bullets={true}
 			/>
 		{/if}
 	</section>
@@ -119,7 +125,7 @@
 			</p>
 		{/if}
 
-		<PropertyList properties={undecidable_properties} {type} />
+		<PropertyList properties={undecidable_properties} {type} no_bullets={true} />
 	</section>
 {/if}
 

--- a/src/components/PropertyList.svelte
+++ b/src/components/PropertyList.svelte
@@ -10,13 +10,14 @@
 			reason?: string | null
 		}[]
 		type: StructureType
+		no_bullets?: boolean
 	}
 
-	let { properties, type }: Props = $props()
+	let { properties, type, no_bullets = false }: Props = $props()
 </script>
 
 {#if properties.length}
-	<ul>
+	<ul class:no-bullets={no_bullets}>
 		{#each properties as { id, relation, reason }}
 			<li>
 				<TextWithReason {reason}>
@@ -29,9 +30,3 @@
 {:else}
 	<p>&mdash;</p>
 {/if}
-
-<style>
-	li {
-		position: relative;
-	}
-</style>

--- a/src/components/PropertyList.svelte
+++ b/src/components/PropertyList.svelte
@@ -17,7 +17,7 @@
 </script>
 
 {#if properties.length}
-	<ul class:no-bullets={no_bullets}>
+	<ul class:no-bullets={no_bullets} class="with-margins">
 		{#each properties as { id, relation, reason }}
 			<li>
 				<TextWithReason {reason}>

--- a/src/components/StructureList.svelte
+++ b/src/components/StructureList.svelte
@@ -10,7 +10,7 @@
 </script>
 
 {#if structures.length}
-	<ul>
+	<ul class="with-margins">
 		{#each structures as structure}
 			<li>
 				<a href="/{type}/{structure.id}">

--- a/src/components/TextWithReason.svelte
+++ b/src/components/TextWithReason.svelte
@@ -25,13 +25,11 @@
 
 {#if reason}
 	<span class="wrapper" class:expanded={popup_state?.id === id}>
-		<span>
-			<button onclick={show_reason} aria-label="Show reason">
-				<Fa icon={faCommentDots} scale={0.825} />
-			</button>
+		<button onclick={show_reason} aria-label="Show reason">
+			<Fa icon={faCommentDots} scale={0.825} />
+		</button>
 
-			{@render children()}
-		</span>
+		<span>{@render children()}</span>
 	</span>
 {:else}
 	<span>
@@ -41,7 +39,9 @@
 
 <style>
 	.wrapper {
-		display: inline-grid;
+		display: inline-flex;
+		align-items: start;
+		gap: 0.35rem;
 
 		&.expanded {
 			color: var(--accent-color);

--- a/src/pages/PropertyListPage.svelte
+++ b/src/pages/PropertyListPage.svelte
@@ -49,7 +49,7 @@
 	{/if}
 </p>
 
-<ul>
+<ul class="with-margins">
 	{#each searched_properties as { id, relation, dual_property_id }}
 		<li>
 			{relation}

--- a/src/pages/PropertyPage.svelte
+++ b/src/pages/PropertyPage.svelte
@@ -52,7 +52,7 @@
 </p>
 
 {#if property.dual_property_id || related_properties.length || property.nlab_link}
-	<ul>
+	<ul class="with-margins">
 		{#if property.dual_property_id}
 			<li>
 				<strong>Dual property:</strong>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -6,7 +6,7 @@
 
 <h2>Admin Page</h2>
 
-<ul>
+<ul class="with-margins">
 	<li>
 		<a href="/admin/statistics">Statistics</a>
 	</li>

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -156,7 +156,7 @@ ul.no-bullets {
 }
 
 ul.with-margins > li + li {
-	margin-top: 0.25rem;
+	margin-top: 0.125rem;
 }
 
 ol {

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -150,6 +150,11 @@ ul {
 	}
 }
 
+ul.no-bullets {
+	padding-left: 0;
+	list-style: none;
+}
+
 ul.with-margins > li + li {
 	margin-top: 0.25rem;
 }

--- a/src/routes/category/[id]/+page.svelte
+++ b/src/routes/category/[id]/+page.svelte
@@ -52,7 +52,7 @@
 <section>
 	<h3>Special morphisms</h3>
 
-	<ul class="with-margins">
+	<ul class="with-margins no-bullets">
 		{#each data.special_morphisms as obj}
 			<li>
 				<TextWithReason reason={obj.reason}>

--- a/src/routes/content/[id]/+page.svelte
+++ b/src/routes/content/[id]/+page.svelte
@@ -37,7 +37,7 @@
 	{#if data.category_implications.length > 0}
 		<p class="hint">This page is referenced by the following implications.</p>
 
-		<ul>
+		<ul class="with-margins">
 			{#each data.category_implications as { id }}
 				<li>
 					<a href="/category-implication/{id}">{id}</a>

--- a/src/routes/missing/+page.svelte
+++ b/src/routes/missing/+page.svelte
@@ -53,7 +53,7 @@
 			be missing.
 		</p>
 
-		<ul>
+		<ul class="with-margins">
 			{#each data.undistinguishable_category_pairs as pair}
 				<li>
 					<a href="/category/{pair.id1}">
@@ -83,7 +83,7 @@
 	<details>
 		<summary>Show all {data.missing_combinations.length} combinations</summary>
 
-		<ul class="combinations">
+		<ul class="combinations with-margins">
 			{#each data.missing_combinations as [p, q]}
 				<li class="combination">
 					<a href={get_property_url(p, 'category')}>{p}</a> &and; &not;<a


### PR DESCRIPTION
1. On small screens, text does not go under the icon in a list item anymore.
2. Bullet points have been removed when there was a clickable icon anyway.
3. Small margins have been added.

All this makes it easier to read the lists, especially the long ones.

### Before

<img width="600" src="https://github.com/user-attachments/assets/eaf46d6b-87a6-48ca-af99-c57d124ed496" /><br /><br />

### After

<img width="600"  src="https://github.com/user-attachments/assets/684af392-65d8-4952-98fe-e5437c780c18" /><br /><br />

### Before / After

<img width="300" src="https://github.com/user-attachments/assets/f77f2deb-3b8c-4c4b-9647-cfd732efd107" />&nbsp;&nbsp;<img width="300" src="https://github.com/user-attachments/assets/40a2e475-fdcf-4283-be5e-d6062000f6ae" /><br /><br />

<img width="300" src="https://github.com/user-attachments/assets/d8c0ecea-2906-4d97-9e00-908ce80520ad" />&nbsp;&nbsp;<img width="300" src="https://github.com/user-attachments/assets/aae263d9-d2cd-48bf-ad23-033946d0ce29" /><br /><br />





