### PR TITLE
Sh(X) never has a generator (unless X has the indiscrete topology)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -252,6 +252,7 @@
 		"subscheme",
 		"subsemigroup",
 		"subsheaf",
+		"subterminal",
 		"summands",
 		"suprema",
 		"supremum",

--- a/content/topos-with-generator.md
+++ b/content/topos-with-generator.md
@@ -1,0 +1,21 @@
+---
+title: Topos with a Generator
+description: An elementary topos with a generator has at most two subterminal objects
+author: Daniel Schepler
+---
+
+# Topos with a Generator
+
+::: Lemma
+Suppose a category is coregular, and it has disjoint finite coproducts, a terminal object, and a generator. Then every regular subterminal object (i.e. an object $X$ such that the unique morphism $X \to 1$ is a regular monomorphism) is either initial or terminal.
+:::
+
+_Proof._ Suppose $G$ is a generator, and let $P$ be a regular subterminal object. If the two inclusion morphisms $P \rightrightarrows P + P$ are equal, then by disjointness of finite coproducts, $P$ must be initial. Otherwise, in order for $G$ to distinguish these two morphisms, there must be a morphism  $G \to P$, which implies that the unique morphism $G \to 1$ factors through $P$.
+
+Now, if we consider the two morphisms $i_1, i_2 : 1 \rightrightarrows 1 +_P 1$, we see that for every morphism $f : G \to 1$ (of which there is exactly one), we have $i_1 \circ f = i_2 \circ f$. Since $G$ is a generator, that implies $i_1 = i_2$. On the other hand, by coregularity, we see that the equalizer of $i_1, i_2 : 1 \rightrightarrows 1 +_P 1$ is $P$. Therefore, we conclude that $P \simeq 1$. <span class="qed">$\square$</span>
+
+::: Corollary
+In an elementary topos with a generator, every subterminal object is either initial or terminal.
+:::
+
+_Proof._ An elementary topos satisfies all the conditions of the lemma; and it is also mono-regular so that every subterminal object is automatically regular subterminal. <span class="qed">$\square$</span>

--- a/databases/catdat/data/categories/SetxSet.yaml
+++ b/databases/catdat/data/categories/SetxSet.yaml
@@ -31,7 +31,10 @@ unsatisfied_properties:
     reason: When $X$ is non-empty, there is no morphism between $(\varnothing,X)$ and $(X,\varnothing)$.
 
   - property: generator
-    reason: Assume that $(A,B)$ is a generator. Of course, $A$ and $B$ cannot be both empty. Assume w.l.o.g. that $A$ is non-empty. Then there is no morphism $(A,B) \to (0,1)$, but there are two different morphisms $(0,1) \rightrightarrows (0,2)$.
+    reason: >-
+      Assume that $(A,B)$ is a generator. Of course, $A$ and $B$ cannot be both empty. Assume w.l.o.g. that $A$ is non-empty. Then there is no morphism $(A,B) \to (0,1)$, but there are two different morphisms $(0,1) \rightrightarrows (0,2)$.
+
+      Alternatively, the claim follows from <a href="/content/topos-with-generator">this result</a>.
 
 special_objects:
   initial object:

--- a/databases/catdat/data/categories/Sh(X).yaml
+++ b/databases/catdat/data/categories/Sh(X).yaml
@@ -16,7 +16,7 @@ related_categories:
   - Sh(X,Ab)
 
 comments:
-  - It is likely that neither of the currently remaining unknown properties (finitary algebraic, locally ℵ₁-presentable, exact filtered colimits, etc.) are satisfied for a <i>generic</i> space $X$, but we need to make this precise by adding additional requirements to $X$. Maybe we need to create separate entries for specific spaces $X$.
+  - It is likely that none of the currently remaining unknown properties (locally ℵ₁-presentable, exact filtered colimits, etc.) are satisfied for a <i>generic</i> space $X$, but we need to make this precise by adding additional requirements to $X$. Maybe we need to create separate entries for specific spaces $X$.
 
 satisfied_properties:
   - property: locally small
@@ -29,8 +29,11 @@ unsatisfied_properties:
   - property: skeletal
     reason: Consider constant sheaves for isomorphic but non-equal sets.
 
-  - property: trivial
-    reason: This is because $X$ is assumed to be non-empty.
+  - property: generator
+    reason: >-
+      Suppose $\Sh(X)$ had a generator. Then by <a href="/content/topos-with-generator">this result</a>, every subterminal object would be either initial or terminal. On the other hand, the subterminal objects of $\Sh(X)$ are of the form $y_U \coloneqq \Hom({-}, U)$ for $U$ open. (Alternative descriptions of $y_U$ include:
+      $$y_U(V) = \begin{cases} 1, & V \subseteq U; \\ \varnothing & \mathrm{otherwise} \end{cases}$$
+      with the unique restriction maps; and $y_U$ represents the functor $\Gamma(U, {-})$ of sections over $U$.) Therefore, the lemma implies that every open set of $X$ is either $\varnothing$ or $X$, contradicting our assumption that $X$ does not have the indiscrete topology.
 
 special_objects:
   initial object:

--- a/databases/catdat/data/categories/Sp.yaml
+++ b/databases/catdat/data/categories/Sp.yaml
@@ -46,7 +46,10 @@ unsatisfied_properties:
     reason: 'For $n \geq 0$ let $E_n$ be the combinatorial species of $n$-sets: $E_n(A) = \{A\}$ when $A$ has cardinality $n$, otherwise $E_n(A) = \varnothing$. Then there is no morphism between $E_n$ and $E_m$ unless $n = m$.'
 
   - property: generator
-    reason: 'Assume that a generator $G$ exists. For $n \geq 0$ let $F_n$ be the combinatorial species of sets of cardinality $\neq n$: $F_n(A) = \varnothing$ when $A$ has cardinality $n$, otherwise $F_n(A) = \{A\}$. There are two different morphisms $F_n \rightrightarrows F_n \sqcup F_n$. Hence, there must be at least one morphism $G \to F_n$. If $A$ has cardinality $n$, this implies $G(A) = \varnothing$. Since this holds for all $n$, $G$ is the initial object. But this is clearly no generator (it would mean that the category is thin).'
+    reason: >-
+      Assume that a generator $G$ exists. For $n \geq 0$ let $F_n$ be the combinatorial species of sets of cardinality $\neq n$: $F_n(A) = \varnothing$ when $A$ has cardinality $n$, otherwise $F_n(A) = \{A\}$. There are two different morphisms $F_n \rightrightarrows F_n \sqcup F_n$. Hence, there must be at least one morphism $G \to F_n$. If $A$ has cardinality $n$, this implies $G(A) = \varnothing$. Since this holds for all $n$, $G$ is the initial object. But this is clearly no generator (it would mean that the category is thin).
+
+      Alternatively, the claim follows from <a href="/content/topos-with-generator">this result</a>.
 
   - property: natural numbers object
     reason: >-


### PR DESCRIPTION
It turns out this only resolves the direct assignment plus not being finitary algebraic.

---

- unknown (category, property)-pairs before this PR: 116
- unknown (category, property)-pairs after this PR: 114