### PR TITLE
Add three functors on abelian groups related to torsion

### DIFF
--- a/databases/catdat/data/functors/modulo-p.yaml
+++ b/databases/catdat/data/functors/modulo-p.yaml
@@ -1,0 +1,45 @@
+id: modulo-p
+name: modulo p functor
+notation: $T^p$
+source: Ab
+target: Ab
+description: This functor maps an abelian group $A$ to the quotient $T^p(A) \coloneqq A/pA$, where $p$ is a fixed prime number. This group can also be represented as $A \otimes \IZ/p$.
+nlab_link: null
+
+tags:
+  - algebra
+  - free
+
+related_functors: []
+
+satisfied_properties:
+  - property: left adjoint
+    reason: 'This functor is left adjoint to the $p$-torsion functor $T_p : \Ab \to \Ab$.'
+
+  - property: preserves products
+    reason: >-
+      For a product of a family of abelian groups $(A_i)_{i \in I}$ it is easy to check that
+      $$\textstyle p \prod_{i \in I} A_i = \prod_{i \in I} p A_i$$
+      as subgroups of $\prod_{i \in I} A_i$. Hence,
+      $$\textstyle \prod_{i \in I} A_i / p \prod_{i \in I} A_i = \prod_{i \in I} A_i / \prod_{i \in I} p A_i \cong \prod_{i \in I} A_i / p A_i.$$
+
+unsatisfied_properties:
+  - property: essentially surjective
+    reason: The essential image consists precisely of the elementary abelian $p$-groups, equivalently, the vector spaces over $\IF_p$. For example, $\IZ$ is not contained in it.
+
+  - property: faithful
+    reason: 'We have $\IQ / p \IQ = 0$, but $\IQ \not\cong 0$. Thus, faithfulness is failing for $0, \id_{\IQ} : \IQ \rightrightarrows \IQ$.'
+
+  - property: full
+    reason: 'Let $\IZ_{(p)}$ denote the additive group of $p$-local numbers, i.e. the localization of $\IZ$ at the prime ideal $\langle p \rangle$. The map from $\Hom(\IZ_{(p)},\IZ)$ to $\Hom(\IZ_{(p)} / p \IZ_{(p)} ,\IZ / p)$ is not surjective: The abelian group $\HomInternal(\IZ_{(p)},\IZ)$ is trivial: For a prime $q \neq p$ every element of $\IZ_{(p)}$ is $q^\infty$-divisible, but $0$ is the only $q^\infty$-divisible integer. However, $\IZ_{(p)} / p \IZ_{(p)} \cong \IZ/p$ shows that $\HomInternal(\IZ_{(p)} / p \IZ_{(p)} ,\IZ / p)$ is isomorphic to $\IZ/p$.'
+
+  - property: preserves monomorphisms
+    reason: 'The monomorphism $p : \IZ \to \IZ$ is mapped to the zero map $0 : \IZ/p \to \IZ/p$.'
+
+  - property: cofinitary
+    reason: >-
+      Let $q$ be be an integer which is $\geq 2$ and coprime to $p$. Consider the sequence
+      $$\cdots \xrightarrow{q} \IZ \xrightarrow{q} \IZ  \xrightarrow{q} \IZ.$$
+      Its limit is $0$ since each entry needs to be $q^\infty$-divisible. However, the sequence modulo $p$
+      $$\cdots \xrightarrow{q} \IZ/p \xrightarrow{q} \IZ/p  \xrightarrow{q} \IZ/p$$
+      consists entirely of isomorphisms, so that its limit is $\IZ/p$.

--- a/databases/catdat/data/functors/p-torsion.yaml
+++ b/databases/catdat/data/functors/p-torsion.yaml
@@ -1,0 +1,51 @@
+id: p-torsion
+name: p-torsion functor
+notation: $T_p$
+source: Ab
+target: Ab
+description: >-
+  This functor maps an abelian group $A$ to its $p$-torsion subgroup
+  $$T_p(A) \coloneqq \{a \in A : pa = 0\},$$
+  where $p$ is a fixed prime number. This group can also be represented as $\HomInternal(\IZ/p,A)$.
+nlab_link: null
+left_adjoint: modulo-p
+
+tags:
+  - algebra
+
+related_functors:
+  - torsion
+
+satisfied_properties:
+  - property: right adjoint
+    reason: 'This functor is clearly right adjoint to $A \mapsto A/pA$.'
+
+  - property: preserves coproducts
+    reason: This is easy to check using the description of coproducts as direct sums.
+
+  - property: finitary
+    reason: >-
+      This follows abstractly from the fact that $\IZ/p$ is finitely presentable. We nevertheless give a direct proof. Let $(A_i)$ be a filtered diagram of abelian groups. We need to show that the canonical map
+      $$\colim_i T_p(A_i) \to T_p(\colim_i A_i)$$
+      is an isomorphism.
+
+      Injectivity: Every element of $\colim_i T_p(A_i)$ is induced by an element in some $T_p(A_i)$. Assume it lies in the kernel, i.e. it becomes zero in $\colim_i A_i$. Then there exists some $i \to j$ such that its image in $A_j$ is zero. Hence its image in $T_p(A_j)$ is zero, and we are done.
+
+      Surjectivity: Assume we have a $p$-torsion element in $\colim_i A_i$. It has a preimage in some $A_i$. When we multiply it with $p$, it becomes zero in the colimit. This means that there exists some $i \to j$ such that this multiple becomes zero in $A_j$. Therefore, the image in $A_j$ is a $p$-torsion element. It provides the desired preimage.
+
+unsatisfied_properties:
+  - property: faithful
+    reason: 'We have $T_p(\IZ) = 0$, but $\IZ \not\cong 0$. Thus, faithfulness is failing for $0, \id_{\IZ} : \IZ \rightrightarrows \IZ$.'
+
+  - property: full
+    reason: 'The canonical map from $\Hom(\IZ/p^2,\IZ/p)$ to $\Hom(T_p(\IZ/p^2),T_p(\IZ/p)) = \Hom(p \IZ/p^2, \IZ/p)$ is not surjective: The homomorphism $[p] \mapsto [1]$ is not contained in its image.'
+
+  - property: essentially surjective
+    reason: The essential image consists precisely of the elementary abelian $p$-groups, equivalently, the vector spaces over $\IF_p$. For example, $\IZ$ is not contained in it.
+
+  - property: preserves epimorphisms
+    reason: The surjective homomorphism $\IZ \to \IZ/p$ is mapped to the homomorphism $0 \to \IZ/p$, which is not surjective.
+
+  - property: representable
+    # TODO: automate this
+    reason: Its target is not $\Set$. (However, this functor is representable in the enriched sense.)

--- a/databases/catdat/data/functors/torsion.yaml
+++ b/databases/catdat/data/functors/torsion.yaml
@@ -1,0 +1,54 @@
+id: torsion
+name: torsion functor
+notation: $T$
+source: Ab
+target: Ab
+description: >-
+  This functor maps an abelian group $A$ to its torsion subgroup
+  $$T(A) \coloneqq \{a \in A : \exists n \geq 1 \, (na = 0)\}.$$
+nlab_link: https://ncatlab.org/nlab/show/torsion+subgroup
+tags:
+  - algebra
+
+related_functors:
+  - p-torsion
+
+satisfied_properties:
+  - property: preserves coproducts
+    reason: This is easy to check using the description of coproducts as direct sums.
+
+  - property: preserves finite products
+    # TODO: automate this with an implication
+    reason: Finite products coincide with finite direct sums.
+
+  - property: preserves equalizers
+    reason: 'Let $E \subseteq A$ be the equalizer of two homomorphisms $f,g : A \rightrightarrows B$. If $a \in T(A)$ is equalized by $T(f),T(g) : T(A) \rightrightarrows T(B)$, then $a \in A$ is equalized by $f,g$, so that $a \in E$. It follows $a \in T(A) \cap E = T(E)$.'
+
+  - property: finitary
+    reason: >-
+      Let $(A_i)$ be a filtered diagram of abelian groups. We need to show that the canonical map
+      $$\colim_i T(A_i) \to T(\colim_i A_i)$$
+      is an isomorphism.
+
+      Injectivity: Every element of $\colim_i T(A_i)$ is induced by an element in some $T(A_i)$. Assume it lies in the kernel, i.e. it becomes zero in $\colim_i A_i$. Then there exists some $i \to j$ such that its image in $A_j$ is zero. Hence its image in $T(A_j)$ is zero, and we are done.
+
+      Surjectivity: Assume we have a torsion element in $\colim_i A_i$. It has a preimage in some $A_i$. When we multiply it with some integer $\geq 1$, it becomes zero in the colimit. This means that there exists some $i \to j$ such that this multiple becomes zero in $A_j$. Therefore, the image in $A_j$ is a torsion element. It provides the desired preimage.
+
+unsatisfied_properties:
+  - property: faithful
+    reason: 'We have $T(\IZ) = 0$, but $\IZ \not\cong 0$. Thus, faithfulness is failing for $0, \id_{\IZ} : \IZ \rightrightarrows \IZ$.'
+
+  - property: full
+    reason: 'Let $p$ be a prime. The canonical map from $\Hom(\IZ/p^2,\IZ/p)$ to $\Hom(T(\IZ/p^2),T(\IZ/p)) = \Hom(p \IZ/p^2, \IZ/p)$ is not surjective: The homomorphism $[p] \mapsto [1]$ is not contained in its image.'
+
+  - property: essentially surjective
+    reason: The essential image consists precisely of the abelian torsion groups. For example, $\IZ$ is not contained in it.
+
+  - property: preserves epimorphisms
+    reason: Let $p$ be a prime. The surjective homomorphism $\IZ \to \IZ/p$ is mapped to the homomorphism $0 \to \IZ/p$, which is not surjective.
+
+  - property: preserves products
+    reason: >-
+      The canonical homomorphism
+      $$\textstyle T(\prod_{n \geq 1} \IZ/n) \to \prod_{n \geq 1} T(\IZ/n) = \prod_{n \geq 1} \IZ/n$$
+      is not surjective since $([1],[1],\dotsc)$ is not contained in the image.

--- a/databases/catdat/data/macros.yaml
+++ b/databases/catdat/data/macros.yaml
@@ -40,6 +40,7 @@
 # operators
 \Mor: \operatorname{Mor}
 \Hom: \operatorname{Hom}
+\HomInternal: \underline{\operatorname{Hom}}
 \End: \operatorname{End}
 \Ob: \operatorname{Ob}
 \id: \operatorname{id}


### PR DESCRIPTION
This PR adds three functors on **Ab** and decides all of their properties:

- $T^p(A) = A/pA$ (modulo $p$ quotient)
- $T_p(A) = \\{a  \in A : pa = 0\\}$ ($p$-torsion subgroup)
- $T(A)= \\{a  \in A : \exists n \geq 1 ~ (na = 0) \\}$ (torsion subgroup)

We have $T^p \dashv T_p$.