### PR TITLE
Automated source and target restrictions of functor properties

### DIFF
--- a/databases/catdat/data/functor-properties/representable.yaml
+++ b/databases/catdat/data/functor-properties/representable.yaml
@@ -1,6 +1,7 @@
 id: representable
 relation: is
 description: 'A functor $F : \C \to \D$ is <i>representable</i> if $\C$ is locally small, $\D = \Set$, and there is an object $A \in \C$ with $F \cong \Hom(A,-)$.'
+required_target: Set
 nlab_link: https://ncatlab.org/nlab/show/representable+functor
 invariant_under_equivalences: true
 dual_property: null

--- a/databases/catdat/data/functors/continuous-functions.yaml
+++ b/databases/catdat/data/functors/continuous-functions.yaml
@@ -22,10 +22,6 @@ unsatisfied_properties:
   - property: essentially surjective
     reason: The algebra $C(X)$ is <a href="https://en.wikipedia.org/wiki/Reduced_ring" target="_blank">reduced</a>, whereas there exist non-reduced algebras such as $\IR[T]/\langle T^2 \rangle$.
 
-  - property: representable
-    # TODO: automate this
-    reason: Its target is not $\Set$.
-
   - property: preserves finite coproducts
     reason: 'The canonical homomorphism $C(X) \otimes_{\IR} C(Y) \to C(X \times Y)$ need not be surjective. For example, for $X = Y = \IR$ one can show that $(x,y) \mapsto \exp(xy)$ is not contained in its image.'
 

--- a/databases/catdat/data/functors/diagonal_sets.yaml
+++ b/databases/catdat/data/functors/diagonal_sets.yaml
@@ -31,9 +31,5 @@ unsatisfied_properties:
   - property: full
     reason: 'Take any pair of distinct maps $f,g : X \rightrightarrows Y$. Then $(f,g) : (X,X) \to (Y,Y)$ is not induced diagonally via a map $X \to Y$.'
 
-  - property: representable
-    # TODO: automate this
-    reason: The codomain is not $\Set$.
-
   - property: essentially surjective
     reason: This is trivial.

--- a/databases/catdat/data/functors/forget_abelian.yaml
+++ b/databases/catdat/data/functors/forget_abelian.yaml
@@ -36,7 +36,3 @@ satisfied_properties:
 unsatisfied_properties:
   - property: preserves finite coproducts
     reason: The coproduct of two non-trivial cyclic groups in $\Ab$ is just their direct sum, which is finite, but the coproduct of these groups in $\Grp$, also called the free product, is an infinite group.
-
-  - property: representable
-    # TODO: automate this
-    reason: The target is not $\Set$.

--- a/databases/catdat/data/functors/p-torsion.yaml
+++ b/databases/catdat/data/functors/p-torsion.yaml
@@ -45,7 +45,3 @@ unsatisfied_properties:
 
   - property: preserves epimorphisms
     reason: The surjective homomorphism $\IZ \to \IZ/p$ is mapped to the homomorphism $0 \to \IZ/p$, which is not surjective.
-
-  - property: representable
-    # TODO: automate this
-    reason: Its target is not $\Set$. (However, this functor is representable in the enriched sense.)

--- a/databases/catdat/schema/010_functor-properties.sql
+++ b/databases/catdat/schema/010_functor-properties.sql
@@ -5,11 +5,23 @@ CREATE TABLE functor_properties (
     nlab_link TEXT CHECK (nlab_link IS NULL OR nlab_link like 'https://%'),
     invariant_under_equivalences INTEGER NOT NULL DEFAULT TRUE,
     dual_property_id TEXT,
+    required_source TEXT,
+    required_target TEXT,
     FOREIGN KEY (relation) REFERENCES relations (relation) ON DELETE RESTRICT,
-    FOREIGN KEY (dual_property_id) REFERENCES functor_properties (id) ON DELETE SET NULL
+    FOREIGN KEY (dual_property_id) REFERENCES functor_properties (id) ON DELETE SET NULL,
+    FOREIGN KEY (required_source) REFERENCES categories (id) ON DELETE SET NULL,
+    FOREIGN KEY (required_target) REFERENCES categories (id) ON DELETE SET NULL
 );
 
 CREATE UNIQUE INDEX functor_properties_lower_id_unique ON functor_properties (lower(id));
+
+CREATE INDEX idx_functor_properties_required_source
+ON functor_properties(required_source)
+WHERE required_source IS NOT NULL;
+
+CREATE INDEX idx_functor_properties_required_target
+ON functor_properties(required_target)
+WHERE required_target IS NOT NULL;
 
 CREATE TABLE related_functor_properties (
     property_id TEXT NOT NULL,

--- a/databases/catdat/scripts/deduce.ts
+++ b/databases/catdat/scripts/deduce.ts
@@ -3,6 +3,7 @@ import { deduce_functor_implications } from './deduce-functor-implications'
 import { deduce_special_objects } from './deduce-special-objects'
 import { deduce_special_morphisms } from './deduce-special-morphisms'
 import { deduce_properties_for_structures } from './deduce-structure-properties'
+import { restrict_functor_properties } from './restrict-functor-properties'
 
 deduce()
 
@@ -16,6 +17,7 @@ function deduce() {
 	deduce_special_objects()
 	deduce_special_morphisms()
 
+	restrict_functor_properties()
 	deduce_functor_implications()
 	deduce_properties_for_structures('functor')
 }

--- a/databases/catdat/scripts/restrict-functor-properties.ts
+++ b/databases/catdat/scripts/restrict-functor-properties.ts
@@ -1,0 +1,39 @@
+import { get_client } from './utils/helpers'
+
+const db = get_client()
+
+/**
+ * Ensures that selected properties of functors are restricted
+ * to specified source and target categories.
+ */
+export function restrict_functor_properties() {
+	console.info('\n--- Restrict functor properties ---')
+
+	for (const domain of ['source', 'target']) {
+		const res = db
+			.prepare(
+				`INSERT INTO functor_property_assignments (
+                    functor_id,
+                    property_id,
+                    is_satisfied,
+                    reason,
+                    is_deduced
+                )
+                SELECT
+                    f.id,
+                    p.id,
+                    FALSE,
+                    'The ${domain} category is not ' || c.notation || '.',
+                    FALSE
+                FROM functor_properties p
+                INNER JOIN categories c ON c.id = p.required_${domain}
+                JOIN functors f
+                WHERE f.${domain} <> p.required_${domain}`,
+			)
+			.run()
+
+		console.info(
+			`Restricted ${res.changes} functor properties based on their required ${domain}`,
+		)
+	}
+}

--- a/databases/catdat/scripts/seed.ts
+++ b/databases/catdat/scripts/seed.ts
@@ -403,9 +403,11 @@ function seed_functor_properties() {
 
 	const property_insert = db.prepare(`
 		INSERT INTO functor_properties (
-			id, relation, description, nlab_link,
-			dual_property_id, invariant_under_equivalences
-		) VALUES (?, ?, ?, ?, ?, ?)`)
+			id, relation, description,
+			required_source, required_target,
+			nlab_link, dual_property_id,
+			invariant_under_equivalences
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
 
 	const related_insert = db.prepare(
 		`INSERT INTO related_functor_properties (property_id, related_property_id) VALUES (?, ?)`,
@@ -416,6 +418,8 @@ function seed_functor_properties() {
 			property.id,
 			property.relation,
 			property.description,
+			property.required_source || null,
+			property.required_target || null,
 			property.nlab_link || null,
 			property.dual_property || null,
 			Number(property.invariant_under_equivalences),

--- a/databases/catdat/scripts/seed.types.ts
+++ b/databases/catdat/scripts/seed.types.ts
@@ -82,6 +82,8 @@ export type FunctorPropertyYaml = {
 	id: string
 	relation: string
 	description: string
+	required_source?: string
+	required_target?: string
 	nlab_link?: string | null
 	dual_property?: string | null
 	invariant_under_equivalences: boolean


### PR DESCRIPTION
A functor property such as being representable requires that the target category be **Set**. Previously, when non-representability could not be deduced (for example, in the case of a continuous functor), it was necessary to manually mark the functor as not representable, even when the target category was not **Set**. This has now been automated.

Specifically, in the file defining a functor property, one can add the optional fields `required_source` and `required_target`. In `representable.yaml`, the following has been added:

```yaml
required_target: Set
```

The deduction script now automatically marks this property as false for all functors whose target is not **Set**. More precisely, this is done before the main deduction procedure for functors starts, and the assignment is registered as "non-deduced" since it is too basic.