### PR TITLE
Add list page for content pages

### DIFF
--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -142,14 +142,6 @@ function render_content<T = Record<string, unknown>>(
 	return { meta_data: data as T, html: html_with_svg }
 }
 
-/**
- * Names of stored markdown files
- */
-export const content_ids = fs
-	.readdirSync(path.resolve('content'))
-	.filter((file) => file.endsWith('.md'))
-	.map((file) => file.replace(/\.md$/, ''))
-
 type ContentMetaData = {
 	title: string
 	description: string
@@ -167,4 +159,20 @@ export function get_rendered_content(id: string) {
 	const txt = fs.readFileSync(file_path, 'utf8')
 
 	return render_content<ContentMetaData>(txt)
+}
+
+/**
+ * Returns the list of metadata of content pages
+ */
+export function get_content_pages() {
+	return fs
+		.readdirSync(path.resolve('content'))
+		.filter((file) => file.endsWith('.md'))
+		.map((file) => {
+			const id = path.basename(file, '.md')
+			const txt = fs.readFileSync(path.resolve('content', file), 'utf8')
+			const data = matter(txt).data as ContentMetaData
+			return { ...data, id }
+		})
+		.sort((p, q) => p.title.localeCompare(q.title, 'en', { sensitivity: 'base' }))
 }

--- a/src/routes/category-implications/+page.svelte
+++ b/src/routes/category-implications/+page.svelte
@@ -27,5 +27,10 @@
 			category is self-dual and, for example, complete, it is automatically inferred
 			to be cocomplete as well.
 		</p>
+
+		<p class="hint">
+			For results that do not quite fit the implication model,
+			<a href="/content">content pages</a> are used instead.
+		</p>
 	{/snippet}
 </ImplicationListPage>

--- a/src/routes/content/+page.server.ts
+++ b/src/routes/content/+page.server.ts
@@ -1,0 +1,5 @@
+import { get_content_pages } from '$lib/server/markdown'
+
+export const load = () => {
+	return { pages: get_content_pages() }
+}

--- a/src/routes/content/+page.svelte
+++ b/src/routes/content/+page.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import MetaData from '$components/MetaData.svelte'
+
+	let { data } = $props()
+</script>
+
+<MetaData
+	title="Content pages"
+	description="For long-form content, particularly longer proofs and reusable lemmas, we use content pages."
+/>
+
+<h2>Content pages</h2>
+
+<p class="hint">
+	For long-form content, particularly longer proofs and reusable lemmas, we use content
+	pages.
+</p>
+
+<ul>
+	{#each data.pages as page}
+		<li>
+			<a href="/content/{page.id}">{page.title}</a>
+		</li>
+	{/each}
+</ul>

--- a/src/routes/content/[id]/+page.server.ts
+++ b/src/routes/content/[id]/+page.server.ts
@@ -1,13 +1,8 @@
-import { content_ids, get_rendered_content } from '$lib/server/markdown'
+import { get_rendered_content } from '$lib/server/markdown'
 import { error } from '@sveltejs/kit'
-import type { EntryGenerator } from './$types'
 import { batch } from '$lib/server/db.catdat'
 import sql from 'sql-template-tag'
 import type { StructureShort, PropertyShort } from '$lib/commons/types'
-
-export const entries: EntryGenerator = () => {
-	return content_ids.map((id) => ({ id }))
-}
 
 export const load = async (event) => {
 	const id = event.params.id

--- a/src/routes/functor-implications/+page.svelte
+++ b/src/routes/functor-implications/+page.svelte
@@ -17,5 +17,10 @@
 			properties exist. For example, the statement that a right adjoint is
 			continuous automatically implies that a left adjoint is cocontinuous.
 		</p>
+
+		<p class="hint">
+			For results that do not quite fit the implication model,
+			<a href="/content">content pages</a> are used instead.
+		</p>
 	{/snippet}
 </ImplicationListPage>


### PR DESCRIPTION
A new page `/content` is added which links to all content pages.

This is analogous to #166 (but lemmas have been deprecated).