### PR TITLE
Add the forgetful functor Ring → Mon and its left adjoint

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -255,6 +255,7 @@
 		"subobjects",
 		"subposet",
 		"subproset",
+		"subring",
 		"subscheme",
 		"subsemigroup",
 		"subsheaf",

--- a/databases/catdat/data/functors/forget_abelian.yaml
+++ b/databases/catdat/data/functors/forget_abelian.yaml
@@ -32,7 +32,7 @@ satisfied_properties:
     proof: 'This follows from the concrete construction of coequalizers, but it can also be proven as follows: Assume that $f,g : A \rightrightarrows B$ have coequalizer $p : B \to C$ in $\Ab$. If $G$ is any group and $h : B \to G$ is a homomorphism with $hf = hg$, consider the image factorization $h = i h''$ of $h$. We have $h'' f = h'' g$, and the image $\im(h)$ is abelian. Hence, there is a unique homomorphism $k : C \to \im(h)$ with $kp = h''$. Hence, $ik : C \to G$ satisfies $ikp = h$. Uniqueness follows since we already know that the forgetful functor is preserves epimorphisms.'
 
   - property: finitary
-    proof: 'Since the forgetful functor $U_{\Grp} : \Grp \to \Set$ is finitary and conservative, it suffices to prove that the composition $U_{\Ab,\Grp} \circ U_{\Grp} : \Ab \to \Set$ is finitary. This is just the forgetful functor $U_{\Ab} : \Ab \to \Set$ and therefore finitary.'
+    proof: 'Since the forgetful functor $U_{\Grp} : \Grp \to \Set$ is finitary and conservative, it suffices to prove that the composition $U_{\Grp} \circ U_{\Ab,\Grp} : \Ab \to \Set$ is finitary. This is just the forgetful functor $U_{\Ab} : \Ab \to \Set$ and therefore finitary.'
 
 unsatisfied_properties:
   - property: preserves finite coproducts

--- a/databases/catdat/data/functors/forget_addition.yaml
+++ b/databases/catdat/data/functors/forget_addition.yaml
@@ -1,0 +1,58 @@
+id: forget_addition
+name: forgetful functor from rings to monoids
+notation: $U_{\Ring,\Mon}$
+source: Ring
+target: Mon
+description: This functor maps a ring to its underlying multiplicative monoid, which as "forgotten" the addition of the ring.
+nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
+left_adjoint: monoid_ring
+
+tags:
+  - algebra
+  - forgetful
+
+related_functors:
+  - forget_ring
+
+satisfied_properties:
+  - property: right adjoint
+    proof: The monoid ring functor $\Mon \to \Ring$, $M \mapsto \IZ[M]$ is left adjoint to $U_{\Ring,\Mon}$.
+
+  - property: conservative
+    proof: 'This is because even the composition $U_{\Mon} \circ U_{\Ring,\Mon} : \Ring \to \Set$, namely the forgetful functor $U_{\Ring} : \Ring \to \Set$, is conservative.'
+
+  - property: finitary
+    proof: 'Since the forgetful functor $U_{\Mon} : \Mon \to \Set$ is finitary and conservative, it suffices to prove that the composition $U_{\Mon} \circ U_{\Ring,\Mon} : \Ring \to \Set$ is finitary. This is just the forgetful functor $U_{\Ring} : \Ring \to \Set$ and is therefore finitary.'
+
+  - property: preserves reflexive coequalizers
+    proof: 'Since the forgetful functor $U_{\Mon} : \Mon \to \Set$ preserves reflexive coequalizers (by Theorem 2.5 at the <a href="https://ncatlab.org/nlab/show/reflexive+coequalizer" target="_blank">nLab</a>) and is conservative, it suffices to prove that the composition $U_{\Mon} \circ U_{\Ring,\Mon} : \Ring \to \Set$ preserves reflexive coequalizers. This is just the forgetful functor $U_{\Ring} : \Ring \to \Set$ and therefore preserves reflexive coequalizers (by loc.cit.).'
+
+  - property: preserves epimorphisms
+    proof: This follows from <a href="https://en.wikipedia.org/wiki/Isbell's_zigzag_theorem" target="_blank">Isbell's zigzag theorem</a>.
+
+unsatisfied_properties:
+  - property: preserves initial objects
+    proof: The initial object in $\Ring$ is $\IZ$, but the initial object in $\Mon$ is the trivial monoid.
+
+  - property: full
+    proof: The map $\IZ \to \IZ$, $z \mapsto 1$ is compatible with multiplication, but not with addition.
+
+  - property: essentially surjective
+    proof: 'A necessary condition for a monoid to be the multiplicative monoid of a ring is that it has an <a href="https://en.wikipedia.org/wiki/Absorbing_element" target="_blank">absorbing element</a>. Thus, for example, $(\IN,+,0)$ is not contained in the essential image. Remark: even a monoid with an absorbing element does not necessarily come from a ring; see <a href="https://math.stackexchange.com/questions/3075364" target="_blank">MSE/3075364</a>.'
+
+  - property: preserves coequalizers
+    proof: >-
+      Consider the two homomorphisms $f,g : \IZ[X] \rightrightarrows \IZ[X]$ defined by $f(X) = X^2$ and $g(X) = 0$. Their coequalizer is the ring $\IZ[X] / \langle X^2 \rangle$. In particular, it identifies $X^2 + X$ and $X$. We will prove that the coequalizer of $U(f), U(g) : U(\IZ[X]) \rightrightarrows U(\IZ[X])$ in $\Mon$ does not identify these elements.
+
+
+      The coequalizer in $\Mon$ is the quotient of $U(\IZ[X])$ by the smallest congruence relation satisfying $p(X^2) \sim p(0)$. Thus, two polynomials $f,g$ are equivalent iff there is a finite sequence
+      $$f = f_0,f_1,\dotsc,f_n = g$$
+      where for each index $i$ we have
+      $$\{f_i,f_{i+1}\} = \{p(X^2) q(X), p(0) q(X)\}$$
+      for some polynomials $p,q$ (that depend on the index).
+
+
+      Let $v : \IZ[X] \to \IN \cup \{\infty\}$ denote the $X$-adic valuation, returning the exponent of the largest power of $X$ dividing a polynomial. We claim that if $v(f)=1$ and $f \sim g$, then $v(g)=1$, and in that case $f/g \in \IQ(X^2)$. In fact, consider a step in the sequence $\{f_i,f_{i+1}\} = \{p(X^2) q(X), p(0) q(X)\}$ as above. If $p(0)=0$, then $p(0) q(X) = 0$ has valuation $\infty$, and $p(X^2) q(X)$ has valuation $\geq 2$. If $p(0) \neq 0$, then the valuations of $p(X^2) q(X)$ and $p(0) q(X)$ both equal the valuation of $q(X)$. Therefore, $v(f_i)=1 \iff v(f_{i+1})=1$. Moreover, in that case the ratio $f_i / f_{i+1}$ is either $p(X^2) / p(0)$ (which is well-defined) or $p(0) / p(X^2)$, both of which lie in $\IQ(X^2)$. From this, the claim follows.
+
+
+      Now we can conclude that $X^2+X$ and $X$ are not equivalent: both have valuation $1$, but their quotient is $X+1$, which is not contained in $\IQ(X^2)$.

--- a/databases/catdat/data/functors/forget_ring.yaml
+++ b/databases/catdat/data/functors/forget_ring.yaml
@@ -13,6 +13,7 @@ tags:
 related_functors:
   - forget_group
   - forget_vector
+  - forget_addition
 
 satisfied_properties:
   - property: representable

--- a/databases/catdat/data/functors/free_group.yaml
+++ b/databases/catdat/data/functors/free_group.yaml
@@ -10,7 +10,9 @@ tags:
   - algebra
   - free
 
-related_functors: []
+related_functors:
+  - monoid_ring
+  - enveloping_group
 
 satisfied_properties:
   - property: left adjoint

--- a/databases/catdat/data/functors/monoid_ring.yaml
+++ b/databases/catdat/data/functors/monoid_ring.yaml
@@ -1,0 +1,43 @@
+id: monoid_ring
+name: monoid ring functor
+notation: $\IZ[-]$
+source: Mon
+target: Ring
+description: This functor maps a monoid $M$ to the monoid ring $\IZ[M]$, which consists of finite sums of elements in $M$.
+nlab_link: https://ncatlab.org/nlab/show/group+algebra
+
+tags:
+  - algebra
+  - free
+
+related_functors:
+  - free_group
+
+satisfied_properties:
+  - property: left adjoint
+    proof: 'This functor is left adjoint to the forgetful functor $U_{\Ring,\Mon} : \Ring \to \Mon$, which maps a ring to its underlying multiplicative monoid.'
+
+  - property: conservative
+    proof: 'Assume that $f : M \to N$ is a homomorphism of monoids such that the induced ring homomorphism $\IZ[f] : \IZ[M] \to \IZ[N]$ is bijective. Since the natural map $N \to \IZ[N]$ is injective, it follows immediately that $f$ is injective. Now let $n \in N$ and choose a preimage $\sum_m z_m \cdot m$ in $\IZ[M]$. Thus, $n = \sum_m z_m \cdot f(m)$. If $f(m) \neq n$ for all $m$, this would contradict the linear independence of $N$ in $\IZ[N]$. Thus, $n$ lies in the image of $f$.'
+
+  - property: preserves monomorphisms
+    proof: 'Let $f : M \to N$ be an injective monoid homomorphism. To show that the ring homomorphism $\IZ[f] : \IZ[M] \to \IZ[N]$ is injective, take an element in the kernel, say $\sum_{m \in M} z_m \cdot m$. Then $\sum_{m \in M} z_m \cdot f(m) = 0$ in $\IZ[N]$. Since the $f(m) \in N$ are pairwise distinct and linearly independent over $\IZ$, it follows that $z_m = 0$ for every $m \in M$, proving the claim.'
+
+  - property: preserves coreflexive equalizers
+    proof: 'Let $f,g : M \rightrightarrows N$ be homomorphisms of monoids with a common retraction $r : N \to M$, i.e. $r f = r g = \id_M$. Let $E = \{m \in M : f(m) = g(m)\}$ be the equalizer of $f$ and $g$. Consider an element $x \in \IZ[M]$ that is equalized by $\IZ[f], \IZ[g]$; we need to show that $x \in \IZ[E]$ (which is a subring of $\IZ[M]$, as we have seen before). Write $x = \sum_m z_m \cdot m$. Then $\sum_m z_m \cdot f(m) = \sum_m z_m \cdot g(m)$. If $n \in N$, comparing coefficients on both sides shows that $\sum_{m \in f^*(n)} z_m = \sum_{m \in g^*(n)} z_m$ in $\IZ$. Since $f$ and $g$ are injective, the fibers have at most one element. Now let $m \in M$ with $z_m \neq 0$. Let $n \coloneqq f(m)$. By the coefficient equation above, we deduce that $g^*(n)$ must be non-empty. Choose $m'' \in M$ with $g(m'') = n$. By applying $r$ to $f(m) = g(m'')$, we get $m = m''$. Thus, $m \in E$. This shows that $x \in \IZ[E]$.'
+
+unsatisfied_properties:
+  - property: full
+    proof: Take $M = \langle X \rangle$ and $N = \{1\}$, the free monoids of ranks $1$ and $0$, respectively. Their monoid rings are $\IZ[X]$ (the polynomial ring) and $\IZ$. The only ring homomorphism $\IZ[X] \to \IZ$ in the image of the functor is $X \mapsto 1$. But there are many more, such as $X \mapsto 0$.
+
+  - property: essentially surjective
+    proof: Every monoid ring is torsion-free (in fact, the underlying additive group is free abelian), so the ring $\IZ/2$ is not contained in the essential image.
+
+  - property: preserves terminal objects
+    proof: The monoid ring of the trivial monoid is the ring $\IZ$, which is not the zero ring.
+
+  - property: preserves equalizers
+    proof: 'Consider the free monoids $M = \langle a,b \rangle$, $N = \langle c \rangle$ and the homomorphisms $f,g : M \rightrightarrows N$ defined by $f(a)=c$, $f(b)=1$ and $g(a)=1$, $g(b)=c$. Then $a$ and $b$ are not contained in the equalizer $E$ of $f$ and $g$. More generally, $E$ contains exactly the words in $a,b$ in which $a$ and $b$ occur the same number of times. The element $a+b \in \IZ[M]$ is equalized by $\IZ[f], \IZ[g]$ since $\IZ[f]$ maps it to $c+1$, while $\IZ[g]$ maps it to $1+c$. But it is not contained in $\IZ[E]$.'
+
+  - property: cofinitary
+    proof: 'Consider the homomorphisms of commutative additive monoids $\IN^{n+1} \to \IN^n$ defined by $(k_1,\dotsc,k_{n+1}) \mapsto (k_1,\dotsc,k_n)$ for $n \geq 1$. Their limit is the power $\IN^\omega$. The natural ring homomorphism $\alpha : \IZ[\IN^\omega] \to \lim_n \IZ[\IN^n]$ is not surjective: The ring $\IZ[\IN^n]$ identifies with the polynomial ring $\IZ[X_1,\dotsc,X_n]$, and the transition maps are given by $X_{n+1} \mapsto 1$. The ring $\IZ[\IN^\omega]$ can be seen as a variant of the polynomial ring $\IZ[X_1,X_2,\dotsc]$ in which monomials are allowed to contain infinitely many variables, but a polynomial is still just a finite linear combination of such monomials. The homomorphism $\alpha$ inserts $1$ in the unused variables: $\alpha(X_1^{k_1} X_2^{k_2} \cdots)_n = X_1^{k_1} X_2^{k_2} \cdots X_n^{k_n}$. For every element in the image of $\alpha$ there is some $N \in \IN$ such that every entry in $\IZ[X_1,\dotsc,X_n]$ is a sum of at most $N$ monomials. Now consider the element $f \in \lim_n \IZ[X_1,\dotsc,X_n]$ defined by $f_n = \sum_{i=1}^n (X_i - 1)$. It is indeed contained in the limit, since $X_{n+1} \mapsto 1$ turns $f_{n+1}$ into $f_n$. Since $f_n$ is a sum of $n+1$ monomials, $f$ is not contained in the image of $\alpha$.'


### PR DESCRIPTION
This PR adds

- the forgetful functor **Ring** &rarr; **Mon**
- the monoid ring functor **Mon** &rarr; **Ring** (its left adjoint)

and decides their properties.