### PR TITLE
Record database downloads

### DIFF
--- a/databases/app/scripts/setup.ts
+++ b/databases/app/scripts/setup.ts
@@ -22,6 +22,7 @@ async function setup() {
 	console.info('\n--- Setup App database ---')
 	await create_visits_table()
 	await create_submissions_table()
+	await create_actions_table()
 }
 
 /**
@@ -58,4 +59,20 @@ async function create_submissions_table() {
     `)
 
 	console.info('Submissions table ready')
+}
+
+/**
+ * Creates the user actions table, used to record anonymously various user actions.
+ */
+async function create_actions_table() {
+	await db.execute(`
+        CREATE TABLE IF NOT EXISTS user_actions (
+            id INTEGER PRIMARY KEY,
+            action TEXT NOT NULL,
+            value TEXT,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+    `)
+
+	console.info('User actions table ready')
 }

--- a/src/routes/api/user_action/+server.ts
+++ b/src/routes/api/user_action/+server.ts
@@ -1,0 +1,37 @@
+import { query_app } from '$lib/server/db.app'
+import { is_object } from '$lib/server/utils'
+import sql from 'sql-template-tag'
+import { is_allowed } from '../track/track.utils'
+import { json } from '@sveltejs/kit'
+
+type ValidBody = { action: string; value?: string }
+
+const is_valid_body = (body: unknown): body is ValidBody =>
+	is_object(body) &&
+	'action' in body &&
+	typeof body.action === 'string' &&
+	(!('value' in body) || typeof body.value === 'string')
+
+export const POST = async (event) => {
+	if (!is_allowed(event)) return json({ error: 'Forbidden' }, { status: 403 })
+
+	if (event.request.headers.get('Content-Type') !== 'application/json') {
+		return json({ error: 'Invalid Request' }, { status: 400 })
+	}
+
+	const body: unknown = await event.request.json()
+
+	if (!is_valid_body(body)) {
+		return json({ error: 'Invalid Request Body' }, { status: 400 })
+	}
+
+	const { action, value = null } = body
+
+	const { err } = await query_app(
+		sql`INSERT INTO user_actions (action, value) VALUES (${action}, ${value})`,
+	)
+
+	if (err) return json({ error: 'Database error' }, { status: 500 })
+
+	return json({ message: 'User action has been recorded' })
+}

--- a/src/routes/download/+page.svelte
+++ b/src/routes/download/+page.svelte
@@ -1,5 +1,16 @@
 <script lang="ts">
 	import MetaData from '$components/MetaData.svelte'
+
+	/**
+	 * This is (temporarily) recorded to see if this feature is used at all.
+	 */
+	async function record_download() {
+		await fetch(`/api/user_action`, {
+			method: 'POST',
+			body: JSON.stringify({ action: 'download_database' }),
+			headers: { 'Content-Type': 'application/json' },
+		})
+	}
 </script>
 
 <MetaData title="Download" description="Download CatDat's SQLite database" />
@@ -18,7 +29,7 @@
 	beyond what is available through the web application.
 </p>
 
-<a href="/databases/catdat-snapshot.db" class="button" download>
+<a href="/databases/catdat-snapshot.db" class="button" download onclick={record_download}>
 	Download CatDat database
 </a>
 


### PR DESCRIPTION
When the database is downloaded, this is recorded. This way I can see if this feature is used at all. 

To make this work, a new table `user_actions` and a corresponding API endpoint have been created. This endpoint can also be used for other anonymous user actions.