### PR TITLE
Refactor queries: avoid type casts

### DIFF
--- a/databases/catdat/scripts/deduce-category-implications.ts
+++ b/databases/catdat/scripts/deduce-category-implications.ts
@@ -19,7 +19,17 @@ export function deduce_category_implications() {
  * then P^op ===> Q^op holds as well.
  */
 function create_dualized_category_implications() {
-	const implications_query = db.prepare(
+	const implications_query = db.prepare<
+		never[],
+		{
+			id: string
+			assumptions: string
+			conclusions: string
+			dual_assumptions: string
+			dual_conclusions: string
+			is_equivalence: 0 | 1
+		}
+	>(
 		`SELECT
 			v.id,
 			v.assumptions,
@@ -39,14 +49,7 @@ function create_dualized_category_implications() {
 		WHERE v.is_deduced = FALSE`,
 	)
 
-	const implications = implications_query.all() as {
-		id: string
-		assumptions: string
-		conclusions: string
-		dual_assumptions: string
-		dual_conclusions: string
-		is_equivalence: 0 | 1
-	}[]
+	const implications = implications_query.all()
 
 	const dualizable_implications = implications.filter(is_dualizable)
 

--- a/databases/catdat/scripts/deduce-functor-implications.ts
+++ b/databases/catdat/scripts/deduce-functor-implications.ts
@@ -19,7 +19,19 @@ export function deduce_functor_implications() {
  * categories (if any) need to be dualized as well.
  */
 function create_dualized_functor_implications() {
-	const implications_query = db.prepare(
+	const implications_query = db.prepare<
+		never[],
+		{
+			id: string
+			assumptions: string
+			conclusions: string
+			dual_assumptions: string
+			dual_source_assumptions: string
+			dual_target_assumptions: string
+			dual_conclusions: string
+			is_equivalence: 0 | 1
+		}
+	>(
 		`SELECT
 			v.id,
 			v.assumptions,
@@ -49,16 +61,7 @@ function create_dualized_functor_implications() {
 		WHERE v.is_deduced = FALSE`,
 	)
 
-	const implications = implications_query.all() as {
-		id: string
-		assumptions: string
-		conclusions: string
-		dual_assumptions: string
-		dual_source_assumptions: string
-		dual_target_assumptions: string
-		dual_conclusions: string
-		is_equivalence: 0 | 1
-	}[]
+	const implications = implications_query.all()
 
 	const dualizable_implications = implications.filter(is_dualizable)
 

--- a/databases/catdat/scripts/redundancies.ts
+++ b/databases/catdat/scripts/redundancies.ts
@@ -166,12 +166,12 @@ function get_redundant_unsatisfied_property(
  */
 function get_ignored_redundant_assignments(type: StructureType) {
 	const rows = db
-		.prepare(
-			`SELECT ${type}_id as structure_id, property_id
+		.prepare<never[], { structure_id: string; property_id: string }>(
+			`SELECT ${type}_id AS structure_id, property_id
 			FROM ${type}_property_assignments
 			WHERE check_redundancy = FALSE`,
 		)
-		.all() as { structure_id: string; property_id: string }[]
+		.all()
 
 	const grouped: Record<string, Set<string>> = {}
 

--- a/databases/catdat/scripts/test.ts
+++ b/databases/catdat/scripts/test.ts
@@ -57,8 +57,11 @@ function test_mutual_category_duals() {
 	const dict: Record<string, string | null> = {}
 
 	const categories = db
-		.prepare('SELECT id, dual_category_id FROM categories')
-		.all() as { id: string; dual_category_id: string | null }[]
+		.prepare<
+			never[],
+			{ id: string; dual_category_id: string | null }
+		>('SELECT id, dual_category_id FROM categories')
+		.all()
 
 	for (const { id, dual_category_id } of categories) {
 		dict[id] = dual_category_id
@@ -80,7 +83,7 @@ function test_mutual_category_duals() {
  */
 function test_properties_of_trivial_category() {
 	const rows = db
-		.prepare(
+		.prepare<never[], { property_id: string }>(
 			`SELECT property_id FROM category_property_assignments
 			WHERE category_id = '1' AND is_satisfied = FALSE`,
 		)
@@ -103,8 +106,11 @@ function test_mutual_property_duals(type: StructureType) {
 	const dict: Record<string, string | null> = {}
 
 	const properties = db
-		.prepare(`SELECT id, dual_property_id FROM ${type}_properties`)
-		.all() as { id: string; dual_property_id: string | null }[]
+		.prepare<
+			never[],
+			{ id: string; dual_property_id: string | null }
+		>(`SELECT id, dual_property_id FROM ${type}_properties`)
+		.all()
 
 	for (const { id, dual_property_id } of properties) {
 		dict[id] = dual_property_id
@@ -125,7 +131,7 @@ function test_mutual_property_duals(type: StructureType) {
  * been decided. If this test fails, property assignments or implications are missing.
  */
 function test_decided_structures(structure_ids: string[], type: StructureType) {
-	const unknown_query = db.prepare(
+	const unknown_query = db.prepare<[string], { id: string }>(
 		`SELECT p.id FROM ${type}_properties p WHERE NOT EXISTS
 			(SELECT 1 FROM ${type}_property_assignments
 				WHERE ${type}_id = ? AND property_id = p.id
@@ -134,7 +140,7 @@ function test_decided_structures(structure_ids: string[], type: StructureType) {
 	)
 
 	for (const structure_id of structure_ids) {
-		const res = unknown_query.all(structure_id) as { id: string }[]
+		const res = unknown_query.all(structure_id)
 		const unknown_properties = res.map((row) => row.id)
 
 		if (unknown_properties.length > 0) {
@@ -157,16 +163,16 @@ function test_properties_of_selected_structures(
 	expected: Record<string, Record<string, boolean>>,
 	type: StructureType,
 ) {
-	const property_query = db.prepare(
+	const property_query = db.prepare<
+		[string],
+		{ property_id: string; is_satisfied: 0 | 1 }
+	>(
 		`SELECT property_id, is_satisfied FROM ${type}_property_assignments
 		WHERE ${type}_id = ? AND is_satisfied IS NOT NULL`,
 	)
 
 	for (const structure_id in expected) {
-		const properties = property_query.all(structure_id) as {
-			property_id: string
-			is_satisfied: 0 | 1
-		}[]
+		const properties = property_query.all(structure_id)
 
 		for (const { property_id, is_satisfied } of properties) {
 			const ok = Boolean(is_satisfied) === expected[structure_id][property_id]

--- a/databases/catdat/scripts/utils/categories.ts
+++ b/databases/catdat/scripts/utils/categories.ts
@@ -18,11 +18,11 @@ export type NormalizedCategoryImplication = {
  */
 export function get_categories(db: Database) {
 	return db
-		.prepare(
-			`SELECT id, name, dual_category_id as dual
+		.prepare<never[], CategoryMeta>(
+			`SELECT id, name, dual_category_id AS dual
             FROM categories ORDER BY lower(name)`,
 		)
-		.all() as CategoryMeta[]
+		.all()
 }
 
 /**
@@ -38,16 +38,19 @@ export function get_normalized_category_implications(
 	db: Database,
 ): NormalizedCategoryImplication[] {
 	const all_implications_db = db
-		.prepare(
+		.prepare<
+			never[],
+			{
+				id: string
+				assumptions: string
+				conclusions: string
+				is_equivalence: 0 | 1
+			}
+		>(
 			`SELECT id, assumptions, conclusions, is_equivalence
 			FROM category_implications_view`,
 		)
-		.all() as {
-		id: string
-		assumptions: string
-		conclusions: string
-		is_equivalence: 0 | 1
-	}[]
+		.all()
 
 	const implications: NormalizedCategoryImplication[] = []
 

--- a/databases/catdat/scripts/utils/deduction.ts
+++ b/databases/catdat/scripts/utils/deduction.ts
@@ -55,15 +55,15 @@ export function get_normalized_implications(
  */
 export function get_properties_dict(db: Database, type: StructureType) {
 	const properties = db
-		.prepare(
+		.prepare<never[], PropertyMeta>(
 			`SELECT
-				p.id, p.dual_property_id as dual, p.relation,
+				p.id, p.dual_property_id AS dual, p.relation,
 				r.conditional
 			FROM ${type}_properties p
 			INNER JOIN relations r ON r.relation = p.relation
 			ORDER BY lower(p.id)`,
 		)
-		.all() as PropertyMeta[]
+		.all()
 
 	const dict: Record<string, PropertyMeta> = {}
 
@@ -83,15 +83,21 @@ export function get_property_assignments(
 	type: StructureType,
 ) {
 	const rows = db
-		.prepare(
-			`SELECT property_id, ${type}_id as structure_id, is_satisfied
+		.prepare<
+			never[],
+			{
+				property_id: string
+				structure_id: string
+				is_satisfied: 0 | 1 | null
+			}
+		>(
+			`SELECT
+				property_id,
+				${type}_id AS structure_id,
+				is_satisfied
 			FROM ${type}_property_assignments`,
 		)
-		.all() as {
-		property_id: string
-		structure_id: string
-		is_satisfied: 0 | 1 | null
-	}[]
+		.all()
 
 	const grouped: Record<
 		string,
@@ -133,16 +139,24 @@ export function get_property_assignments_by_deduction(
 	type: StructureType,
 ) {
 	const rows = db
-		.prepare(
-			`SELECT property_id, ${type}_id as structure_id, is_satisfied, is_deduced
-			FROM ${type}_property_assignments WHERE is_satisfied IS NOT NULL`,
+		.prepare<
+			never[],
+			{
+				property_id: string
+				structure_id: string
+				is_satisfied: 0 | 1
+				is_deduced: 0 | 1
+			}
+		>(
+			`SELECT
+				property_id,
+				${type}_id AS structure_id,
+				is_satisfied,
+				is_deduced
+			FROM ${type}_property_assignments
+			WHERE is_satisfied IS NOT NULL`,
 		)
-		.all() as {
-		property_id: string
-		structure_id: string
-		is_satisfied: 0 | 1
-		is_deduced: 0 | 1
-	}[]
+		.all()
 
 	const grouped: Record<
 		string,

--- a/databases/catdat/scripts/utils/functors.ts
+++ b/databases/catdat/scripts/utils/functors.ts
@@ -26,34 +26,40 @@ type NormalizedFunctorImplication = {
  */
 export function get_functors(db: Database): FunctorMeta[] {
 	const rows = db
-		.prepare(
+		.prepare<
+			never[],
+			{
+				id: string
+				name: string
+				source: string
+				target: string
+				source_props: string
+				target_props: string
+			}
+		>(
 			`SELECT
-				id, name, source, target,
+				id,
+				name,
+				source,
+				target,
 				(
 					SELECT json_group_array(property_id) FROM (
 						SELECT property_id
 						FROM category_property_assignments
 						WHERE category_id = source AND is_satisfied = TRUE
 					)
-				) as source_props,
+				) AS source_props,
 				(
 					SELECT json_group_array(property_id) FROM (
 						SELECT property_id
 						FROM category_property_assignments
 						WHERE category_id = target AND is_satisfied = TRUE
 					)
-				) as target_props
+				) AS target_props
 			FROM functors
 			ORDER BY lower(name)`,
 		)
-		.all() as {
-		id: string
-		name: string
-		source: string
-		target: string
-		source_props: string
-		target_props: string
-	}[]
+		.all()
 
 	return rows.map((row) => ({
 		id: row.id,
@@ -78,20 +84,23 @@ export function get_normalized_functor_implications(
 	db: Database,
 ): NormalizedFunctorImplication[] {
 	const all_implications_db = db
-		.prepare(
+		.prepare<
+			never[],
+			{
+				id: string
+				assumptions: string
+				source_assumptions: string
+				target_assumptions: string
+				conclusions: string
+				is_equivalence: 0 | 1
+			}
+		>(
 			`SELECT
                 id, assumptions, source_assumptions, target_assumptions,
 				conclusions, is_equivalence
 			FROM functor_implications_view`,
 		)
-		.all() as {
-		id: string
-		assumptions: string
-		source_assumptions: string
-		target_assumptions: string
-		conclusions: string
-		is_equivalence: 0 | 1
-	}[]
+		.all()
 
 	const implications: NormalizedFunctorImplication[] = []
 

--- a/src/lib/server/consistency.ts
+++ b/src/lib/server/consistency.ts
@@ -119,7 +119,6 @@ export function get_missing_combinations(type: StructureType) {
 		dual_property_id: string | null
 	}>({
 		sql: `SELECT id, dual_property_id FROM ${type}_properties ORDER BY lower(id)`,
-		values: [],
 	})
 
 	if (err) return { err, missing_combinations: [] }
@@ -135,7 +134,6 @@ export function get_missing_combinations(type: StructureType) {
 		ON a.${type}_id = an.${type}_id
 		WHERE a.is_satisfied = TRUE AND an.is_satisfied = FALSE
 	`,
-		values: [],
 	})
 
 	if (err_existing) return { err: err_existing, missing_combinations: [] }

--- a/src/lib/server/db.app.ts
+++ b/src/lib/server/db.app.ts
@@ -17,9 +17,15 @@ db_app.execute('PRAGMA foreign_keys = ON')
  * Small wrapper around db.execute to handle errors,
  * use sql templates, and specify the type of the result.
  */
-export async function query_app<T>(stmt: { sql: string; values: any[] }) {
+export async function query_app<T>({
+	sql,
+	values = [],
+}: {
+	sql: string
+	values?: any[]
+}) {
 	try {
-		const { rows } = await db_app.execute(stmt.sql, stmt.values)
+		const { rows } = await db_app.execute(sql, values)
 		return { rows: rows as T[], err: null }
 	} catch (err) {
 		console.error(err)
@@ -32,16 +38,16 @@ export async function query_app<T>(stmt: { sql: string; values: any[] }) {
  * use sql templates, and specify the type of the result.
  */
 export async function batch_app<T extends any[]>(
-	queries: { sql: string; values: any[] }[],
+	queries: { sql: string; values?: any[] }[],
 ) {
 	try {
 		const results = await db_app.batch(
-			queries.map((query) => ({
-				sql: query.sql,
-				args: query.values,
-			})),
+			queries.map(({ sql, values = [] }) => ({ sql, args: values ?? [] })),
 		)
-		return { results: results.map(({ rows }) => rows) as Arrayed<T>, err: null }
+		return {
+			results: results.map(({ rows }) => rows) as Arrayed<T>,
+			err: null,
+		}
 	} catch (err) {
 		console.error(err)
 		return { results: null, err: err as LibsqlError }

--- a/src/lib/server/db.catdat.ts
+++ b/src/lib/server/db.catdat.ts
@@ -13,10 +13,10 @@ const db = new Database(db_path, { readonly: true, fileMustExist: true })
  * Small wrapper around db.prepare.all to handle errors,
  * use sql templates, and specify the type of the result.
  */
-export function query<T>(stmt: { sql: string; values: any[] }) {
+export function query<T>({ sql, values = [] }: { sql: string; values?: any[] }) {
 	try {
-		const rows = db.prepare(stmt.sql).all(...stmt.values)
-		return { rows: rows as T[], err: null }
+		const rows = db.prepare<unknown[], T>(sql).all(...values)
+		return { rows, err: null }
 	} catch (err) {
 		console.error(err)
 		return { rows: null, err: err as SqliteError }
@@ -27,13 +27,13 @@ export function query<T>(stmt: { sql: string; values: any[] }) {
  * Small wrapper around db.transaction to handle errors
  * use sql templates, and specify the type of the result.
  */
-export function batch<T extends any[]>(queries: { sql: string; values: any[] }[]) {
+export function batch<T extends any[]>(queries: { sql: string; values?: any[] }[]) {
 	try {
 		const run_batch = db.transaction(() => {
 			const results = []
 
-			for (const query of queries) {
-				const result = db.prepare(query.sql).all(...query.values)
+			for (const { sql, values = [] } of queries) {
+				const result = db.prepare(sql).all(...values)
 				results.push(result)
 			}
 

--- a/src/lib/server/properties.ts
+++ b/src/lib/server/properties.ts
@@ -5,7 +5,6 @@ import { error } from '@sveltejs/kit'
 export function get_property_ids(type: StructureType) {
 	const { rows, err } = query<{ id: string }>({
 		sql: `SELECT id FROM ${type}_properties ORDER BY lower(id)`,
-		values: [],
 	})
 
 	if (err) error(500, 'Failed to load properties')

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -27,7 +27,6 @@ export function search_handler(event: RequestEvent, type: StructureType): Search
 		dual_property_id: string | null
 	}>({
 		sql: `SELECT id, dual_property_id FROM ${type}_properties ORDER BY lower(id)`,
-		values: [],
 	})
 
 	if (err_all) error(500, 'Failed to load properties')

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -55,7 +55,7 @@ export const load = async (event) => {
 			`,
 		sql`SELECT
                 country,
-                COUNT(*) as count
+                COUNT(*) AS count
             FROM visits
             GROUP BY country
             ORDER BY count DESC
@@ -63,14 +63,14 @@ export const load = async (event) => {
 			`,
 		sql`SELECT
                 theme,
-                COUNT(*) as count,
+                COUNT(*) AS count,
 				 ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER (), 1) AS percentage
             FROM visits
             GROUP BY theme
             ORDER BY theme`,
 		sql`SELECT
                 device_type,
-                COUNT(*) as count,
+                COUNT(*) AS count,
 				ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER (), 1) AS percentage
             FROM visits
             GROUP BY device_type

--- a/src/routes/category/[id]/+page.server.ts
+++ b/src/routes/category/[id]/+page.server.ts
@@ -42,8 +42,8 @@ export const load = async (event) => {
 				c.description,
 				c.nlab_link,
 				c.dual_category_id,
-				d.name as dual_category_name,
-				d.notation as dual_category_notation
+				d.name AS dual_category_name,
+				d.notation AS dual_category_notation
 			FROM categories c
 			LEFT JOIN categories d ON d.id = c.dual_category_id
 			WHERE c.id = ${id}

--- a/src/routes/functor/[id]/+page.server.ts
+++ b/src/routes/functor/[id]/+page.server.ts
@@ -41,10 +41,10 @@ export const load = async (event) => {
 				f.target,
 				f.description,
 				f.nlab_link,
-                s.name as source_name,
-				t.name as target_name,
-				s.notation as source_notation,
-				t.notation as target_notation
+                s.name AS source_name,
+				t.name AS target_name,
+				s.notation AS source_notation,
+				t.notation AS target_notation
             FROM functors f
             INNER JOIN categories s ON s.id = f.source
             INNER JOIN categories t ON t.id = f.target


### PR DESCRIPTION
This is a small refactoring of the queries in the application and the scripts.

- allow passing no `values`, defaults to empty array
- use built-in generic for `db.prepare` (from better-sqlite3) to avoid type casts (or rather: let the package do the type cast, there is no runtime check)
- use uppercase `AS` for all aliases in SQL queries to distinguish them easily (in global searches) from type casts in TypeScript.

So instead of

```ts
const categories = db.prepare(`SELECT id FROM categories WHERE ...`).all() as Category[]
```

we can write

```ts
const categories = db.prepare<never[], Category>(`SELECT id FROM categories WHERE ...`).all()
```

Here, the first generic allows type checking of the passed arguments to `.all()` resp. `.get()`. When no arguments should be passed, `never[]` is appropriate.