### PR TITLE
Add various properties of the category of Banach spaces

### DIFF
--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -51,6 +51,9 @@ unsatisfied_properties:
   - property: unital
     proof: See <a href="https://math.stackexchange.com/questions/5033161" target="_blank">MSE/5033161</a>.
 
+  - property: counital
+    proof: The canonical morphism $X \sqcup Y \to X \times Y$ is surjective, and therefore an epimorphism. Hence, if it were also a strong monomorphism, it would be an isomorphism. However, for example, when $X = Y = \IC$, the norms do not agree.
+
   - property: co-Malcev
     proof: See the comments to <a href="https://mathoverflow.net/a/509555/2841" target="_blank">MO/509552</a>.
 

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -35,6 +35,13 @@ satisfied_properties:
   - property: cocartesian cofiltered limits
     proof: 'If $X$ is a Banach space and $(Y_i)$ is a cofiltered diagram of Banach spaces, the canonical map $X \oplus \lim_i Y_i \to \lim_i (X \oplus Y_i)$ is an isomorphism: Since the forgetful functor $\Ban \to \Vect$ preserves finite coproducts and all limits, and $\Vect$ has the claimed property (see <a href="/category-implication/biproducts_cartesian_filtered_colimits">here</a>), the canonical map is bijective. It remains to show that it is isometric. For $(x,y) \in X \oplus \lim_i Y_i$ the norm in the domain is $|x| + \sup_i |y_i|$, and the norm in the codomain is $\sup_i (|x| + |y_i|)$, and these clearly agree.'
 
+  - property: regular
+    proof: >-
+      It suffices to prove that regular epimorphisms are stable under pullbacks. We will use their classification below.
+      So let $f : V \to W$ be a regular epimorphism of Banach spaces and let $g : T \to W$ be any morphism. We need to show that the projection $V \times_W T \to T$ is a regular epimorphism.
+      Clearly, it is surjective since $f$ is surjective. Now let $t \in T$ be an element of norm $<1$. Since $g$ is a linear contraction, $g(t)$ has norm $<1$. Since $f$ is a regular epimorphism, there is some $v \in V$ with norm $<1$ and $f(v) = g(t)$.
+      Then $(v,t) \in V \times_W T$ has norm $\max(|v|,|t|) < 1$ and provides a preimage of $t$.
+
 unsatisfied_properties:
   - property: skeletal
     proof: This is trivial.

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -49,7 +49,7 @@ unsatisfied_properties:
     proof: If $\Omega$ is a regular subobject classifier, then by the classification of regular monomorphisms, $\Hom(X,\Omega)$ is isomorphic to the set of closed subspaces of $X$ for any Banach space $X$. For $X = \IC$ this implies that there are exactly two vectors in $\Omega$ with norm $\leq 1$, which is absurd. (For $\Omega = 0$ there is just one, and for $\Omega \neq 0$ there are infinitely many.)
 
   - property: unital
-    proof: See <a href="https://math.stackexchange.com/questions/5033161" target="_blank">MSE/5033161</a>.
+    proof: The canonical morphism $X \sqcup Y \to X \times Y$ is injective, and therefore a monomorphism. Hence, if it were also a strong epimorphism, it would be an isomorphism. However, for example, when $X = Y = \IC$, the norms do not agree.
 
   - property: counital
     proof: The canonical morphism $X \sqcup Y \to X \times Y$ is surjective, and therefore an epimorphism. Hence, if it were also a strong monomorphism, it would be an isomorphism. However, for example, when $X = Y = \IC$, the norms do not agree.

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -38,28 +38,28 @@ satisfied_properties:
   - property: regular
     proof: >-
       It suffices to prove that regular epimorphisms are stable under pullbacks. We will use their classification via open unit balls below.
-      So let $f : V \to W$ be a regular epimorphism of Banach spaces and let $g : T \to W$ be any morphism. We need to show that the projection $V \times_W T \to T$ is a regular epimorphism.
-      Let $t \in T$ be an element of norm $<1$. Since $g$ is a linear contraction, $g(t)$ has norm $<1$. Since $f$ is a regular epimorphism, there is some $v \in V$ with norm $<1$ and $f(v) = g(t)$.
-      Then $(v,t) \in V \times_W T$ is a preimage of $t$ with norm $\max(|v|,|t|) < 1$.
+      So let $f : X \to Y$ be a regular epimorphism of Banach spaces and let $g : T \to Y$ be any morphism. We need to show that the projection $X \times_Y T \to X$ is a regular epimorphism.
+      Let $t \in T$ be an element of norm $<1$. Since $g$ is a linear contraction, $g(t)$ has norm $<1$. Since $f$ is a regular epimorphism, there is some $x \in X$ with norm $<1$ and $f(x) = g(t)$.
+      Then $(x,t) \in X \times_Y T$ is a preimage of $t$ with norm $\max(|x|,|t|) < 1$.
 
 unsatisfied_properties:
   - property: skeletal
     proof: This is trivial.
 
   - property: balanced
-    proof: The linear map $\IC \to \IC$, $x \mapsto x/2$ is a counterexample. It is bijective, hence a mono- and epimorphism, but not isometric and therefore no isomorphism.
+    proof: The linear map $\IC \to \IC$, $x \mapsto x/2$ with the usual norm on $\IC$ is a counterexample. It is bijective, hence a mono- and epimorphism, but not isometric and therefore no isomorphism.
 
   - property: CSP
-    proof: By using the concrete description of products and coproducts, for the constant family $X_n = \IC$ the canonical morphism $\coprod_n X_n \to \prod_n X_n$ becomes the canonical inclusion map $\ell^1 \hookrightarrow \ell^\infty$. This is not an epimorphism (i.e., has no dense image) since the closure of the image is precisely $c_0$. So for example, $(1,1,\dotsc)$ is not contained in the closure of the image.
+    proof: By using the concrete description of products and coproducts, for the constant family $X_n = \IC$ equipped with the usual norm, the canonical morphism $\coprod_n X_n \to \prod_n X_n$ becomes the canonical inclusion map $\ell^1 \hookrightarrow \ell^\infty$. This is not an epimorphism (i.e., has no dense image) since the closure of the image is precisely $c_0$. So for example, $(1,1,\dotsc)$ is not contained in the closure of the image.
 
   - property: regular subobject classifier
     proof: If $\Omega$ is a regular subobject classifier, then by the classification of regular monomorphisms, $\Hom(X,\Omega)$ is isomorphic to the set of closed subspaces of $X$ for any Banach space $X$. For $X = \IC$ this implies that there are exactly two vectors in $\Omega$ with norm $\leq 1$, which is absurd. (For $\Omega = 0$ there is just one, and for $\Omega \neq 0$ there are infinitely many.)
 
   - property: regular quotient object classifier
     proof: >-
-      Assume that $\Psi$ is a regular quotient object classifier in $\Ban$. For a Banach space $V$ let $S(V)$ be the set of closed subspaces of $V$. Then for any Banach space $V$ the map
-      $$\Hom(\Psi,V) \to S(V), \quad f \mapsto \overline{\im(f)}$$
-      is bijective. In particular, there is a morphism $f : \Psi \to V$ with dense image, i.e. an epimorphism. But this contradicts the already established fact that $\Ban$ is well-copowered (since it is locally presentable).
+      Assume that $\Psi$ is a regular quotient object classifier in $\Ban$. For a Banach space $X$ let $S(X)$ be the set of closed subspaces of $X$. Then for any Banach space $X$ the map
+      $$\Hom(\Psi,X) \to S(X), \quad f \mapsto \overline{\im(f)}$$
+      is bijective. In particular, there is a morphism $f : \Psi \to X$ with dense image, i.e. an epimorphism. But this contradicts the already established fact that $\Ban$ is well-copowered (since it is locally presentable).
       Alternatively, we may use that for every cardinal $\kappa$ the Banach space $\ell^2(\kappa^+)$ has no dense subset of size $\kappa$.
 
   - property: unital
@@ -72,10 +72,10 @@ unsatisfied_properties:
     proof: See the comments to <a href="https://mathoverflow.net/a/509555/2841" target="_blank">MO/509552</a>.
 
   - property: filtered-colimit-stable monomorphisms
-    proof: 'The proof is similar to <a href="/category/Met">$\Met$</a>. For $n \geq 1$ let $V_n$ be the Banach space with underlying vector space $\IC$ and the norm $|x|_n \coloneqq \frac{1}{n} |x|$. For $n \leq m$ the identity map provides a morphism $V_n \to V_m$, which is clearly a monomorphism (also an epimorphism by the way, but an isomorphism iff $n=m$). Let $V$ be the colimit of all $V_n$ in the category of semi-normed vector spaces. It is constructed as the colimit in the category of vector spaces with the semi-norm $|x| \coloneqq \inf \{|x|_m : n \leq m \}$ for $x \in V_n$. So clearly, the semi-norm is zero. Hence, the colimit in the category of normed vector spaces is $0$. The colimit in the category of Banach spaces is its completion, also $0$. Thus, the monomorphisms $V_1 \to V_n$ become $V_1 \to 0$ in the colimit.'
+    proof: 'The proof is similar to <a href="/category/Met">$\Met$</a>. For $n \geq 1$ let $X_n$ be the Banach space with underlying vector space $\IC$ and the norm $|x|_n \coloneqq \frac{1}{n} |x|$. For $n \leq m$ the identity map provides a morphism $X_n \to X_m$, which is clearly a monomorphism (also an epimorphism by the way, but an isomorphism iff $n=m$). Let $X$ be the colimit of all $X_n$ in the category of semi-normed vector spaces. It is constructed as the colimit in the category of vector spaces with the semi-norm $|x| \coloneqq \inf \{|x|_m : n \leq m \}$ for $x \in X_n$. So clearly, the semi-norm is zero. Hence, the colimit in the category of normed vector spaces is $0$. The colimit in the category of Banach spaces is its completion, which is also $0$. Thus, the monomorphisms $X_1 \hookrightarrow X_n$ become the zero map $X_1 \to 0$ in the colimit, which is not a monomorphism.'
 
   - property: cofiltered-limit-stable epimorphisms
-    proof: 'We show that epimorphisms are not stable under sequential limits. Let $X_n = Y_n = \IC$ for all $n \geq 0$. The transition morphism $Y_{n+1} \to Y_n$ is the identity, and the transition morphism $X_{n+1} \to X_n$ is $x \mapsto x/2$. The morphisms $X_n \to Y_n$, $x \mapsto x/2^n$ are compatible with the transitions, and they are surjective, hence epimorphisms. Now we check $\lim_n X_n = 0$: An element $(x_n) \in \lim_n X_n$ is a family of complex numbers satisfying $x_n = x_{n+1}/2$ <i>and</i> $\sup_n |x_n| < \infty$. But then $x_n = 2^n x_0$ and this can only be bounded when $x_0=0$. Hence, $0 = \lim_n X_n \to \lim_n Y_n = \IC$ is no epimorphism.'
+    proof: 'We show that epimorphisms are not stable under sequential limits. Let $X_n = Y_n = \IC$ for all $n \geq 0$, equipped with the usual norm. The transition morphism $Y_{n+1} \to Y_n$ is the identity, and the transition morphism $X_{n+1} \to X_n$ is $x \mapsto x/2$. The morphisms $X_n \to Y_n$, $x \mapsto x/2^n$ are compatible with the transitions, and they are surjective, hence epimorphisms. Now we check $\lim_n X_n = 0$: An element $(x_n) \in \lim_n X_n$ is a family of complex numbers satisfying $x_n = x_{n+1}/2$ <i>and</i> $\sup_n |x_n| < \infty$. But then $x_n = 2^n x_0$ and this can only be bounded when $x_0=0$. Hence, $0 = \lim_n X_n \to \lim_n Y_n = \IC$ is no epimorphism.'
 
 special_objects:
   initial object:
@@ -83,9 +83,9 @@ special_objects:
   terminal object:
     description: trivial Banach space
   coproducts:
-    description: 'The coproduct of a family of Banach spaces $(B_i,|{-}|)_{i \in I}$ is the subspace $\bigl\{x \in \prod_{i \in I} B_i : \sum_{i \in I} |x_i| < \infty\bigr\}$ of their vector space product equipped with the $1$-norm $|x|_1 \coloneqq \sum_{i \in I} |x_i|$.'
+    description: 'The coproduct of a family of Banach spaces $(X_i,|{-}|)_{i \in I}$ is the subspace $\bigl\{x \in \prod_{i \in I} X_i : \sum_{i \in I} |x_i| < \infty\bigr\}$ of their vector space product equipped with the $1$-norm $|x|_1 \coloneqq \sum_{i \in I} |x_i|$.'
   products:
-    description: 'The product of a family of Banach spaces $(B_i,|{-}|)_{i \in I}$ is the subspace $\bigl\{x \in \prod_{i \in I} B_i : \sup_{i \in I} |x_i| < \infty\bigr\}$ of their vector space product equipped with the $\sup$-norm $|x|_\infty \coloneqq \sup_{i \in I} |x_i|$.'
+    description: 'The product of a family of Banach spaces $(X_i,|{-}|)_{i \in I}$ is the subspace $\bigl\{x \in \prod_{i \in I} X_i : \sup_{i \in I} |x_i| < \infty\bigr\}$ of their vector space product equipped with the $\sup$-norm $|x|_\infty \coloneqq \sup_{i \in I} |x_i|$.'
 
 special_morphisms:
   isomorphisms:
@@ -108,14 +108,14 @@ special_morphisms:
       (3) implies (1): If $U \subseteq Y$ is a closed subspace, then the inclusion is the kernel of the projection $Y \to Y/U$, where $Y/U$ is the <a href="https://math.stackexchange.com/questions/319867" target="_blank">well-known</a> quotient Banach space.
   regular epimorphisms:
     description: >-
-      For a linear contraction $f : V \to W$ the following are equivalent: (1) $f$ is a regular epimorphism. (2) The norm on $W$ is given by $|w| = \inf \{|v| : f(v) = w\}$. (3) $f$ maps the open unit ball of $V$ onto the open unit ball of $W$.
+      For a linear contraction $f : X \to Y$ the following are equivalent: (1) $f$ is a regular epimorphism. (2) The norm on $Y$ is given by $|y| = \inf \{|x| : f(x) = y\}$. (3) $f$ maps the open unit ball of $X$ onto the open unit ball of $Y$.
     proof: >-
       First of all, notice that all three conditions imply that $f$ is surjective.
 
-      (1) implies (2): This follows immediately from the concrete construction of coequalizers, and the quotient Banach space $V/U$ in particular.
+      (1) implies (2): This follows immediately from the concrete construction of coequalizers, and the quotient Banach space in particular.
 
-      (2) implies (1): Let $U \coloneqq \ker(f)$. Then $U$ is a closed subspace of $V$, and $f$ induces a bijective linear contraction $\tilde{f} : V/U \to W$. It is isometric by assumption on $f$ and the definition of the norm on $V/U$. Thus, $\tilde{f}$ is an isomorphism. Since $V/U$ is the cokernel of $U \hookrightarrow V$, it follows that $f$ is a regular epimorphism.
+      (2) implies (1): Let $U \coloneqq \ker(f)$. Then $U$ is a closed subspace of $X$, and $f$ induces a bijective linear contraction $\tilde{f} : X/U \to Y$. It is isometric by assumption on $f$ and the definition of the norm on $X/U$. Thus, $\tilde{f}$ is an isomorphism. Since $X/U$ is the cokernel of $U \hookrightarrow X$, it follows that $f$ is a regular epimorphism.
 
-      (2) implies (3): Let $w \in W$ be an element with $|w| < 1$. Since $|w|$ is the infimum of all $|v|$ with $f(v)=w$, there is some $v$ with $f(v)=w$ and $|v| < 1$.
+      (2) implies (3): Let $y \in Y$ be an element with $|y| < 1$. Since $|y|$ is the infimum of all $|x|$ with $f(x)=y$, there is some $x$ with $f(x)=y$ and $|x| < 1$.
 
-      (3) implies (2): Let $w \in W$. Since $f$ is a linear contraction, the inequality $|w| \leq \inf \{|v| : f(v) = w\}$ holds. Let $\varepsilon > 0$. Consider $w' \coloneqq w / (|w| + \varepsilon)$. Then $|w'| < 1$. Thus, by assumption, there is some $v' \in V$ with $|v'| < 1$ and $f(v') =w'$. Let $v \coloneqq (|w| + \varepsilon) v'$. Then $f(v) = w$ and $|v| < |w| + \varepsilon$. Thus, the infimum in question is $\leq |w| + \varepsilon$, for every $\varepsilon > 0$, and hence $\leq |w|$.
+      (3) implies (2): Let $y \in Y$. Since $f$ is a linear contraction, the inequality $|y| \leq \inf \{|x| : f(x) = y\}$ holds. Let $\varepsilon > 0$. Consider $y' \coloneqq y / (|y| + \varepsilon)$. Then $|y'| < 1$. Thus, by assumption, there is some $x' \in X$ with $|x'| < 1$ and $f(x') =y'$. Let $x \coloneqq (|y| + \varepsilon) x'$. Then $f(x) = y$ and $|x| < |y| + \varepsilon$. Thus, the infimum in question is $\leq |y| + \varepsilon$, for every $\varepsilon > 0$, and hence $\leq |y|$.

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -76,9 +76,9 @@ special_objects:
   terminal object:
     description: trivial Banach space
   coproducts:
-    description: 'The coproduct of a family of Banach spaces $(B_i)$ is the subspace $\bigl\{x \in \prod_i B_i : \sum_i |x_i| < \infty\bigr\}$ equipped with the $1$-norm $|x| \coloneqq \sum_i |x_i|$.'
+    description: 'The coproduct of a family of Banach spaces $(B_i,|{-}|)_{i \in I}$ is the subspace $\bigl\{x \in \prod_{i \in I} B_i : \sum_{i \in I} |x_i| < \infty\bigr\}$ of their vector space product equipped with the $1$-norm $|x|_1 \coloneqq \sum_{i \in I} |x_i|$.'
   products:
-    description: direct products with the $\sup$-norm
+    description: 'The product of a family of Banach spaces $(B_i,|{-}|)_{i \in I}$ is the subspace $\bigl\{x \in \prod_{i \in I} B_i : \sup_{i \in I} |x_i| < \infty\bigr\}$ of their vector space product equipped with the $\sup$-norm $|x|_\infty \coloneqq \sup_{i \in I} |x_i|$.'
 
 special_morphisms:
   isomorphisms:

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -86,3 +86,14 @@ special_morphisms:
   regular monomorphisms:
     description: closed embeddings
     proof: The non-trivial direction follows from the <a href="https://math.stackexchange.com/questions/319867" target="_blank">well-known fact</a> that for every closed subspace of a Banach space its quotient space is again a Banach space.
+  regular epimorphisms:
+    description: >-
+      For a linear contraction $f : V \to W$ the following are equivalent: (1) $f$ is a regular epimorphism. (2) $f$ is surjective and the norm on $W$ is given by $|w| = \inf \{|v| : f(v) = w\}$. (3) $f$ is surjective and $f$ maps the open unit ball of $V$ onto the open unit ball of $W$.
+    proof: >-
+      (1) implies (2): This follows immediately from the concrete construction of coequalizers, and the quotient Banach space $V/U$ in particular.
+
+      (2) implies (1): Let $U \coloneqq \ker(f)$. Then $U$ is a closed subspace of $V$, and $f$ induces a bijective linear contraction $\tilde{f} : V/U \to W$. It is isometric by assumption on $f$ and the definition of the norm on $V/U$. Thus, $\tilde{f}$ is an isomorphism. Since $V/U$ is the cokernel of $U \hookrightarrow V$, it follows that $f$ is a regular epimorphism.
+
+      (2) implies (3): Let $w \in W$ be an element with $|w| < 1$. Since $|w|$ is the infimum of all $|v|$ with $f(v)=w$, there is some $v$ with $f(v)=w$ and $|v| < 1$.
+
+      (3) implies (2): Let $w \in W$. Since $f$ is a linear contraction, the inequality $|w| \leq \inf \{|v| : f(v) = w\}$ holds. Let $\varepsilon > 0$. Consider $w' \coloneqq w / (|w| + \varepsilon)$. Then $|w'| < 1$. Thus, by assumption, there is some $v' \in V$ with $|v'| < 1$ and $f(v') =w'$. Let $v \coloneqq (|w| + \varepsilon) v'$. Then $f(v) = w$ and $|v| < |w| + \varepsilon$. Thus, the infimum in question is $\leq |w| + \varepsilon$, for every $\varepsilon > 0$, and hence $\leq |w|$.

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -37,10 +37,10 @@ satisfied_properties:
 
   - property: regular
     proof: >-
-      It suffices to prove that regular epimorphisms are stable under pullbacks. We will use their classification below.
+      It suffices to prove that regular epimorphisms are stable under pullbacks. We will use their classification via open unit balls below.
       So let $f : V \to W$ be a regular epimorphism of Banach spaces and let $g : T \to W$ be any morphism. We need to show that the projection $V \times_W T \to T$ is a regular epimorphism.
-      Clearly, it is surjective since $f$ is surjective. Now let $t \in T$ be an element of norm $<1$. Since $g$ is a linear contraction, $g(t)$ has norm $<1$. Since $f$ is a regular epimorphism, there is some $v \in V$ with norm $<1$ and $f(v) = g(t)$.
-      Then $(v,t) \in V \times_W T$ has norm $\max(|v|,|t|) < 1$ and provides a preimage of $t$.
+      Let $t \in T$ be an element of norm $<1$. Since $g$ is a linear contraction, $g(t)$ has norm $<1$. Since $f$ is a regular epimorphism, there is some $v \in V$ with norm $<1$ and $f(v) = g(t)$.
+      Then $(v,t) \in V \times_W T$ is a preimage of $t$ with norm $\max(|v|,|t|) < 1$.
 
 unsatisfied_properties:
   - property: skeletal
@@ -95,8 +95,10 @@ special_morphisms:
     proof: The non-trivial direction follows from the <a href="https://math.stackexchange.com/questions/319867" target="_blank">well-known fact</a> that for every closed subspace of a Banach space its quotient space is again a Banach space.
   regular epimorphisms:
     description: >-
-      For a linear contraction $f : V \to W$ the following are equivalent: (1) $f$ is a regular epimorphism. (2) $f$ is surjective and the norm on $W$ is given by $|w| = \inf \{|v| : f(v) = w\}$. (3) $f$ is surjective and $f$ maps the open unit ball of $V$ onto the open unit ball of $W$.
+      For a linear contraction $f : V \to W$ the following are equivalent: (1) $f$ is a regular epimorphism. (2) The norm on $W$ is given by $|w| = \inf \{|v| : f(v) = w\}$. (3) $f$ maps the open unit ball of $V$ onto the open unit ball of $W$.
     proof: >-
+      First of all, notice that all three conditions imply that $f$ is surjective.
+
       (1) implies (2): This follows immediately from the concrete construction of coequalizers, and the quotient Banach space $V/U$ in particular.
 
       (2) implies (1): Let $U \coloneqq \ker(f)$. Then $U$ is a closed subspace of $V$, and $f$ induces a bijective linear contraction $\tilde{f} : V/U \to W$. It is isometric by assumption on $f$ and the definition of the norm on $V/U$. Thus, $\tilde{f}$ is an isomorphism. Since $V/U$ is the cokernel of $U \hookrightarrow V$, it follows that $f$ is a regular epimorphism.

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -38,9 +38,23 @@ satisfied_properties:
   - property: regular
     proof: >-
       It suffices to prove that regular epimorphisms are stable under pullbacks. We will use their classification via open unit balls below.
-      So let $f : X \to Y$ be a regular epimorphism of Banach spaces and let $g : T \to Y$ be any morphism. We need to show that the projection $X \times_Y T \to X$ is a regular epimorphism.
+      So let $f : X \to Y$ be a regular epimorphism and let $g : T \to Y$ be any morphism. We need to show that the projection $X \times_Y T \to X$ is a regular epimorphism.
       Let $t \in T$ be an element of norm $<1$. Since $g$ is a linear contraction, $g(t)$ has norm $<1$. Since $f$ is a regular epimorphism, there is some $x \in X$ with norm $<1$ and $f(x) = g(t)$.
       Then $(x,t) \in X \times_Y T$ is a preimage of $t$ with norm $\max(|x|,|t|) < 1$.
+
+  - property: coregular
+    proof: >-
+      It suffices to prove that regular monomorphisms are stable under pushouts. We will use their classification as isometric linear maps below.
+      So let $i : X \to Y$ be an isometric linear map and let $f : X \to T$ be any morphism. We need to show that the linear contraction $\iota : T \to T \sqcup_X Y$ is isometric as well. The pushout can be constructed as the quotient of the direct sum $T \oplus Y$, equipped with the $1$-norm, modulo the closure of the subspace containing all $(-f(x),i(x))$ for $x \in X$. Using that $i$ is an isometry, it is easily checked that this subspace is already closed.
+      For $t \in T$ the norm of $\iota(t) = [(t,0)]$ is the infimum of the norms of $(t,0) + (-f(x),i(x)) = (t - f(x), i(x))$ for $x \in X$.
+      By taking $x=0$ we see that the infimum is $\leq |t|$.
+      On the other hand, for any $x \in X$ we compute
+      $$\begin{align*}
+      |(t - f(x), i(x))| & = |t - f(x)| + |i(x)| \\
+      & = |t - f(x)| + |x| \\
+      & \geq |t - f(x)| + |f(x)| \geq |t|.
+      \end{align*}$$
+      This shows that the infimum is precisely $|t|$.
 
 unsatisfied_properties:
   - property: skeletal

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -55,6 +55,13 @@ unsatisfied_properties:
   - property: regular subobject classifier
     proof: If $\Omega$ is a regular subobject classifier, then by the classification of regular monomorphisms, $\Hom(X,\Omega)$ is isomorphic to the set of closed subspaces of $X$ for any Banach space $X$. For $X = \IC$ this implies that there are exactly two vectors in $\Omega$ with norm $\leq 1$, which is absurd. (For $\Omega = 0$ there is just one, and for $\Omega \neq 0$ there are infinitely many.)
 
+  - property: regular quotient object classifier
+    proof: >-
+      Assume that $\Psi$ is a regular quotient object classifier in $\Ban$. For a Banach space $V$ let $S(V)$ be the set of closed subspaces of $V$. Then for any Banach space $V$ the map
+      $$\Hom(\Psi,V) \to S(V), \quad f \mapsto \overline{\im(f)}$$
+      is bijective. In particular, there is a morphism $f : \Psi \to V$ with dense image, i.e. an epimorphism. But this contradicts the already established fact that $\Ban$ is well-copowered (since it is locally presentable).
+      Alternatively, we may use that for every cardinal $\kappa$ the Banach space $\ell^2(\kappa^+)$ has no dense subset of size $\kappa$.
+
   - property: unital
     proof: The canonical morphism $X \sqcup Y \to X \times Y$ is injective, and therefore a monomorphism. Hence, if it were also a strong epimorphism, it would be an isomorphism. However, for example, when $X = Y = \IC$, the norms do not agree.
 

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -56,6 +56,42 @@ satisfied_properties:
       \end{align*}$$
       This shows that the infimum is precisely $|t|$.
 
+  - property: effective congruences
+    proof: >-
+      Let $R \hookrightarrow X \times X$ be a congruence in $\Ban$. We may assume that it is an inclusion of vector spaces. Since the forgetful functor $\Ban \to \Vect$ preserves finite limits, the congruence yields a congruence in $\Vect$, which we understand well:
+      It is fully classified by the subspace $U \coloneqq \{x \in X : (x,0) \in R\}$ via $R = \{(x,y) \in X \times X : x-y \in U\}$.
+
+
+      Since $R \hookrightarrow X \times X$ is a linear contraction, the norm $|{-}|_R$ on $R$ satisfies
+      $$\max(|x|,|y|) \leq |(x,y)|_R.$$
+      We claim that this is an equality, i.e. that $R \hookrightarrow X \times X$ is an isometry.
+
+
+      Since the reflexivity morphism $X \to R$, $x \mapsto (x,x)$ is a split monomorphism, it is isometric, i.e.
+      $$|(x,x)|_R = |x|.$$
+      Since the transitivity morphism $R \times_X R \to R$ is a linear contraction and the fiber product carries the $\max$-norm, we have
+      $$|(x,z)|_R \leq \max(|(x,y)|_R, |(y,z)|_R)$$
+      whenever $(x,y) \in R$ and $(y,z) \in R$.
+
+
+      Now let $(x,z) \in R$ and define $y \coloneqq \frac{1}{2} (x + z)$. Then
+      $$(x,y) = \tfrac{1}{2} (x,x) + \tfrac{1}{2} (x,z)$$
+      and likewise
+      $$(y,z) = \tfrac{1}{2} (z,z) + \tfrac{1}{2} (x,z)$$
+      are contained in $R$. We have
+      $$|(x,y)_R| \leq \tfrac{1}{2} |x| + \tfrac{1}{2} |(x,z)|_R$$
+      and likewise
+      $$|(y,z)|_R \leq \tfrac{1}{2} |z| + \tfrac{1}{2} |(x,z)|_R$$
+      Together with the transitivity bound we obtain
+      $$\begin{align*}
+      |(x,z)|_R & \leq \max(|(x,y)|_R, |(y,z)|_R) \\
+      & \leq \tfrac{1}{2} \max(|x|,|z|) + \tfrac{1}{2} |(x,z)|_R,
+      \end{align*}$$
+      which proves the claim $|(x,z)|_R \leq \max(|x|,|z|)$.
+
+
+      Since $R \hookrightarrow X \times X$ is an isometry, $R$ is a closed subspace of $X \times X$. It follows that also $U$ is a closed subspace of $X$. Finally, $R$ is the kernel pair of the projection $X \to X/U$ since this is true by construction on the level of vector spaces and the kernel pair carries the $\max$-norm, just like $R$.
+
 unsatisfied_properties:
   - property: skeletal
     proof: This is trivial.

--- a/databases/catdat/data/categories/Ban.yaml
+++ b/databases/catdat/data/categories/Ban.yaml
@@ -98,8 +98,14 @@ special_morphisms:
     description: linear contractions with dense image
     proof: 'Let $f : X \to Y$ be an epimorphism of Banach spaces. The subspace $U \coloneqq \overline{f(X)} \subseteq Y$ is closed. It is well-known that the quotient $Y/U$ is also a Banach space with a projection $p : Y \to Y/U$. Since $p \circ f = 0 = 0 \circ f$, we infer $p = 0$, so that $U = Y$.'
   regular monomorphisms:
-    description: closed embeddings
-    proof: The non-trivial direction follows from the <a href="https://math.stackexchange.com/questions/319867" target="_blank">well-known fact</a> that for every closed subspace of a Banach space its quotient space is again a Banach space.
+    description: >-
+      For a linear contraction $f : X \to Y$ the following are equivalent: (1) $f$ is a regular monomorphism. (2) $f$ is isometric. (3) $f$ is isomorphic to the inclusion of a closed subspace of $Y$.
+    proof: >-
+      (1) implies (2): This follows immediately from the concrete construction of equalizers.
+
+      (2) implies (3): The image of $f$ is complete, hence closed. The rest is clear.
+
+      (3) implies (1): If $U \subseteq Y$ is a closed subspace, then the inclusion is the kernel of the projection $Y \to Y/U$, where $Y/U$ is the <a href="https://math.stackexchange.com/questions/319867" target="_blank">well-known</a> quotient Banach space.
   regular epimorphisms:
     description: >-
       For a linear contraction $f : V \to W$ the following are equivalent: (1) $f$ is a regular epimorphism. (2) The norm on $W$ is given by $|w| = \inf \{|v| : f(v) = w\}$. (3) $f$ maps the open unit ball of $V$ onto the open unit ball of $W$.

--- a/databases/catdat/data/category-properties/counital.yaml
+++ b/databases/catdat/data/category-properties/counital.yaml
@@ -1,6 +1,6 @@
 id: counital
 relation: is
-description: 'A category is <i>counital</i> if its dual is unital, i.e., it has a zero object, finite colimits, and for all objects $X,Y$ the two morphisms $(\id_X;0) : X \sqcup Y \twoheadrightarrow X$ and $(0;\id_Y) : X \sqcup Y \twoheadrightarrow Y$ are jointly strongly monomorphic. When products exist, the canonical morphism $X \sqcup Y \to X \times Y$ therefore must be a strong monomorphism.'
+description: 'A category is <i>counital</i> if its dual is unital, i.e., it has a zero object, finite colimits, and for all objects $X,Y$ the two morphisms $(\id_X;0) : X \sqcup Y \twoheadrightarrow X$ and $(0;\id_Y) : X \sqcup Y \twoheadrightarrow Y$ are jointly strongly monomorphic. When binary products exist, the canonical morphism $X \sqcup Y \to X \times Y$ therefore must be a <a href="https://ncatlab.org/nlab/show/strong+monomorphism" target="_blank">strong monomorphism</a>.'
 dual_property: unital
 invariant_under_equivalences: true
 

--- a/databases/catdat/data/category-properties/unital.yaml
+++ b/databases/catdat/data/category-properties/unital.yaml
@@ -1,6 +1,6 @@
 id: unital
 relation: is
-description: 'A category is <i>unital</i> if it has a zero object, finite limits, and for all objects $X,Y$ the two morphisms $(\id_X,0) : X \hookrightarrow X \times Y$ and $(0,\id_Y) : Y \hookrightarrow X \times Y$ are jointly strongly epimorphic. This means: there is no proper subobject of $X \times Y$ that contains $X$ and $Y$. When coproducts exist, the canonical morphism $X \sqcup Y \to X \times Y$ therefore must be a strong epimorphism.'
+description: 'A category is <i>unital</i> if it has a zero object, finite limits, and for all objects $X,Y$ the two morphisms $(\id_X,0) : X \hookrightarrow X \times Y$ and $(0,\id_Y) : Y \hookrightarrow X \times Y$ are jointly strongly epimorphic. This means: there is no proper subobject of $X \times Y$ that contains $X$ and $Y$. When binary coproducts exist, the canonical morphism $X \sqcup Y \to X \times Y$ therefore must be a <a href="https://ncatlab.org/nlab/show/strong+epimorphism" target="_blank">strong epimorphism</a>.'
 nlab_link: https://ncatlab.org/nlab/show/unital+category
 dual_property: counital
 invariant_under_equivalences: true


### PR DESCRIPTION
This PR adds

- the easy proof that **Ban** is not counital (thus, resolves #257)
- the classification of regular epimorphisms in **Ban**
- the proof that **Ban** is regular
- the proof that **Ban** is coregular
- the proof that **Ban** has no regular quotient object classifier
- the proof that **Ban** has effective congruences, hence is Barr-exact

Thanks to @dschepler !