### PR TITLE
Remove trailing commas

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
 	"useTabs": true,
 	"tabWidth": 4,
 	"singleQuote": true,
-	"trailingComma": "all",
+	"trailingComma": "none",
 	"printWidth": 90,
 	"semi": false,
 	"quoteProps": "consistent",

--- a/content/subcategories.md
+++ b/content/subcategories.md
@@ -107,8 +107,12 @@ Let $L$ be a functor which is left adjoint to a faithful functor $U$. Then $L$ p
 :::
 
 _Proof._ If $S$ is a generating set,
-$$\begin{align*}
+
+$$
+\begin{align*}
 \prod_{G\in S} \Hom(L(G),-) & \cong \prod_{G\in S} \Hom(G,U(-)) \\
 & \cong \left( \prod_{G\in S} \Hom(G,-) \right) \circ U
-\end{align*}$$
+\end{align*}
+$$
+
 is a composition of faithful functors, hence faithful. <span class="qed">$\square$</span>

--- a/databases/app/scripts/setup.ts
+++ b/databases/app/scripts/setup.ts
@@ -10,7 +10,7 @@ if (!APP_DB_URL) throw new Error('No APP_DB_URL found')
 
 const db = createClient({
 	url: APP_DB_URL,
-	authToken: APP_DB_AUTH_TOKEN,
+	authToken: APP_DB_AUTH_TOKEN
 })
 
 setup()

--- a/databases/catdat/data/categories/Mono.yaml
+++ b/databases/catdat/data/categories/Mono.yaml
@@ -8,7 +8,6 @@ morphisms: >-
 description: >-
   This is equivalent to the full subcategory of objects $(X, Y, f)$ of <a href="/category/Set_arrow">$\Set^{\rightarrow}$</a> where $f : X \to Y$ is an injective function, i.e. a monomorphism. This explains our notation.
 nlab_link: https://ncatlab.org/nlab/show/M-category#def
-
 tags:
   - set theory
 

--- a/databases/catdat/scripts/config.ts
+++ b/databases/catdat/scripts/config.ts
@@ -7,11 +7,11 @@ export const STRUCTURE_TYPES_WITH_DUALS: StructureType[] = ['category']
 export const PLURALS = {
 	category: 'categories',
 	functor: 'functors',
-	morphism: 'morphisms',
+	morphism: 'morphisms'
 } as const
 
 export const TABLES = {
 	category: 'categories',
 	functor: 'functors',
-	morphism: 'morphisms',
+	morphism: 'morphisms'
 } as const

--- a/databases/catdat/scripts/deduce-implications.ts
+++ b/databases/catdat/scripts/deduce-implications.ts
@@ -21,7 +21,7 @@ export function create_dualized_implications(type: StructureType) {
 	const structure_maps = db
 		.prepare<[StructureType], { map: string; mapped_type: StructureType }>(
 			`SELECT map, mapped_type
-			FROM structure_maps WHERE type = ?`,
+			FROM structure_maps WHERE type = ?`
 		)
 		.all(type)
 
@@ -70,7 +70,7 @@ export function create_dualized_implications(type: StructureType) {
 				)
 			) AS dual_mapped_assumptions
 		FROM implications_view i
-		WHERE i.type = ? AND i.is_deduced = FALSE`,
+		WHERE i.type = ? AND i.is_deduced = FALSE`
 	)
 
 	const implications = implications_query.all(type)
@@ -108,7 +108,7 @@ export function create_dualized_implications(type: StructureType) {
 			const conclusions = parse_json_set<string>(impl.conclusions)
 			const dual_conclusions = parse_json_set<string | null>(impl.dual_conclusions)
 			const dual_mapped_assumptions = parse_nested_json_set<string | null>(
-				impl.dual_mapped_assumptions,
+				impl.dual_mapped_assumptions
 			)
 
 			if (dual_assumptions.has(null)) continue
@@ -132,7 +132,7 @@ export function create_dualized_implications(type: StructureType) {
 				type,
 				impl.is_equivalence,
 				'This follows from the dual implication.',
-				impl.id,
+				impl.id
 			)
 
 			for (const a of dual_assumptions) {
@@ -173,7 +173,7 @@ export function create_self_dual_implications(type: StructureType) {
 				type = ?
 				AND dual_property_id IS NOT NULL
 				AND id != dual_property_id
-				AND invariant_under_equivalences = TRUE`,
+				AND invariant_under_equivalences = TRUE`
 		)
 		.all(type)
 

--- a/databases/catdat/scripts/deduce-special-morphisms.ts
+++ b/databases/catdat/scripts/deduce-special-morphisms.ts
@@ -42,7 +42,7 @@ function deduce_special_morphisms_of_dual_categories() {
             FROM structures c
             INNER JOIN special_morphisms m ON m.category_id = c.id
             INNER JOIN special_morphism_types t ON t.type = m.type
-            WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL`,
+            WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL`
 		)
 		.run()
 

--- a/databases/catdat/scripts/deduce-special-objects.ts
+++ b/databases/catdat/scripts/deduce-special-objects.ts
@@ -36,7 +36,7 @@ function deduce_special_objects_of_dual_categories() {
             FROM structures c
             INNER JOIN special_objects o ON o.category_id = c.id
             INNER JOIN special_object_types t ON t.type = o.type
-            WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL`,
+            WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL`
 		)
 		.run()
 

--- a/databases/catdat/scripts/deduce-structure-properties.ts
+++ b/databases/catdat/scripts/deduce-structure-properties.ts
@@ -9,13 +9,13 @@ import { get_client } from './utils/db'
 import {
 	get_properties_dict,
 	get_property_assignments,
-	type PropertyMeta,
+	type PropertyMeta
 } from './utils/properties'
 import {
 	get_contradiction_string,
 	get_normalized_implications,
 	get_proof_string,
-	NormalizedImplication,
+	NormalizedImplication
 } from './utils/implications'
 import { STRUCTURE_TYPES_WITH_DUALS, type StructureType } from './config'
 import { get_structures, is_dual_structure, type StructureMeta } from './utils/structures'
@@ -33,7 +33,7 @@ export function get_deduced_satisfied_properties(
 		stop_when_found?: string
 	},
 	type: StructureType,
-	associated_satisfied_properties?: Record<string, Set<string>>,
+	associated_satisfied_properties?: Record<string, Set<string>>
 ) {
 	const found = new Set<string>()
 	const proofs: Record<string, string> = {}
@@ -55,9 +55,9 @@ export function get_deduced_satisfied_properties(
 					(key) => {
 						return is_subset(
 							implication.mapped_assumptions?.[key] ?? new Set(),
-							associated_satisfied_properties?.[key] ?? new Set(),
+							associated_satisfied_properties?.[key] ?? new Set()
 						)
-					},
+					}
 				)
 				if (!is_applicable) continue
 			}
@@ -74,7 +74,7 @@ export function get_deduced_satisfied_properties(
 				proofs[implication.conclusion] = get_proof_string(
 					implication,
 					options.properties_dict,
-					type,
+					type
 				)
 			}
 		}
@@ -102,7 +102,7 @@ export function get_deduced_unsatisfied_properties(
 		stop_when_found?: string
 	},
 	type: StructureType,
-	associated_satisfied_properties?: Record<string, Set<string>>,
+	associated_satisfied_properties?: Record<string, Set<string>>
 ) {
 	const found = new Set<string>()
 	const proofs: Record<string, string> = {}
@@ -118,17 +118,17 @@ export function get_deduced_unsatisfied_properties(
 					!deduced_unsatisfied_properties.has(p) &&
 					!newly_found.has(p) &&
 					is_subset(implication.assumptions, satisfied_properties, {
-						exception: p,
+						exception: p
 					})
 				if (!is_valid) continue
 
 				if (implication.mapped_assumptions) {
 					const is_applicable = Object.keys(
-						implication.mapped_assumptions,
+						implication.mapped_assumptions
 					).every((key) => {
 						return is_subset(
 							implication.mapped_assumptions?.[key] ?? new Set(),
-							associated_satisfied_properties?.[key] ?? new Set(),
+							associated_satisfied_properties?.[key] ?? new Set()
 						)
 					})
 					if (!is_applicable) continue
@@ -151,7 +151,7 @@ export function get_deduced_unsatisfied_properties(
 						implication,
 						options.properties_dict,
 						p,
-						type,
+						type
 					)
 				}
 			}
@@ -173,7 +173,7 @@ function save_satisfied_properties(
 	structure_id: string,
 	found: Set<string>,
 	proofs: Record<string, string>,
-	type: StructureType,
+	type: StructureType
 ) {
 	if (found.size === 0) return
 
@@ -210,7 +210,7 @@ function save_unsatisfied_properties(
 	structure_id: string,
 	found: Set<string>,
 	proofs: Record<string, string>,
-	type: StructureType,
+	type: StructureType
 ) {
 	if (found.size === 0) return
 
@@ -250,14 +250,14 @@ function deduce_satisfied_properties(
 	implications: NormalizedImplication[],
 	satisfied_properties: Set<string>,
 	properties_dict: Record<string, PropertyMeta>,
-	type: StructureType,
+	type: StructureType
 ) {
 	const { found, proofs } = get_deduced_satisfied_properties(
 		satisfied_properties,
 		implications,
 		{ properties_dict },
 		type,
-		structure.associated_satisfied_properties,
+		structure.associated_satisfied_properties
 	)
 
 	for (const p of found) satisfied_properties.add(p)
@@ -279,7 +279,7 @@ function deduce_unsatisfied_properties(
 	satisfied_properties: Set<string>,
 	unsatisfied_properties: Set<string>,
 	properties_dict: Record<string, PropertyMeta>,
-	type: StructureType,
+	type: StructureType
 ) {
 	const { found, proofs } = get_deduced_unsatisfied_properties(
 		satisfied_properties,
@@ -287,7 +287,7 @@ function deduce_unsatisfied_properties(
 		implications,
 		{ properties_dict },
 		type,
-		structure.associated_satisfied_properties,
+		structure.associated_satisfied_properties
 	)
 
 	for (const p of found) unsatisfied_properties.add(p)
@@ -312,7 +312,7 @@ function deduce_dual_properties(
 	dual_unsatisfied: Set<string>,
 	dual_undecidable: Set<string>,
 	properties_dict: Record<string, PropertyMeta>,
-	type: StructureType,
+	type: StructureType
 ) {
 	const new_satisfied = new Set<string>()
 
@@ -356,7 +356,7 @@ function deduce_dual_properties(
 	}
 
 	console.info(
-		`Deduced ${new_satisfied.size} satisfied properties by duality for ${structure.id}`,
+		`Deduced ${new_satisfied.size} satisfied properties by duality for ${structure.id}`
 	)
 
 	for (const q of new_unsatisfied) {
@@ -364,7 +364,7 @@ function deduce_dual_properties(
 	}
 
 	console.info(
-		`Deduced ${new_unsatisfied.size} unsatisfied properties by duality for ${structure.id}`,
+		`Deduced ${new_unsatisfied.size} unsatisfied properties by duality for ${structure.id}`
 	)
 
 	for (const q of new_undecidable) {
@@ -372,7 +372,7 @@ function deduce_dual_properties(
 	}
 
 	console.info(
-		`Deduced ${new_undecidable.size} undecidable properties by duality for ${structure.id}`,
+		`Deduced ${new_undecidable.size} undecidable properties by duality for ${structure.id}`
 	)
 }
 
@@ -381,7 +381,7 @@ function deduce_dual_properties(
  */
 function delete_deduced_properties(db: Database, type: StructureType) {
 	db.prepare(
-		`DELETE FROM property_assignments WHERE is_deduced = TRUE AND type = ?`,
+		`DELETE FROM property_assignments WHERE is_deduced = TRUE AND type = ?`
 	).run(type)
 }
 
@@ -411,7 +411,7 @@ export function deduce_properties_for_structures(type: StructureType) {
 				implications,
 				assigned.satisfied,
 				properties_dict,
-				type,
+				type
 			)
 
 			deduce_unsatisfied_properties(
@@ -421,7 +421,7 @@ export function deduce_properties_for_structures(type: StructureType) {
 				assigned.satisfied,
 				assigned.unsatisfied,
 				properties_dict,
-				type,
+				type
 			)
 		}
 	})
@@ -447,7 +447,7 @@ export function deduce_properties_for_structures(type: StructureType) {
 				dual_assigned.unsatisfied,
 				dual_assigned.undecidable,
 				properties_dict,
-				type,
+				type
 			)
 
 			deduce_satisfied_properties(
@@ -456,7 +456,7 @@ export function deduce_properties_for_structures(type: StructureType) {
 				implications,
 				assigned.satisfied,
 				properties_dict,
-				type,
+				type
 			)
 
 			deduce_unsatisfied_properties(
@@ -466,7 +466,7 @@ export function deduce_properties_for_structures(type: StructureType) {
 				assigned.satisfied,
 				assigned.unsatisfied,
 				properties_dict,
-				type,
+				type
 			)
 		}
 	})

--- a/databases/catdat/scripts/deduce.ts
+++ b/databases/catdat/scripts/deduce.ts
@@ -5,7 +5,7 @@ import { restrict_representable_functors } from './restrict-functor-properties'
 import {
 	clear_deduced_implications,
 	create_dualized_implications,
-	create_self_dual_implications,
+	create_self_dual_implications
 } from './deduce-implications'
 
 deduce()

--- a/databases/catdat/scripts/proof-length.ts
+++ b/databases/catdat/scripts/proof-length.ts
@@ -30,7 +30,7 @@ function report_long_property_proofs(type: StructureType) {
                 length(proof) AS length
             FROM property_assignments
             WHERE type = ? AND is_deduced = FALSE AND length(proof) >= ?
-            ORDER BY length(proof) DESC`,
+            ORDER BY length(proof) DESC`
 		)
 		.all(type, PROOF_LENGTH_THRESHOLD)
 
@@ -40,7 +40,7 @@ function report_long_property_proofs(type: StructureType) {
 
 	for (const { id, property, length } of long_proofs) {
 		console.warn(
-			`🟡 The proof for (${id}, ${property}) has ${length} characters. Consider moving it to a content page.`,
+			`🟡 The proof for (${id}, ${property}) has ${length} characters. Consider moving it to a content page.`
 		)
 	}
 }
@@ -56,7 +56,7 @@ function report_long_implication_proofs(type: StructureType) {
 				type = ?
 				AND is_deduced = FALSE
 				AND length(proof) >= ?
-            ORDER BY length(proof) DESC`,
+            ORDER BY length(proof) DESC`
 		)
 		.all(type, PROOF_LENGTH_THRESHOLD)
 
@@ -66,7 +66,7 @@ function report_long_implication_proofs(type: StructureType) {
 
 	for (const { id, length } of long_proofs) {
 		console.warn(
-			`🟡 The proof for ${id} has ${length} characters. Consider moving it to a content page.`,
+			`🟡 The proof for ${id} has ${length} characters. Consider moving it to a content page.`
 		)
 	}
 }

--- a/databases/catdat/scripts/redundancies.ts
+++ b/databases/catdat/scripts/redundancies.ts
@@ -1,13 +1,13 @@
 import { get_client } from './utils/db'
 import {
 	get_deduced_satisfied_properties,
-	get_deduced_unsatisfied_properties,
+	get_deduced_unsatisfied_properties
 } from './deduce-structure-properties'
 import { get_property_assignments_by_deduction } from './utils/properties'
 import type { StructureType } from './config'
 import {
 	get_normalized_implications,
-	type NormalizedImplication,
+	type NormalizedImplication
 } from './utils/implications'
 import { get_structures } from './utils/structures'
 
@@ -41,7 +41,7 @@ function check_redundant_property_assignments(type: StructureType) {
 
 	const ignore_count = Object.keys(ignore_dict).reduce(
 		(count, id) => count + ignore_dict[id].size,
-		0,
+		0
 	)
 
 	let redundancy_count = 0
@@ -52,12 +52,12 @@ function check_redundant_property_assignments(type: StructureType) {
 			assignments[structure.id].satisfied.non_deduced,
 			implications,
 			ignore_dict[structure.id],
-			structure.associated_satisfied_properties,
+			structure.associated_satisfied_properties
 		)
 
 		if (redundant_satisfied_property) {
 			console.warn(
-				`🟠 Redundant satisfied property for ${structure.id}: "${redundant_satisfied_property}" is implied by others.`,
+				`🟠 Redundant satisfied property for ${structure.id}: "${redundant_satisfied_property}" is implied by others.`
 			)
 
 			redundancy_count++
@@ -65,7 +65,7 @@ function check_redundant_property_assignments(type: StructureType) {
 
 		const all_satisfied_properties = new Set([
 			...assignments[structure.id].satisfied.non_deduced,
-			...assignments[structure.id].satisfied.deduced,
+			...assignments[structure.id].satisfied.deduced
 		])
 
 		const redundant_unsatisfied_property = get_redundant_unsatisfied_property(
@@ -74,12 +74,12 @@ function check_redundant_property_assignments(type: StructureType) {
 			assignments[structure.id].unsatisfied.non_deduced,
 			implications,
 			ignore_dict[structure.id],
-			structure.associated_satisfied_properties,
+			structure.associated_satisfied_properties
 		)
 
 		if (redundant_unsatisfied_property) {
 			console.warn(
-				`🟡 Redundant unsatisfied property for ${structure.id}: "${redundant_unsatisfied_property}" is implied by others.`,
+				`🟡 Redundant unsatisfied property for ${structure.id}: "${redundant_unsatisfied_property}" is implied by others.`
 			)
 
 			redundancy_count++
@@ -108,7 +108,7 @@ function get_redundant_satisfied_property(
 	satisfied_properties: Set<string>,
 	implications: NormalizedImplication[],
 	ignored: Set<string> = new Set(),
-	associated_satisfied_properties?: Record<string, Set<string>>,
+	associated_satisfied_properties?: Record<string, Set<string>>
 ) {
 	for (const p of [...satisfied_properties]) {
 		if (ignored.has(p)) continue
@@ -118,7 +118,7 @@ function get_redundant_satisfied_property(
 			implications,
 			{ stop_when_found: p },
 			type,
-			associated_satisfied_properties,
+			associated_satisfied_properties
 		)
 		if (deduced_satisfied_properties.has(p)) return p
 		satisfied_properties.add(p)
@@ -138,7 +138,7 @@ function get_redundant_unsatisfied_property(
 	unsatisfied_properties: Set<string>,
 	implications: NormalizedImplication[],
 	ignored: Set<string> = new Set(),
-	associated_satisfied_properties?: Record<string, Set<string>>,
+	associated_satisfied_properties?: Record<string, Set<string>>
 ) {
 	for (const p of [...unsatisfied_properties]) {
 		if (ignored.has(p)) continue
@@ -149,7 +149,7 @@ function get_redundant_unsatisfied_property(
 			implications,
 			{ stop_when_found: p },
 			type,
-			associated_satisfied_properties,
+			associated_satisfied_properties
 		)
 		if (deduced_unsatisfied_properties.has(p)) return p
 		unsatisfied_properties.add(p)
@@ -167,7 +167,7 @@ function get_ignored_redundant_assignments(type: StructureType) {
 		.prepare<[StructureType], { structure_id: string; property_id: string }>(
 			`SELECT structure_id, property_id
 			FROM property_assignments
-			WHERE check_redundancy = FALSE AND type = ?`,
+			WHERE check_redundancy = FALSE AND type = ?`
 		)
 		.all(type)
 

--- a/databases/catdat/scripts/restrict-functor-properties.ts
+++ b/databases/catdat/scripts/restrict-functor-properties.ts
@@ -34,7 +34,7 @@ export function restrict_representable_functors() {
             DO UPDATE SET
                 proof = excluded.proof,
                 is_deduced = excluded.is_deduced,
-                check_redundancy = excluded.check_redundancy`,
+                check_redundancy = excluded.check_redundancy`
 		)
 		.run()
 

--- a/databases/catdat/scripts/seed.ts
+++ b/databases/catdat/scripts/seed.ts
@@ -9,7 +9,7 @@ import type {
 	PropertyEntry,
 	StructureYaml,
 	PropertyYaml,
-	MorphismYaml,
+	MorphismYaml
 } from './utils/seed.types'
 import { create_schema_hash, get_saved_schema_hash } from './utils/schema'
 import { PLURALS, STRUCTURE_TYPES, type StructureType } from './config'
@@ -106,23 +106,23 @@ function clear_all_tables() {
  */
 function seed_config() {
 	const structure_tag_insert = db.prepare<[string, StructureType]>(
-		`INSERT INTO structure_tags (tag, type) VALUES (?, ?)`,
+		`INSERT INTO structure_tags (tag, type) VALUES (?, ?)`
 	)
 
 	const property_tag_insert = db.prepare<[string, StructureType]>(
-		`INSERT INTO property_tags (tag, type) VALUES (?, ?)`,
+		`INSERT INTO property_tags (tag, type) VALUES (?, ?)`
 	)
 
 	const relation_insert = db.prepare(
-		`INSERT INTO relations (relation, negation, conditional) VALUES (?, ?, ?)`,
+		`INSERT INTO relations (relation, negation, conditional) VALUES (?, ?, ?)`
 	)
 
 	const object_insert = db.prepare(
-		`INSERT INTO special_object_types (type, dual) VALUES (?, ?)`,
+		`INSERT INTO special_object_types (type, dual) VALUES (?, ?)`
 	)
 
 	const morphism_insert = db.prepare(
-		`INSERT INTO special_morphism_types (type, dual) VALUES (?, ?)`,
+		`INSERT INTO special_morphism_types (type, dual) VALUES (?, ?)`
 	)
 
 	function insert_config(config: ConfigYaml) {
@@ -163,7 +163,7 @@ function seed_config() {
 function seed_structures<T extends StructureYaml>({
 	type,
 	folder,
-	extra,
+	extra
 }: {
 	type: StructureType
 	folder: string
@@ -174,34 +174,34 @@ function seed_structures<T extends StructureYaml>({
 			id, type, name, notation, description, nlab_link,
 			dual_structure_id
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?)`
 	)
 
 	const tag_insert = db.prepare(
 		`INSERT INTO structure_tag_assignments (structure_id, tag, type)
-		VALUES (?, ?, ?)`,
+		VALUES (?, ?, ?)`
 	)
 
 	const comment_insert = db.prepare(
 		`INSERT INTO structure_comments (structure_id, comment)
-		VALUES (?, ?)`,
+		VALUES (?, ?)`
 	)
 
 	const related_insert = db.prepare(
 		`INSERT INTO related_structures (structure_id, related_structure_id, type)
-		VALUES (?, ?, ?)`,
+		VALUES (?, ?, ?)`
 	)
 
 	const property_assignment_insert = db.prepare(
 		`INSERT INTO property_assignments (
 			structure_id, property_id, type, is_satisfied, proof, check_redundancy
-		) VALUES (?, ?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?)`
 	)
 
 	function insert_property_assignments(
 		structure_id: string,
 		entries: PropertyEntry[],
-		is_satisfied: 0 | 1 | null,
+		is_satisfied: 0 | 1 | null
 	) {
 		for (const entry of entries) {
 			property_assignment_insert.run(
@@ -210,7 +210,7 @@ function seed_structures<T extends StructureYaml>({
 				type,
 				is_satisfied,
 				entry.proof,
-				entry.check_redundancy === false ? 0 : 1,
+				entry.check_redundancy === false ? 0 : 1
 			)
 		}
 	}
@@ -223,7 +223,7 @@ function seed_structures<T extends StructureYaml>({
 			structure.notation,
 			structure.description,
 			structure.nlab_link,
-			structure.dual || null,
+			structure.dual || null
 		)
 
 		if (!structure.tags.length) {
@@ -248,7 +248,7 @@ function seed_structures<T extends StructureYaml>({
 		insert_property_assignments(
 			structure.id,
 			structure.undecidable_properties ?? [],
-			null,
+			null
 		)
 
 		if (extra) extra(structure)
@@ -264,16 +264,16 @@ function insert_category(category: CategoryYaml) {
 	const category_insert = db.prepare(
 		`INSERT INTO categories (
 	        id, objects, morphisms
-		) VALUES (?, ?, ?)`,
+		) VALUES (?, ?, ?)`
 	)
 
 	const special_object_insert = db.prepare(
-		`INSERT INTO special_objects (category_id, type, description) VALUES (?, ?, ?)`,
+		`INSERT INTO special_objects (category_id, type, description) VALUES (?, ?, ?)`
 	)
 
 	const special_morphism_insert = db.prepare(
 		`INSERT INTO special_morphisms (category_id, type, description, proof)
-		VALUES (?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?)`
 	)
 
 	category_insert.run(category.id, category.objects, category.morphisms)
@@ -295,14 +295,14 @@ function insert_category(category: CategoryYaml) {
 function insert_functor(functor: FunctorYaml) {
 	const functor_insert = db.prepare(
 		`INSERT INTO functors (id, source, target, left_adjoint)
-		VALUES (?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?)`
 	)
 
 	functor_insert.run(
 		functor.id,
 		functor.source,
 		functor.target,
-		functor.left_adjoint || null,
+		functor.left_adjoint || null
 	)
 }
 
@@ -312,7 +312,7 @@ function insert_functor(functor: FunctorYaml) {
 function insert_morphism(morphism: MorphismYaml) {
 	const morphism_insert = db.prepare(
 		`INSERT INTO morphisms (id, category)
-		VALUES (?, ?)`,
+		VALUES (?, ?)`
 	)
 
 	morphism_insert.run(morphism.id, morphism.category)
@@ -332,13 +332,13 @@ function seed_properties({ type, folder }: { type: StructureType; folder: string
 	const related_insert = db.prepare(
 		`INSERT INTO related_properties
 			(property_id, related_property_id, type)
-		VALUES (?, ?, ?)`,
+		VALUES (?, ?, ?)`
 	)
 
 	const tag_insert = db.prepare(
 		`INSERT INTO property_tag_assignments
 			(property_id, tag, type)
-		VALUES (?, ?, ?)`,
+		VALUES (?, ?, ?)`
 	)
 
 	function insert_property(property: PropertyYaml) {
@@ -349,7 +349,7 @@ function seed_properties({ type, folder }: { type: StructureType; folder: string
 			property.description,
 			property.nlab_link,
 			property.dual,
-			Number(property.invariant_under_equivalences),
+			Number(property.invariant_under_equivalences)
 		)
 
 		for (const related of property.related) {
@@ -370,7 +370,7 @@ function seed_properties({ type, folder }: { type: StructureType; folder: string
 		db,
 		`properties of ${PLURALS[type]}`,
 		path.join(data_folder, folder),
-		insert_property,
+		insert_property
 	)
 }
 
@@ -381,32 +381,32 @@ function seed_implications({ type, folder }: { type: StructureType; folder: stri
 	const structure_maps = db
 		.prepare<[StructureType], { map: string; mapped_type: StructureType }>(
 			`SELECT map, mapped_type
-			FROM structure_maps WHERE type = ?`,
+			FROM structure_maps WHERE type = ?`
 		)
 		.all(type)
 
 	const implication_insert = db.prepare(
 		`INSERT INTO implications (
 	        id, type, proof, is_equivalence
-		) VALUES (?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?)`
 	)
 
 	const assumption_insert = db.prepare(
 		`INSERT INTO assumptions (
 			implication_id, property_id, type
-		) VALUES (?, ?, ?)`,
+		) VALUES (?, ?, ?)`
 	)
 
 	const conclusion_insert = db.prepare(
 		`INSERT INTO conclusions (
 			implication_id, property_id, type
-		) VALUES (?, ?, ?)`,
+		) VALUES (?, ?, ?)`
 	)
 
 	const mapped_assumption_insert = db.prepare(
 		`INSERT INTO mapped_assumptions (
 			implication_id, map, property_id, type, property_type
-		) VALUES (?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?)`
 	)
 
 	function insert_implications(implications: ImplicationYaml[]) {
@@ -436,6 +436,6 @@ function seed_implications({ type, folder }: { type: StructureType; folder: stri
 		db,
 		`${type} implications`,
 		path.join(data_folder, folder),
-		insert_implications,
+		insert_implications
 	)
 }

--- a/databases/catdat/scripts/test.ts
+++ b/databases/catdat/scripts/test.ts
@@ -39,7 +39,7 @@ function execute_tests() {
 		test_decided_structures(decided_categories, 'category')
 		test_properties_of_selected_structures(
 			{ Set: Set_expected, Ab: Ab_expected, Top: Top_expected },
-			'category',
+			'category'
 		)
 
 		console.info('\n--- Test functors ---')
@@ -49,7 +49,7 @@ function execute_tests() {
 		test_decided_structures(decided_functors, 'functor')
 		test_properties_of_selected_structures(
 			{ forget_vector: forget_vector_expected, id_Set: id_Set_expected },
-			'functor',
+			'functor'
 		)
 
 		console.info('\n--- Test morphisms ---')
@@ -76,7 +76,7 @@ function test_mutual_structure_duals(type: StructureType) {
 	const structures_with_duals = db
 		.prepare<[StructureType], { id: string; dual: string | null }>(
 			`SELECT id, dual_structure_id AS dual
-			FROM structures WHERE type = ?`,
+			FROM structures WHERE type = ?`
 		)
 		.all(type)
 
@@ -102,14 +102,14 @@ function test_positivity(structure_id: string, type: StructureType) {
 	const unsatisfied_props = db
 		.prepare<[StructureType, string], string>(
 			`SELECT property_id FROM property_assignments
-			WHERE type = ? AND structure_id = ? AND is_satisfied = FALSE`,
+			WHERE type = ? AND structure_id = ? AND is_satisfied = FALSE`
 		)
 		.pluck()
 		.all(type, structure_id)
 
 	if (unsatisfied_props.length > 0) {
 		throw new Error(
-			`❌ The ${type} ${structure_id} has ${unsatisfied_props.length} unsatisfied properties, but it should have 0.`,
+			`❌ The ${type} ${structure_id} has ${unsatisfied_props.length} unsatisfied properties, but it should have 0.`
 		)
 	}
 
@@ -155,7 +155,7 @@ function test_decided_structures(structure_ids: string[], type: StructureType) {
 			(
 				SELECT 1 FROM property_assignments
 				WHERE type = ? AND structure_id = ? AND property_id = p.id
-			)`,
+			)`
 		)
 		.pluck()
 
@@ -164,7 +164,7 @@ function test_decided_structures(structure_ids: string[], type: StructureType) {
 
 		if (unknown_properties.length > 0) {
 			throw new Error(
-				`❌ Found unknown properties of ${structure_id}:\n${unknown_properties.join(', ')}.\nEvery property needs to be decided for this ${type}.`,
+				`❌ Found unknown properties of ${structure_id}:\n${unknown_properties.join(', ')}.\nEvery property needs to be decided for this ${type}.`
 			)
 		}
 
@@ -180,14 +180,14 @@ function test_decided_structures(structure_ids: string[], type: StructureType) {
  */
 function test_properties_of_selected_structures(
 	expected: Record<string, Record<string, boolean>>,
-	type: StructureType,
+	type: StructureType
 ) {
 	const property_query = db.prepare<
 		[StructureType, string],
 		{ property_id: string; is_satisfied: 0 | 1 }
 	>(
 		`SELECT property_id, is_satisfied FROM property_assignments
-		WHERE type = ? AND structure_id = ? AND is_satisfied IS NOT NULL`,
+		WHERE type = ? AND structure_id = ? AND is_satisfied IS NOT NULL`
 	)
 
 	for (const structure_id in expected) {
@@ -211,7 +211,7 @@ function check_link_targets_exist() {
 		fs
 			.readdirSync(path.resolve('content'))
 			.filter((file) => file.endsWith('.md'))
-			.map((file) => path.basename(file, '.md')),
+			.map((file) => path.basename(file, '.md'))
 	)
 
 	const proofs: { proof: string; error_prefix: string }[] = [
@@ -222,28 +222,28 @@ function check_link_targets_exist() {
 					structure_id AS structure,
 					property_id AS property,
 					proof
-				FROM property_assignments`,
+				FROM property_assignments`
 			)
 			.all()
 			.map((x) => ({
 				proof: x.proof,
-				error_prefix: `❌ The proof of (${x.structure}, ${x.property})`,
+				error_prefix: `❌ The proof of (${x.structure}, ${x.property})`
 			})),
 		...db
 			.prepare<never[], { id: string; proof: string }>(
-				`SELECT id, proof FROM implications`,
+				`SELECT id, proof FROM implications`
 			)
 			.all()
 			.map((x) => ({
 				proof: x.proof,
-				error_prefix: `❌ The proof of the implication (${x.id})`,
-			})),
+				error_prefix: `❌ The proof of the implication (${x.id})`
+			}))
 	]
 
 	for (const { proof, error_prefix } of proofs) {
 		const link_regex = new RegExp(
 			`<a\\s+href="\\/(${STRUCTURE_TYPES.join('|')})(?:-(implication|property))?\\/([^"]+)"`,
-			'g',
+			'g'
 		)
 
 		for (const match of proof.matchAll(link_regex)) {
@@ -267,7 +267,7 @@ function check_link_targets_exist() {
 
 			if (!exists) {
 				throw new Error(
-					`${error_prefix} has a link to "${id}" which does not exist:\n"${proof}"`,
+					`${error_prefix} has a link to "${id}" which does not exist:\n"${proof}"`
 				)
 			}
 		}
@@ -279,7 +279,7 @@ function check_link_targets_exist() {
 
 			if (!content_ids.has(id)) {
 				throw new Error(
-					`${error_prefix} has a link to "${id}" which does not exist:\n"${proof}"`,
+					`${error_prefix} has a link to "${id}" which does not exist:\n"${proof}"`
 				)
 			}
 		}

--- a/databases/catdat/scripts/utils/implications.ts
+++ b/databases/catdat/scripts/utils/implications.ts
@@ -22,7 +22,7 @@ export type NormalizedImplication = {
  */
 export function get_normalized_implications(
 	db: Database,
-	type: StructureType,
+	type: StructureType
 ): NormalizedImplication[] {
 	const implications_db = db
 		.prepare<
@@ -42,7 +42,7 @@ export function get_normalized_implications(
 				conclusions,
 				mapped_assumptions
 			FROM implications_view i
-			WHERE i.type = ?`,
+			WHERE i.type = ?`
 		)
 		.all(type)
 
@@ -57,7 +57,7 @@ export function get_normalized_implications(
 			const implication: NormalizedImplication = {
 				id: impl.id,
 				assumptions,
-				conclusion,
+				conclusion
 			}
 
 			if (Object.keys(mapped_assumptions).length > 0) {
@@ -72,7 +72,7 @@ export function get_normalized_implications(
 				const implication: NormalizedImplication = {
 					id: impl.id,
 					assumptions: conclusions,
-					conclusion: assumption,
+					conclusion: assumption
 				}
 
 				if (Object.keys(mapped_assumptions).length > 0) {
@@ -90,14 +90,14 @@ export function get_normalized_implications(
 function get_assumption_string(
 	implication: NormalizedImplication,
 	properties_dict: Record<string, PropertyMeta>,
-	conditional = false,
+	conditional = false
 ): string {
 	const { assumptions } = implication
 
 	const own = Array.from(assumptions)
 		.map(
 			(assumption) =>
-				`${properties_dict[assumption][conditional ? 'conditional_relation' : 'relation']} ${get_property_label(assumption)}`,
+				`${properties_dict[assumption][conditional ? 'conditional_relation' : 'relation']} ${get_property_label(assumption)}`
 		)
 		.join(' and ')
 
@@ -106,7 +106,7 @@ function get_assumption_string(
 	const mapped = Object.entries(implication.mapped_assumptions)
 		.map(
 			([map, props]) =>
-				`and the ${map} has the required properties (${Array.from(props!).join(', ')})`,
+				`and the ${map} has the required properties (${Array.from(props!).join(', ')})`
 		)
 		.join(', ')
 
@@ -116,7 +116,7 @@ function get_assumption_string(
 function get_conclusion_string(
 	implication: NormalizedImplication,
 	properties_dict: Record<string, PropertyMeta>,
-	conditional = false,
+	conditional = false
 ): string {
 	const { conclusion } = implication
 
@@ -126,7 +126,7 @@ function get_conclusion_string(
 export function get_proof_string(
 	implication: NormalizedImplication,
 	properties_dict: Record<string, PropertyMeta>,
-	type: StructureType,
+	type: StructureType
 ) {
 	const assumption_string = get_assumption_string(implication, properties_dict)
 	const conclusion_string = get_conclusion_string(implication, properties_dict)
@@ -139,7 +139,7 @@ export function get_contradiction_string(
 	implication: NormalizedImplication,
 	properties_dict: Record<string, PropertyMeta>,
 	property: string,
-	type: StructureType,
+	type: StructureType
 ) {
 	const assumption_string = get_assumption_string(implication, properties_dict, true)
 	const conclusion_string = get_conclusion_string(implication, properties_dict, true)

--- a/databases/catdat/scripts/utils/properties.ts
+++ b/databases/catdat/scripts/utils/properties.ts
@@ -25,7 +25,7 @@ export function get_properties_dict(db: Database, type: StructureType) {
 			FROM properties p
 			INNER JOIN relations r ON r.relation = p.relation
 			WHERE p.type = ?
-			ORDER BY lower(p.id)`,
+			ORDER BY lower(p.id)`
 		)
 		.all(type)
 
@@ -44,7 +44,7 @@ export function get_properties_dict(db: Database, type: StructureType) {
 export function get_property_assignments(
 	db: Database,
 	structures: { id: string }[],
-	type: StructureType,
+	type: StructureType
 ) {
 	const assignments = db
 		.prepare<
@@ -60,7 +60,7 @@ export function get_property_assignments(
 				structure_id,
 				is_satisfied
 			FROM property_assignments
-			WHERE type = ?`,
+			WHERE type = ?`
 		)
 		.all(type)
 
@@ -70,9 +70,9 @@ export function get_property_assignments(
 			{
 				satisfied: new Set<string>(),
 				unsatisfied: new Set<string>(),
-				undecidable: new Set<string>(),
-			},
-		]),
+				undecidable: new Set<string>()
+			}
+		])
 	)
 
 	for (const assignment of assignments) {
@@ -105,7 +105,7 @@ function get_assignment_key(is_satisfied: 0 | 1 | null) {
 export function get_property_assignments_by_deduction(
 	db: Database,
 	structures: { id: string }[],
-	type: StructureType,
+	type: StructureType
 ) {
 	const assignments = db
 		.prepare<
@@ -125,7 +125,7 @@ export function get_property_assignments_by_deduction(
 			FROM property_assignments
 			WHERE
 				type = ?
-				AND is_satisfied IS NOT NULL`,
+				AND is_satisfied IS NOT NULL`
 		)
 		.all(type)
 
@@ -135,14 +135,14 @@ export function get_property_assignments_by_deduction(
 			{
 				satisfied: {
 					non_deduced: new Set<string>(),
-					deduced: new Set<string>(),
+					deduced: new Set<string>()
 				},
 				unsatisfied: {
 					non_deduced: new Set<string>(),
-					deduced: new Set<string>(),
-				},
-			},
-		]),
+					deduced: new Set<string>()
+				}
+			}
+		])
 	)
 
 	for (const assignment of assignments) {

--- a/databases/catdat/scripts/utils/schema.ts
+++ b/databases/catdat/scripts/utils/schema.ts
@@ -22,7 +22,7 @@ export function write_schema_hash(hash: string) {
 	fs.writeFileSync(
 		path.join(schema_folder, 'schema.json'),
 		JSON.stringify({ hash }),
-		'utf8',
+		'utf8'
 	)
 }
 

--- a/databases/catdat/scripts/utils/seed.helpers.ts
+++ b/databases/catdat/scripts/utils/seed.helpers.ts
@@ -19,7 +19,7 @@ export function seed_file<T>(
 	db: Database,
 	label: string,
 	file: string,
-	insert: (item: T) => void,
+	insert: (item: T) => void
 ) {
 	console.info(`\nSeed ${label} ...`)
 	const item = read_yaml_file<T>(file)
@@ -41,7 +41,7 @@ export function seed_files<T>(
 	db: Database,
 	label: string,
 	folder: string,
-	insert: (item: T) => void,
+	insert: (item: T) => void
 ) {
 	console.info(`\nSeed ${label} ...`)
 

--- a/databases/catdat/scripts/utils/structures.ts
+++ b/databases/catdat/scripts/utils/structures.ts
@@ -25,7 +25,7 @@ export function get_structures(db: Database, type: StructureType): StructureMeta
                 s.dual_structure_id AS dual
             FROM structures s
 			WHERE s.type = ?
-            ORDER BY lower(s.name)`,
+            ORDER BY lower(s.name)`
 		)
 		.all(type)
 
@@ -43,7 +43,7 @@ export function get_structures(db: Database, type: StructureType): StructureMeta
 					`SELECT property_id FROM property_assignments
 					INNER JOIN ${TABLES[type]} t ON t.id = ?
 					WHERE structure_id = t.${map}
-					AND is_satisfied = TRUE`,
+					AND is_satisfied = TRUE`
 				)
 				.pluck()
 
@@ -65,7 +65,7 @@ export function get_structures(db: Database, type: StructureType): StructureMeta
  * original structure to prevent circular reasoning.
  */
 export function is_dual_structure(
-	structure: StructureMeta,
+	structure: StructureMeta
 ): structure is StructureMeta & { dual: string } {
 	return Boolean(structure.dual) && structure.name.toLowerCase().startsWith('dual')
 }

--- a/databases/catdat/scripts/watch.ts
+++ b/databases/catdat/scripts/watch.ts
@@ -22,7 +22,7 @@ function onchange(file: string) {
 
 const watcher = chokidar.watch(data_folder, {
 	persistent: true,
-	ignoreInitial: true,
+	ignoreInitial: true
 })
 
 watcher.on('add', onchange).on('change', onchange).on('unlink', onchange)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,15 +28,15 @@ export default defineConfig({
 		baseURL: 'http://localhost:5173',
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-		trace: 'on-first-retry',
+		trace: 'on-first-retry'
 	},
 
 	/* Configure projects for major browsers */
 	projects: [
 		{
 			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] },
-		},
+			use: { ...devices['Desktop Chrome'] }
+		}
 
 		// {
 		// 	name: 'firefox',
@@ -73,6 +73,6 @@ export default defineConfig({
 	webServer: {
 		command: 'pnpm dev',
 		url: 'http://localhost:5173',
-		reuseExistingServer: !process.env.CI,
-	},
+		reuseExistingServer: !process.env.CI
+	}
 })

--- a/src/components/ImplicationItem.svelte
+++ b/src/components/ImplicationItem.svelte
@@ -3,7 +3,7 @@
 		faArrowRight,
 		faArrowsLeftRight,
 		faInfoCircle,
-		faPlus,
+		faPlus
 	} from '@fortawesome/free-solid-svg-icons'
 	import Fa from 'svelte-fa'
 	import { get_property_url } from '$lib/commons/property.utils'
@@ -18,7 +18,7 @@
 	let { type, implication, highlighted_property }: Props = $props()
 
 	let has_additional_assumptions = $derived(
-		Object.values(implication.mapped_assumptions).some((list) => list?.length),
+		Object.values(implication.mapped_assumptions).some((list) => list?.length)
 	)
 </script>
 

--- a/src/components/Popup.svelte
+++ b/src/components/Popup.svelte
@@ -10,7 +10,7 @@
 		id: '',
 		open: false,
 		heading: '',
-		text: '',
+		text: ''
 	})
 
 	export function show_popup(data: Omit<PopupState, 'open'>) {

--- a/src/components/PropertyAssignmentList.svelte
+++ b/src/components/PropertyAssignmentList.svelte
@@ -6,7 +6,7 @@
 	import type {
 		PropertyAssignmentDisplay,
 		PropertyShort,
-		StructureType,
+		StructureType
 	} from '$lib/commons/types'
 	import { assignment_level } from '$lib/states/assignment_level.svelte'
 	import { pluralize } from '$lib/client/utils'
@@ -24,7 +24,7 @@
 		satisfied_properties,
 		unsatisfied_properties,
 		undecidable_properties,
-		unknown_properties,
+		unknown_properties
 	}: Props = $props()
 </script>
 
@@ -102,7 +102,7 @@
 		<p class="hint">
 			{pluralize(unknown_properties.length, {
 				one: "There is {count} property for which the database doesn't have an answer if it is satisfied or not.",
-				other: "There are {count} properties for which the database doesn't have an answer if they are satisfied or not.",
+				other: "There are {count} properties for which the database doesn't have an answer if they are satisfied or not."
 			})}
 
 			Please help to <a href="/content/contribute">contribute</a> the data!
@@ -120,7 +120,7 @@
 			<p class="hint">
 				{pluralize(undecidable_properties.length, {
 					one: 'There is {count} property for which it cannot be decided if it is satisfied or not.',
-					other: 'There are {count} properties for which it cannot be decided if they are satisfied or not.',
+					other: 'There are {count} properties for which it cannot be decided if they are satisfied or not.'
 				})}
 			</p>
 		{/if}

--- a/src/components/Selection.svelte
+++ b/src/components/Selection.svelte
@@ -19,7 +19,7 @@
 		section_label,
 		item_label,
 		max = Infinity,
-		children,
+		children
 	}: Props = $props()
 
 	let item = $state('')
@@ -112,7 +112,7 @@
 
 	function scroll_to_option() {
 		document.querySelector(`#${id}-${active_index}`)?.scrollIntoView({
-			block: 'center',
+			block: 'center'
 		})
 	}
 

--- a/src/components/SuggestionForm.svelte
+++ b/src/components/SuggestionForm.svelte
@@ -37,7 +37,7 @@
 			const res = await fetch('/api/submissions', {
 				method: 'POST',
 				body: JSON.stringify({ title, body, url: page.url.href, name }),
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json' }
 			})
 
 			const res_json = await res.json()
@@ -55,7 +55,7 @@
 			await tick()
 			section?.scrollIntoView({
 				block: 'end',
-				behavior: 'smooth',
+				behavior: 'smooth'
 			})
 		}
 	}
@@ -69,7 +69,7 @@
 		await tick()
 		section?.scrollIntoView({
 			block: 'start',
-			behavior: 'smooth',
+			behavior: 'smooth'
 		})
 	}
 </script>

--- a/src/components/TextWithProof.svelte
+++ b/src/components/TextWithProof.svelte
@@ -18,7 +18,7 @@
 		show_popup({
 			id,
 			heading: 'Proof',
-			text: proof!,
+			text: proof!
 		})
 	}
 </script>

--- a/src/lib/client/nav.ts
+++ b/src/lib/client/nav.ts
@@ -12,7 +12,7 @@ import {
 	faPenToSquare,
 	faPuzzlePiece,
 	faSearch,
-	type IconDefinition,
+	type IconDefinition
 } from '@fortawesome/free-solid-svg-icons'
 import { capitalize } from './utils'
 import { PLURALS } from '$lib/commons/structures'
@@ -29,38 +29,38 @@ export function get_navigation_links(type: StructureType): Link[] {
 		{
 			href: '/',
 			text: 'Home',
-			icon: faHome,
+			icon: faHome
 		},
 		{
 			href: `/${type}-list`,
 			text: capitalize(PLURALS[type]),
 			nested: [`/${type}/`, `/${type}-list/`],
-			icon: faDatabase,
+			icon: faDatabase
 		},
 		{
 			href: `/${type}-properties`,
 			text: `Properties`,
 			nested: [`/${type}-property/`, `/${type}-properties/`],
-			icon: faList,
+			icon: faList
 		},
 		{
 			href: `/${type}-implications`,
 			text: `Implications`,
 			nested: [`/${type}-implication`],
-			icon: faArrowsSplitUpAndLeft,
+			icon: faArrowsSplitUpAndLeft
 		},
 		{
 			href: `/${type}-comparison`,
 			text: `Compare`,
 			icon: faChartBar,
-			nested: [`/${type}-comparison`],
+			nested: [`/${type}-comparison`]
 		},
 		{
 			href: `/${type}-search`,
 			text: `Search`,
 			icon: faSearch,
-			nested: [`/${type}-search/results`],
-		},
+			nested: [`/${type}-search/results`]
+		}
 	]
 }
 
@@ -69,32 +69,32 @@ export function get_footer_links() {
 		{
 			href: '/content/contribute',
 			text: 'Contribute',
-			icon: faPenToSquare,
+			icon: faPenToSquare
 		},
 		{
 			href: '/settings',
 			text: 'Settings',
-			icon: faCog,
+			icon: faCog
 		},
 		{
 			href: '/missing',
 			text: 'Missing data',
-			icon: faPuzzlePiece,
+			icon: faPuzzlePiece
 		},
 		{
 			href: '/content/resources',
 			text: 'Resources',
-			icon: faBook,
+			icon: faBook
 		},
 		{
 			href: '/content/foundations',
 			text: 'Foundations',
-			icon: faCubes,
+			icon: faCubes
 		},
 		{
 			href: '/download',
 			text: 'Download',
-			icon: faDownload,
-		},
+			icon: faDownload
+		}
 	]
 }

--- a/src/lib/client/track.ts
+++ b/src/lib/client/track.ts
@@ -11,8 +11,8 @@ export async function track_visit() {
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({
 			device_type: get_device_type(),
-			theme: theme.value,
-		}),
+			theme: theme.value
+		})
 	})
 
 	if (res.ok) sessionStorage.setItem('visit-tracked', '1')

--- a/src/lib/commons/compare.utils.ts
+++ b/src/lib/commons/compare.utils.ts
@@ -25,6 +25,6 @@ export function save_comparison(type: StructureType, compared_categories: string
 
 	window.sessionStorage.setItem(
 		`comparison:${type}`,
-		JSON.stringify(compared_categories),
+		JSON.stringify(compared_categories)
 	)
 }

--- a/src/lib/commons/property.utils.ts
+++ b/src/lib/commons/property.utils.ts
@@ -4,14 +4,14 @@ const ENCODE_MAP: Record<string, string> = {
 	' ': '_',
 	'ℵ₀': 'aleph0',
 	'ℵ₁': 'aleph1',
-	'ℵ₂': 'aleph2',
+	'ℵ₂': 'aleph2'
 }
 
 const DECODE_MAP: Record<string, string> = {
 	_: ' ',
 	aleph0: 'ℵ₀',
 	aleph1: 'ℵ₁',
-	aleph2: 'ℵ₂',
+	aleph2: 'ℵ₂'
 }
 
 export function encode_property_ID(id: string): string {

--- a/src/lib/commons/structures.ts
+++ b/src/lib/commons/structures.ts
@@ -9,7 +9,7 @@ export function is_structure_type(txt: string): txt is StructureType {
 export const PLURALS: Record<StructureType, string> = {
 	category: 'categories',
 	functor: 'functors',
-	morphism: 'morphisms',
+	morphism: 'morphisms'
 }
 
 export function get_selected_type(pathname: string): StructureType {

--- a/src/lib/server/consistency.ts
+++ b/src/lib/server/consistency.ts
@@ -8,7 +8,7 @@ import { get_normalized_implications } from './fetchers/implications'
 export function get_contradiction(
 	satisfied_properties: Set<string>,
 	unsatisfied_properties: Set<string>,
-	type: StructureType,
+	type: StructureType
 ): { contradiction: string[] | null; err: SqliteError | null } {
 	for (const p of satisfied_properties) {
 		const contradiction = [`${p} ⟹ ${p}`]
@@ -22,7 +22,7 @@ export function get_contradiction(
 	const contradiction = contradiction_worker(
 		satisfied_properties,
 		unsatisfied_properties,
-		implications,
+		implications
 	)
 
 	return { contradiction, err: null }
@@ -31,7 +31,7 @@ export function get_contradiction(
 export function contradiction_worker(
 	satisfied_properties: Set<string>,
 	unsatisfied_properties: Set<string>,
-	implications: NormalizedImplication[],
+	implications: NormalizedImplication[]
 ): string[] | null {
 	for (const p of satisfied_properties) {
 		if (unsatisfied_properties.has(p)) return [`${p} ⟹ ${p}`]
@@ -73,14 +73,14 @@ export function contradiction_worker(
 	return build_shortest_proof(
 		satisfied_properties,
 		deduction_dict,
-		contradictory_property,
+		contradictory_property
 	)
 }
 
 function build_shortest_proof(
 	satisfied_properties: Set<string>,
 	deduction_dict: Record<string, NormalizedImplication>,
-	target_property: string,
+	target_property: string
 ) {
 	const proof: string[] = []
 

--- a/src/lib/server/db.app.ts
+++ b/src/lib/server/db.app.ts
@@ -8,7 +8,7 @@ import { APP_DB_AUTH_TOKEN, APP_DB_URL } from '$env/static/private'
  */
 const db_app = createClient({
 	url: APP_DB_URL,
-	authToken: APP_DB_AUTH_TOKEN,
+	authToken: APP_DB_AUTH_TOKEN
 })
 
 db_app.execute('PRAGMA foreign_keys = ON')
@@ -19,7 +19,7 @@ db_app.execute('PRAGMA foreign_keys = ON')
  */
 export async function query_app<T>({
 	sql,
-	values = [],
+	values = []
 }: {
 	sql: string
 	values?: any[]
@@ -38,15 +38,15 @@ export async function query_app<T>({
  * use sql templates, and specify the type of the result.
  */
 export async function batch_app<T extends any[]>(
-	queries: { sql: string; values?: any[] }[],
+	queries: { sql: string; values?: any[] }[]
 ) {
 	try {
 		const results = await db_app.batch(
-			queries.map(({ sql, values = [] }) => ({ sql, args: values ?? [] })),
+			queries.map(({ sql, values = [] }) => ({ sql, args: values ?? [] }))
 		)
 		return {
 			results: results.map(({ rows }) => rows) as Arrayed<T>,
-			err: null,
+			err: null
 		}
 	} catch (err) {
 		console.error(err)

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -13,15 +13,15 @@ const transporter = nodemailer.createTransport({
 	secure: false,
 	auth: {
 		user: EMAIL_ADDRESS,
-		pass: EMAIL_PASSWORD,
-	},
+		pass: EMAIL_PASSWORD
+	}
 })
 
 export async function send_email(email: Email) {
 	if (ENABLE_EMAILS === 'true') {
 		if (!EMAIL_ADDRESS || !EMAIL_PASSWORD) {
 			throw new Error(
-				'Email sending is enabled but EMAIL_ADDRESS or EMAIL_PASSWORD is not set',
+				'Email sending is enabled but EMAIL_ADDRESS or EMAIL_PASSWORD is not set'
 			)
 		}
 		await transporter.sendMail({ from: EMAIL_ADDRESS, ...email })

--- a/src/lib/server/fetchers/category.ts
+++ b/src/lib/server/fetchers/category.ts
@@ -9,7 +9,7 @@ export function fetch_category(id: string) {
 			{ objects: string; morphisms: string },
 			SpecialObject,
 			SpecialMorphism,
-			StructureShort,
+			StructureShort
 		]
 	>([
 		// specific information for the category
@@ -41,7 +41,7 @@ export function fetch_category(id: string) {
 			INNER JOIN structures s ON s.id = f.id
 			WHERE f.source = ${id} OR f.target = ${id}
 			ORDER BY lower(s.name)
-		`,
+		`
 	])
 
 	if (err) error(500, 'Could not load category')
@@ -55,7 +55,7 @@ export function fetch_category(id: string) {
 		...categories[0],
 		special_objects,
 		special_morphisms,
-		functors,
+		functors
 	}
 }
 
@@ -70,7 +70,7 @@ export function fetch_categories_with_missing_morphisms() {
 			WHERE s.type = 'category' AND m.type IS NULL
 			GROUP BY s.id
 			ORDER BY lower(s.name);
-		`,
+		`
 	)
 
 	if (err) error(500, 'Failed to load data')

--- a/src/lib/server/fetchers/comparison.ts
+++ b/src/lib/server/fetchers/comparison.ts
@@ -9,14 +9,14 @@ import { to_placeholders } from '$lib/server/utils'
 export function fetch_comparison_result(
 	compared_ids: string[],
 	type: StructureType,
-	callback: () => void,
+	callback: () => void
 ): ComparisonResult {
 	if (!compared_ids.length) error(400, `No ${type} selected for comparison`)
 
 	if (compared_ids.length > MAX_STRUCTURES_COMPARE) {
 		error(
 			400,
-			`It is only possible to compare up to ${MAX_STRUCTURES_COMPARE} ${PLURALS[type]}`,
+			`It is only possible to compare up to ${MAX_STRUCTURES_COMPARE} ${PLURALS[type]}`
 		)
 	}
 
@@ -30,7 +30,7 @@ export function fetch_comparison_result(
 			FROM structures
 			WHERE type = ?
 			AND id in (${to_placeholders(compared_ids)})`,
-		values: [type, ...compared_ids],
+		values: [type, ...compared_ids]
 	})
 
 	if (err_cat) error(500, `Could not load ${PLURALS[type]}`)
@@ -39,7 +39,7 @@ export function fetch_comparison_result(
 	if (invalid_id) error(404, `Could not find ${type} with ID '${invalid_id}'`)
 
 	const structures = rows.sort(
-		(a, b) => compared_ids.indexOf(a.id) - compared_ids.indexOf(b.id),
+		(a, b) => compared_ids.indexOf(a.id) - compared_ids.indexOf(b.id)
 	)
 
 	const select_columns = compared_ids
@@ -49,7 +49,7 @@ export function fetch_comparison_result(
 					WHEN a${i}.is_satisfied = TRUE THEN 'yes'
 					WHEN a${i}.is_satisfied = FALSE THEN 'no'
 					ELSE 'unknown'
-				END AS struct${i}`,
+				END AS struct${i}`
 		)
 		.join(',\n')
 
@@ -77,7 +77,7 @@ export function fetch_comparison_result(
 
 	const { rows: comparison_objects, err } = query<Record<string, string>>({
 		sql: comparison_query,
-		values,
+		values
 	})
 
 	if (err) error(500, 'Could not load comparison table')
@@ -89,6 +89,6 @@ export function fetch_comparison_result(
 	return {
 		structures: render_nested_formulas(structures),
 		comparison_table,
-		type,
+		type
 	}
 }

--- a/src/lib/server/fetchers/content.ts
+++ b/src/lib/server/fetchers/content.ts
@@ -27,7 +27,7 @@ export function fetch_category_references(content_id: string) {
             WHERE
                 type = 'category'
                 AND proof LIKE '%/content/' || ${content_id} || '%'
-        `,
+        `
 	])
 
 	if (err_categories) error(500, 'Could not load context')

--- a/src/lib/server/fetchers/functor.ts
+++ b/src/lib/server/fetchers/functor.ts
@@ -27,7 +27,7 @@ export function fetch_functor(id: string) {
             LEFT JOIN functors AS rf ON rf.left_adjoint = f.id
             LEFT JOIN structures AS ra ON ra.id = rf.id
             WHERE f.id = ${id}
-        `,
+        `
 	)
 
 	if (err) error(500, 'Could not load functor')

--- a/src/lib/server/fetchers/implication.ts
+++ b/src/lib/server/fetchers/implication.ts
@@ -5,7 +5,7 @@ import type {
 	ImplicationDB,
 	MappedTypes,
 	StructureShort,
-	StructureType,
+	StructureType
 } from '$lib/commons/types'
 import { display_implication } from '$lib/server/transforms'
 
@@ -38,7 +38,7 @@ export function fetch_implication(type: StructureType, id: string) {
             SELECT map, mapped_type
             FROM structure_maps
             WHERE type = ${type}
-        `,
+        `
 	])
 
 	if (err) error(500, 'Could not load implication')

--- a/src/lib/server/fetchers/implications.ts
+++ b/src/lib/server/fetchers/implications.ts
@@ -4,7 +4,7 @@ import { error } from '@sveltejs/kit'
 import type {
 	ImplicationDB,
 	NormalizedImplication,
-	StructureType,
+	StructureType
 } from '$lib/commons/types'
 import { display_implication } from '$lib/server/transforms'
 import { parse_json_set, parse_nested_json_list } from '$lib/server/utils'
@@ -57,7 +57,7 @@ export function get_normalized_implications(type: StructureType) {
 				mapped_assumptions
 			FROM implications_view
 			WHERE type = ${type}
-		`,
+		`
 	)
 
 	if (err) return { implications: null, err }
@@ -80,7 +80,7 @@ export function get_normalized_implications(type: StructureType) {
 				implications.push({
 					id: impl.id,
 					assumptions: conclusions,
-					conclusion: assumption,
+					conclusion: assumption
 				})
 			}
 		}

--- a/src/lib/server/fetchers/missing_data.ts
+++ b/src/lib/server/fetchers/missing_data.ts
@@ -11,7 +11,7 @@ export function fetch_missing_data(type: StructureType) {
 			StructureShort & { count: number },
 			{ id1: string; name1: string; id2: string; name2: string },
 			{ id: string; dual_property_id: string | null },
-			{ p: string; q: string },
+			{ p: string; q: string }
 		]
 	>([
 		// structures with unknown properties
@@ -70,7 +70,7 @@ export function fetch_missing_data(type: StructureType) {
                 AND an.type = ${type}
                 AND a.is_satisfied = TRUE
                 AND an.is_satisfied = FALSE
-	    `,
+	    `
 	])
 
 	if (err) error(500, 'Failed to load data')
@@ -79,12 +79,12 @@ export function fetch_missing_data(type: StructureType) {
 		structures_with_unknown_properties,
 		undistinguishable_structure_pairs,
 		properties,
-		witnessed_pairs,
+		witnessed_pairs
 	] = results
 
 	const total_unknown_property_pairs = structures_with_unknown_properties.reduce(
 		(total, item) => item.count + total,
-		0,
+		0
 	)
 
 	const { implications, err: err_imp } = get_normalized_implications(type)
@@ -112,7 +112,7 @@ export function fetch_missing_data(type: StructureType) {
 			const contradiction = contradiction_worker(
 				new Set([p.id]),
 				new Set([q.id]),
-				implications,
+				implications
 			)
 
 			if (!contradiction) missing_combinations.push([p.id, q.id])
@@ -123,6 +123,6 @@ export function fetch_missing_data(type: StructureType) {
 		structures_with_unknown_properties,
 		undistinguishable_structure_pairs,
 		total_unknown_property_pairs,
-		missing_combinations,
+		missing_combinations
 	}
 }

--- a/src/lib/server/fetchers/morphism.ts
+++ b/src/lib/server/fetchers/morphism.ts
@@ -14,7 +14,7 @@ export function fetch_morphism(id: string) {
             FROM morphisms m
             INNER JOIN structures AS c ON c.id = m.category
             WHERE m.id = ${id}
-        `,
+        `
 	)
 
 	if (err) error(500, 'Could not load morphism')

--- a/src/lib/server/fetchers/properties.ts
+++ b/src/lib/server/fetchers/properties.ts
@@ -2,7 +2,7 @@ import type {
 	GroupedPropertyShort,
 	PropertyShort,
 	StructureType,
-	TagObject,
+	TagObject
 } from '$lib/commons/types'
 import sql from 'sql-template-tag'
 import { query, batch } from '$lib/server/db.catdat'
@@ -14,7 +14,7 @@ export function get_property_ids(type: StructureType) {
 			SELECT id FROM properties
 			WHERE type = ${type}
 			ORDER BY lower(id)
-		`,
+		`
 	)
 
 	if (err) error(500, 'Failed to load properties')
@@ -39,7 +39,7 @@ export function fetch_grouped_properties_and_tags(type: StructureType) {
 				WHERE a.tag = t.tag AND a.type = ${type}
 			)
 			ORDER BY t.id
-		`,
+		`
 	])
 
 	if (err) error(500, 'Failed to load properties')
@@ -61,7 +61,7 @@ export function fetch_grouped_properties_and_tags(type: StructureType) {
 			const swap = {
 				id: p.dual_property_id,
 				dual_property_id: p.id,
-				relation: p.relation,
+				relation: p.relation
 			}
 			grouped_properties.push(swap)
 		} else {

--- a/src/lib/server/fetchers/property.ts
+++ b/src/lib/server/fetchers/property.ts
@@ -3,7 +3,7 @@ import type {
 	StructureShort,
 	PropertyDB,
 	StructureType,
-	TagObject,
+	TagObject
 } from '$lib/commons/types'
 import { batch } from '$lib/server/db.catdat'
 import { display_implication, display_property } from '$lib/server/transforms'
@@ -18,7 +18,7 @@ export function fetch_property(type: StructureType, id: string) {
 			TagObject,
 			ImplicationDB,
 			StructureShort & { is_satisfied: 0 | 1 | null },
-			StructureShort,
+			StructureShort
 		]
 	>([
 		// basic information
@@ -98,7 +98,7 @@ export function fetch_property(type: StructureType, id: string) {
                 s.type = ${type}
                 AND pa.property_id IS NULL
             ORDER BY lower(s.name)
-        `,
+        `
 	])
 
 	if (err) error(500, 'Could not load property')
@@ -109,7 +109,7 @@ export function fetch_property(type: StructureType, id: string) {
 		tag_objects,
 		relevant_implications_db,
 		known_structures,
-		unknown_structures,
+		unknown_structures
 	] = results
 
 	if (!properties.length) {
@@ -143,6 +143,6 @@ export function fetch_property(type: StructureType, id: string) {
 		counterexamples,
 		unknown_structures,
 		undecidable_structures,
-		relevant_implications,
+		relevant_implications
 	}
 }

--- a/src/lib/server/fetchers/search.ts
+++ b/src/lib/server/fetchers/search.ts
@@ -11,7 +11,7 @@ export function fetch_search_results(
 	satisfied_query: string | null,
 	unsatisfied_query: string | null,
 	type: StructureType,
-	callback: () => void,
+	callback: () => void
 ): SearchResults {
 	if (!satisfied_query && !unsatisfied_query) {
 		error(400, 'No properties selected')
@@ -40,7 +40,7 @@ export function fetch_search_results(
 		: []
 
 	const invalid_satisfied_property = satisfied_properties.find(
-		(p) => !all_properties.has(p),
+		(p) => !all_properties.has(p)
 	)
 
 	if (invalid_satisfied_property) {
@@ -52,7 +52,7 @@ export function fetch_search_results(
 		: []
 
 	const invalid_unsatisfied_property = unsatisfied_properties.find(
-		(p) => !all_properties.has(p),
+		(p) => !all_properties.has(p)
 	)
 
 	if (invalid_unsatisfied_property) {
@@ -60,11 +60,11 @@ export function fetch_search_results(
 	}
 
 	const dual_satisfied_properties = satisfied_properties.map(
-		(p) => dual_properties_dict[p],
+		(p) => dual_properties_dict[p]
 	)
 
 	const dual_unsatisfied_properties = unsatisfied_properties.map(
-		(p) => dual_properties_dict[p],
+		(p) => dual_properties_dict[p]
 	)
 
 	const dual_search_available =
@@ -74,7 +74,7 @@ export function fetch_search_results(
 	const { contradiction, err: err_con } = get_contradiction(
 		new Set(satisfied_properties),
 		new Set(unsatisfied_properties),
-		type,
+		type
 	)
 
 	if (err_con) error(500, 'Consistency check failed')
@@ -90,7 +90,7 @@ export function fetch_search_results(
 			dual_unsatisfied_properties,
 			dual_search_available,
 			found_structures: [],
-			type,
+			type
 		}
 	}
 
@@ -132,8 +132,8 @@ export function fetch_search_results(
 			type,
 			...all_selected_properties,
 			...satisfied_properties,
-			...unsatisfied_properties,
-		],
+			...unsatisfied_properties
+		]
 	})
 
 	if (err) error(500, 'Search failed')
@@ -148,6 +148,6 @@ export function fetch_search_results(
 		dual_unsatisfied_properties,
 		dual_search_available,
 		found_structures,
-		type,
+		type
 	}
 }

--- a/src/lib/server/fetchers/structure.ts
+++ b/src/lib/server/fetchers/structure.ts
@@ -7,7 +7,7 @@ import type {
 	StructureDisplay,
 	StructureShort,
 	StructureType,
-	TagObject,
+	TagObject
 } from '$lib/commons/types'
 import { error } from '@sveltejs/kit'
 import sql from 'sql-template-tag'
@@ -23,7 +23,7 @@ export function fetch_structure(type: StructureType, id: string): StructureDetai
 			PropertyAssignmentDB,
 			PropertyShort,
 			StructureShort,
-			CommentObject,
+			CommentObject
 		]
 	>([
 		// basic information
@@ -115,7 +115,7 @@ export function fetch_structure(type: StructureType, id: string): StructureDetai
 		sql`
             SELECT id, comment FROM structure_comments
             WHERE structure_id = ${id}
-        `,
+        `
 	])
 
 	if (err) error(500, `Could not load ${type} with ID ${id}`)
@@ -127,7 +127,7 @@ export function fetch_structure(type: StructureType, id: string): StructureDetai
 		properties_db,
 		unknown_properties,
 		undistinguishable_structures,
-		comments,
+		comments
 	] = results
 
 	if (!structures.length) error(404, `Could not find ${type} with ID '${id}'`)
@@ -157,6 +157,6 @@ export function fetch_structure(type: StructureType, id: string): StructureDetai
 		unknown_properties,
 		undecidable_properties,
 		undistinguishable_structures,
-		comments,
+		comments
 	}
 }

--- a/src/lib/server/fetchers/structures.ts
+++ b/src/lib/server/fetchers/structures.ts
@@ -34,7 +34,7 @@ export function fetch_structures_and_tags(type: StructureType) {
                 WHERE a.tag = t.tag AND a.type = ${type}
             )
             ORDER BY t.id
-        `,
+        `
 	])
 
 	if (err) error(500, `${capitalize(PLURALS[type])} could not be loaded`)

--- a/src/lib/server/formulas.ts
+++ b/src/lib/server/formulas.ts
@@ -6,12 +6,12 @@ export const MATH_REGEX = /\$\$(.*?)\$\$|\$(.*?)\$/gs
 
 export function render_formula(
 	formula: string,
-	options: { displayMode: boolean } = { displayMode: false },
+	options: { displayMode: boolean } = { displayMode: false }
 ): string {
 	return katex.renderToString(formula, {
 		throwOnError: true,
 		macros: MACROS,
-		...options,
+		...options
 	})
 }
 

--- a/src/lib/server/macros.ts
+++ b/src/lib/server/macros.ts
@@ -3,5 +3,5 @@ import path from 'node:path'
 import fs from 'node:fs'
 
 export const MACROS = YAML.parse(
-	fs.readFileSync(path.resolve('databases', 'catdat', 'data', 'macros.yaml'), 'utf8'),
+	fs.readFileSync(path.resolve('databases', 'catdat', 'data', 'macros.yaml'), 'utf8')
 ) as Record<string, string>

--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -72,7 +72,7 @@ md.block.ruler.before(
 
 		state.line = next_line + 1
 		return true
-	},
+	}
 )
 
 /**
@@ -93,7 +93,7 @@ function preprocess_math(content: string) {
 					: render_formula(display_formula, { displayMode: true })
 
 			return placeholder
-		},
+		}
 	)
 
 	return { processed_content: with_placeholders, formulas }
@@ -127,7 +127,7 @@ function insert_svg(content: string) {
  * Renders markdown content and formulas of a given string
  */
 function render_content<T = Record<string, unknown>>(
-	txt: string,
+	txt: string
 ): { meta_data: T; html: string } {
 	const { data, content } = matter(txt)
 

--- a/src/lib/server/redis.ts
+++ b/src/lib/server/redis.ts
@@ -6,7 +6,7 @@ if (!REDIS_URL) throw new Error('Redis URL is missing')
 
 export const redis = new Redis(REDIS_URL, {
 	tls: dev ? undefined : { rejectUnauthorized: true },
-	retryStrategy: (times) => (times >= 5 ? null : 1000),
+	retryStrategy: (times) => (times >= 5 ? null : 1000)
 })
 
 redis.on('connect', () => {

--- a/src/lib/server/transforms.ts
+++ b/src/lib/server/transforms.ts
@@ -4,7 +4,7 @@ import type {
 	PropertyAssignmentDB,
 	PropertyAssignmentDisplay,
 	ImplicationDB,
-	ImplicationDisplay,
+	ImplicationDisplay
 } from '$lib/commons/types'
 import { parse_nested_json_list } from './utils'
 
@@ -15,18 +15,18 @@ export function display_property(property: PropertyDB): PropertyDisplay {
 		description: property.description,
 		dual_property_id: property.dual_property_id,
 		nlab_link: property.nlab_link,
-		invariant_under_equivalences: Boolean(property.invariant_under_equivalences),
+		invariant_under_equivalences: Boolean(property.invariant_under_equivalences)
 	}
 }
 
 export function display_property_assignment(
-	property: PropertyAssignmentDB,
+	property: PropertyAssignmentDB
 ): PropertyAssignmentDisplay {
 	return {
 		id: property.id,
 		proof: property.proof,
 		is_deduced: Boolean(property.is_deduced),
-		relation: property.relation,
+		relation: property.relation
 	}
 }
 
@@ -39,6 +39,6 @@ export function display_implication(implication: ImplicationDB): ImplicationDisp
 		proof: implication.proof,
 		assumptions: JSON.parse(implication.assumptions),
 		conclusions: JSON.parse(implication.conclusions),
-		mapped_assumptions: parse_nested_json_list(implication.mapped_assumptions),
+		mapped_assumptions: parse_nested_json_list(implication.mapped_assumptions)
 	}
 }

--- a/src/lib/states/assignment_level.svelte.ts
+++ b/src/lib/states/assignment_level.svelte.ts
@@ -3,7 +3,7 @@ import { browser } from '$app/environment'
 export const ASSIGNMENT_LEVELS = {
 	all: 'Show all properties for a structure. Indicate which properties have been manually assigned and which have been deduced. This is the default.',
 	merged: "Show all properties for a structure, but don't indicate which properties are manually assigned and which have been deduced.",
-	basic: 'Show only those properties for a structure that have been manually assigned. Deduced properties are not shown.',
+	basic: 'Show only those properties for a structure that have been manually assigned. Deduced properties are not shown.'
 } as const
 
 type AssignmentLevel = keyof typeof ASSIGNMENT_LEVELS
@@ -15,7 +15,7 @@ function is_valid_assignment_level(level: string | null): level is AssignmentLev
 const DEFAULT_ASSIGNMENT_LEVEL: AssignmentLevel = 'all'
 
 export const assignment_level = $state<{ value: AssignmentLevel }>({
-	value: get_saved_assignment_level(),
+	value: get_saved_assignment_level()
 })
 
 function get_saved_assignment_level(): AssignmentLevel {

--- a/src/pages/CategoryDetailPage.svelte
+++ b/src/pages/CategoryDetailPage.svelte
@@ -66,7 +66,7 @@
 				<p class="hint">
 					{pluralize(data.functors.length, {
 						one: 'There is 1 functor',
-						other: 'There are {count} functors',
+						other: 'There are {count} functors'
 					})}
 					whose source or target is the {data.structure.name}.
 				</p>

--- a/src/pages/ComparisonPage.svelte
+++ b/src/pages/ComparisonPage.svelte
@@ -6,7 +6,7 @@
 	import {
 		get_compared_structures,
 		MAX_STRUCTURES_COMPARE,
-		save_comparison,
+		save_comparison
 	} from '$lib/commons/compare.utils'
 	import { PLURALS } from '$lib/commons/structures'
 	import type { StructureShort, StructureType } from '$lib/commons/types'
@@ -28,12 +28,11 @@
 	let chosen_structures: StructureShort[] = $derived(
 		compared_structures
 			.map((name) => structures.find((s) => s.name === name))
-			.filter((s) => s !== undefined),
+			.filter((s) => s !== undefined)
 	)
 
 	let is_valid_comparison = $derived(
-		chosen_structures.length > 0 &&
-			chosen_structures.length <= MAX_STRUCTURES_COMPARE,
+		chosen_structures.length > 0 && chosen_structures.length <= MAX_STRUCTURES_COMPARE
 	)
 
 	function compare_structures() {
@@ -43,7 +42,7 @@
 	}
 
 	let is_comparing = $derived(
-		navigating.to?.route.id?.startsWith(`/${type}-comparison`),
+		navigating.to?.route.id?.startsWith(`/${type}-comparison`)
 	)
 </script>
 

--- a/src/pages/ComparisonResultPage.svelte
+++ b/src/pages/ComparisonResultPage.svelte
@@ -7,7 +7,7 @@
 		faCheck,
 		faQuestion,
 		faXmark,
-		type IconDefinition,
+		type IconDefinition
 	} from '@fortawesome/free-solid-svg-icons'
 	import Fa from 'svelte-fa'
 
@@ -18,7 +18,7 @@
 	const icon_config: Record<string, IconDefinition> = {
 		yes: faCheck,
 		no: faXmark,
-		unknown: faQuestion,
+		unknown: faQuestion
 	}
 
 	let paragraph_element = $state<HTMLElement | null>(null)
@@ -31,7 +31,7 @@
 			([entry]) => {
 				show_thead_outline = entry.intersectionRatio == 0
 			},
-			{ threshold: [0] },
+			{ threshold: [0] }
 		)
 
 		observer.observe(paragraph_element)

--- a/src/pages/ImplicationListPage.svelte
+++ b/src/pages/ImplicationListPage.svelte
@@ -29,7 +29,7 @@
 	let displayed_implications = $derived(
 		show_deduced_implications
 			? implications
-			: implications.filter((implication) => !implication.is_deduced),
+			: implications.filter((implication) => !implication.is_deduced)
 	)
 
 	let search = $state('')
@@ -38,10 +38,10 @@
 		search
 			? displayed_implications.filter((implication) =>
 					[...implication.assumptions, ...implication.conclusions].some(
-						(prop) => normalize_text(prop).includes(normalize_text(search)),
-					),
+						(prop) => normalize_text(prop).includes(normalize_text(search))
+					)
 				)
-			: displayed_implications,
+			: displayed_implications
 	)
 </script>
 
@@ -54,7 +54,7 @@
 <p class="hint">
 	{pluralize(filtered_implications.length, {
 		one: 'Found {count} implication*',
-		other: 'Found {count} implications*',
+		other: 'Found {count} implications*'
 	})}
 </p>
 

--- a/src/pages/ImplicationPage.svelte
+++ b/src/pages/ImplicationPage.svelte
@@ -10,7 +10,7 @@
 		ImplicationDisplay,
 		MappedTypes,
 		StructureShort,
-		StructureType,
+		StructureType
 	} from '$lib/commons/types'
 	import { PLURALS } from '$lib/commons/structures'
 
@@ -91,7 +91,7 @@
 		<summary class="hint">
 			{pluralize(structures.length, {
 				one: `Show {count} ${type} using this implication`,
-				other: `Show {count} ${PLURALS[type]} using this implication`,
+				other: `Show {count} ${PLURALS[type]} using this implication`
 			})}
 		</summary>
 		<StructureList {structures} {type} />

--- a/src/pages/PropertyListPage.svelte
+++ b/src/pages/PropertyListPage.svelte
@@ -27,10 +27,10 @@
 						normalize_text(property.id).includes(normalize_text(search)) ||
 						(!!property.dual_property_id &&
 							normalize_text(property.dual_property_id).includes(
-								normalize_text(search),
-							)),
+								normalize_text(search)
+							))
 				)
-			: grouped_properties,
+			: grouped_properties
 	)
 </script>
 
@@ -46,7 +46,7 @@
 	{:else}
 		{pluralize(searched_properties.length, {
 			one: 'Found {count} group',
-			other: 'Found {count} groups',
+			other: 'Found {count} groups'
 		})}
 	{/if}
 </p>

--- a/src/pages/PropertyPage.svelte
+++ b/src/pages/PropertyPage.svelte
@@ -12,7 +12,7 @@
 		ImplicationDisplay,
 		PropertyDisplay,
 		StructureShort,
-		StructureType,
+		StructureType
 	} from '$lib/commons/types'
 	import { PLURALS } from '$lib/commons/structures'
 	import TagList from '$components/TagList.svelte'
@@ -38,7 +38,7 @@
 		counterexamples,
 		unknown_structures,
 		undecidable_structures,
-		relevant_implications,
+		relevant_implications
 	}: Props = $props()
 </script>
 
@@ -111,7 +111,7 @@
 <p class="hint">
 	{pluralize(examples.length, {
 		one: `There is {count} ${type} with this property.`,
-		other: `There are {count} ${PLURALS[type]} with this property.`,
+		other: `There are {count} ${PLURALS[type]} with this property.`
 	})}
 </p>
 
@@ -122,7 +122,7 @@
 <p class="hint">
 	{pluralize(counterexamples.length, {
 		one: `There is {count} ${type} without this property.`,
-		other: `There are {count} ${PLURALS[type]} without this property.`,
+		other: `There are {count} ${PLURALS[type]} without this property.`
 	})}
 </p>
 
@@ -134,7 +134,7 @@
 	<p class="hint">
 		{pluralize(undecidable_structures.length, {
 			one: `There is {count} ${type} for which it cannot be decided if this property is satisfied or not.`,
-			other: `There are {count} ${PLURALS[type]} for which it cannot be decided if this property is satisfied or not.`,
+			other: `There are {count} ${PLURALS[type]} for which it cannot be decided if this property is satisfied or not.`
 		})}
 	</p>
 
@@ -146,7 +146,7 @@
 <p class="hint">
 	{pluralize(unknown_structures.length, {
 		one: `There is {count} ${type} for which the database has no information on whether it satisfies this property.`,
-		other: `There are {count} ${PLURALS[type]} for which the database has no information on whether they satisfy this property.`,
+		other: `There are {count} ${PLURALS[type]} for which the database has no information on whether they satisfy this property.`
 	})}
 	{#if unknown_structures.length > 0}
 		Please help us fill in the gaps by

--- a/src/pages/SearchPage.svelte
+++ b/src/pages/SearchPage.svelte
@@ -22,7 +22,7 @@
 	let unsatisfied_properties: string[] = $state([])
 
 	let is_valid_search = $derived(
-		satisfied_properties.length > 0 || unsatisfied_properties.length > 0,
+		satisfied_properties.length > 0 || unsatisfied_properties.length > 0
 	)
 
 	$effect(() => {

--- a/src/pages/SearchResultsPage.svelte
+++ b/src/pages/SearchResultsPage.svelte
@@ -20,7 +20,7 @@
 		dual_unsatisfied_properties,
 		dual_search_available,
 		found_structures,
-		contradiction,
+		contradiction
 	}: Props = $props()
 
 	function get_dual_search_results_link() {
@@ -45,7 +45,7 @@
 	$effect(() => {
 		window.sessionStorage.setItem(
 			`${type}-search`,
-			JSON.stringify({ satisfied_properties, unsatisfied_properties }),
+			JSON.stringify({ satisfied_properties, unsatisfied_properties })
 		)
 	})
 </script>
@@ -89,7 +89,7 @@
 	<p class="hint">
 		{pluralize(found_structures.length, {
 			one: `Found {count} ${type}`,
-			other: `Found {count} ${PLURALS[type]}`,
+			other: `Found {count} ${PLURALS[type]}`
 		})}
 	</p>
 

--- a/src/pages/StructureDetailPage.svelte
+++ b/src/pages/StructureDetailPage.svelte
@@ -13,7 +13,7 @@
 		RelatedStructure,
 		StructureDisplay,
 		StructureShort,
-		StructureType,
+		StructureType
 	} from '$lib/commons/types'
 	import type { Snippet } from 'svelte'
 
@@ -46,7 +46,7 @@
 		comments,
 		definition,
 		specials,
-		footer,
+		footer
 	}: Props = $props()
 </script>
 

--- a/src/pages/StructureListPage.svelte
+++ b/src/pages/StructureListPage.svelte
@@ -23,9 +23,9 @@
 	let searched_structures = $derived(
 		search
 			? structures.filter((s) =>
-					normalize_text(s.name).includes(normalize_text(search)),
+					normalize_text(s.name).includes(normalize_text(search))
 				)
-			: structures,
+			: structures
 	)
 </script>
 
@@ -57,7 +57,7 @@
 	<p class="hint">
 		{pluralize(searched_structures.length, {
 			one: `Found {count} ${type}`,
-			other: `Found {count} ${PLURALS[type]}`,
+			other: `Found {count} ${PLURALS[type]}`
 		})}
 	</p>
 

--- a/src/pages/TaggedPropertiesPage.svelte
+++ b/src/pages/TaggedPropertiesPage.svelte
@@ -21,7 +21,7 @@
 <p class="hint">
 	{pluralize(properties.length, {
 		one: `Found {count} property`,
-		other: `Found {count} properties`,
+		other: `Found {count} properties`
 	})}
 </p>
 

--- a/src/pages/TaggedStructuresPage.svelte
+++ b/src/pages/TaggedStructuresPage.svelte
@@ -21,7 +21,7 @@
 <p class="hint">
 	{pluralize(structures.length, {
 		one: `Found {count} ${type}`,
-		other: `Found {count} ${PLURALS[type]}`,
+		other: `Found {count} ${PLURALS[type]}`
 	})}
 </p>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 		faDatabase,
 		faList,
 		faSearch,
-		faUsers,
+		faUsers
 	} from '@fortawesome/free-solid-svg-icons'
 	import Fa from 'svelte-fa'
 </script>

--- a/src/routes/[type]-search/+page.svelte
+++ b/src/routes/[type]-search/+page.svelte
@@ -9,7 +9,7 @@
 			'/category-search/results?satisfied=finitely_complete~pointed&unsatisfied=complete',
 		functor: '/functor-search/results?satisfied=continuous&unsatisfied=cocontinuous',
 		morphism:
-			'/morphism-search/results?satisfied=monomorphism~epimorphism&unsatisfied=isomorphism',
+			'/morphism-search/results?satisfied=monomorphism~epimorphism&unsatisfied=isomorphism'
 	}
 </script>
 

--- a/src/routes/[type]-search/results/+page.server.ts
+++ b/src/routes/[type]-search/results/+page.server.ts
@@ -13,6 +13,6 @@ export const load = (event) => {
 	const unsatisfied_query = event.url.searchParams.get('unsatisfied')
 
 	return fetch_search_results(satisfied_query, unsatisfied_query, type, () =>
-		cache_page(event),
+		cache_page(event)
 	)
 }

--- a/src/routes/[type]/[id]/+page.server.ts
+++ b/src/routes/[type]/[id]/+page.server.ts
@@ -10,7 +10,7 @@ import { add_math, strip_math } from '$lib/server/utils'
 const special_fetchers = {
 	category: fetch_category,
 	functor: fetch_functor,
-	morphism: fetch_morphism,
+	morphism: fetch_morphism
 }
 
 export const load = (event) => {
@@ -25,12 +25,12 @@ export const load = (event) => {
 
 	if (special_structure_data.type === 'functor') {
 		structure_data.structure.notation = add_math(
-			`${strip_math(structure_data.structure.notation)}: ${strip_math(special_structure_data.source_notation)} \\to ${strip_math(special_structure_data.target_notation)}`,
+			`${strip_math(structure_data.structure.notation)}: ${strip_math(special_structure_data.source_notation)} \\to ${strip_math(special_structure_data.target_notation)}`
 		)
 	}
 
 	return render_nested_formulas({
 		structure_data,
-		special_structure_data,
+		special_structure_data
 	})
 }

--- a/src/routes/admin/login/+page.server.ts
+++ b/src/routes/admin/login/+page.server.ts
@@ -14,7 +14,7 @@ export const actions: Actions = {
 
 		if (count >= 5) {
 			return fail(429, {
-				error: 'Too many login attempts. Please try again later.',
+				error: 'Too many login attempts. Please try again later.'
 			})
 		}
 
@@ -37,5 +37,5 @@ export const actions: Actions = {
 		await redis.del(key)
 
 		redirect(303, '/admin')
-	},
+	}
 }

--- a/src/routes/admin/sessions.ts
+++ b/src/routes/admin/sessions.ts
@@ -14,7 +14,7 @@ export function create_session(event: RequestEvent) {
 		httpOnly: true,
 		secure: true,
 		sameSite: 'lax',
-		maxAge: 60 * 60,
+		maxAge: 60 * 60
 	})
 }
 

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -35,7 +35,7 @@ export const load = async (event) => {
 				device_type: string
 				count: number
 				percentage: number
-			},
+			}
 		]
 	>([
 		sql`SELECT
@@ -74,7 +74,7 @@ export const load = async (event) => {
 				ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER (), 1) AS percentage
             FROM visits
             GROUP BY device_type
-            ORDER BY count DESC`,
+            ORDER BY count DESC`
 	])
 
 	if (err) {
@@ -86,7 +86,7 @@ export const load = async (event) => {
 		daily_visits,
 		country_stats,
 		theme_stats,
-		device_stats,
+		device_stats
 	] = results
 
 	return {
@@ -98,6 +98,6 @@ export const load = async (event) => {
 		daily_visits,
 		country_stats,
 		theme_stats,
-		device_stats,
+		device_stats
 	}
 }

--- a/src/routes/admin/submissions/+page.server.ts
+++ b/src/routes/admin/submissions/+page.server.ts
@@ -45,7 +45,7 @@ export const actions = {
 		if (!submission_id) return fail(400, { error: 'Submission ID required' })
 
 		const { err } = await query_app(
-			sql`DELETE FROM submissions WHERE id = ${submission_id}`,
+			sql`DELETE FROM submissions WHERE id = ${submission_id}`
 		)
 
 		if (err) return fail(500, { error: 'Failed to delete submission' })
@@ -71,7 +71,7 @@ export const actions = {
 				SET approved_at = CURRENT_TIMESTAMP
 				WHERE id = ${submission_id}
 				RETURNING title, body, name, url
-			`,
+			`
 		)
 
 		if (err) return fail(500, { error: 'Failed to approve submission' })
@@ -80,7 +80,7 @@ export const actions = {
 
 		const app = new App({
 			appId: GITHUB_APP_ID,
-			privateKey: GITHUB_PRIVATE_KEY,
+			privateKey: GITHUB_PRIVATE_KEY
 		})
 
 		const footer = name
@@ -91,14 +91,14 @@ export const actions = {
 
 		try {
 			const octokit = await app.getInstallationOctokit(
-				Number(GITHUB_INSTALLATION_ID),
+				Number(GITHUB_INSTALLATION_ID)
 			)
 
 			const issue = await octokit.request('POST /repos/{owner}/{repo}/issues', {
 				owner: GITHUB_OWNER,
 				repo: GITHUB_REPO,
 				title,
-				body: full_body,
+				body: full_body
 			})
 
 			return { issue_url: issue.data.html_url }
@@ -106,5 +106,5 @@ export const actions = {
 			console.error(err)
 			return fail(502, { error: 'Issue could not be created' })
 		}
-	},
+	}
 }

--- a/src/routes/admin/submissions/+page.svelte
+++ b/src/routes/admin/submissions/+page.svelte
@@ -7,7 +7,7 @@
 		faCheckCircle,
 		faClock,
 		faLink,
-		faUser,
+		faUser
 	} from '@fortawesome/free-solid-svg-icons'
 
 	import { faCircle, faCircleCheck } from '@fortawesome/free-regular-svg-icons'

--- a/src/routes/api/submissions/+server.ts
+++ b/src/routes/api/submissions/+server.ts
@@ -18,7 +18,7 @@ export const POST = async (event) => {
 	if (count > 5) {
 		return json(
 			{ error: 'Too many submissions. Please try again later.' },
-			{ status: 429 },
+			{ status: 429 }
 		)
 	}
 
@@ -48,7 +48,7 @@ export const POST = async (event) => {
 		await send_email({
 			subject: 'CatDat – New submission',
 			text: email_text,
-			to: APPROVAL_EMAIL,
+			to: APPROVAL_EMAIL
 		})
 	} catch (err) {
 		console.error(err)

--- a/src/routes/api/user_action/+server.ts
+++ b/src/routes/api/user_action/+server.ts
@@ -28,7 +28,7 @@ export const POST = async (event) => {
 	const { action, value = null } = body
 
 	const { err } = await query_app(
-		sql`INSERT INTO user_actions (action, value) VALUES (${action}, ${value})`,
+		sql`INSERT INTO user_actions (action, value) VALUES (${action}, ${value})`
 	)
 
 	if (err) return json({ error: 'Database error' }, { status: 500 })

--- a/src/routes/download/+page.svelte
+++ b/src/routes/download/+page.svelte
@@ -8,7 +8,7 @@
 		await fetch(`/api/user_action`, {
 			method: 'POST',
 			body: JSON.stringify({ action: 'download_database' }),
-			headers: { 'Content-Type': 'application/json' },
+			headers: { 'Content-Type': 'application/json' }
 		})
 	}
 </script>

--- a/src/routes/missing/+page.server.ts
+++ b/src/routes/missing/+page.server.ts
@@ -6,24 +6,24 @@ export const load = () => {
 	const categories_with_missing_morphisms = fetch_categories_with_missing_morphisms()
 
 	const missing_data = Object.fromEntries(
-		STRUCTURE_TYPES.map((type) => [type, fetch_missing_data(type)]),
+		STRUCTURE_TYPES.map((type) => [type, fetch_missing_data(type)])
 	)
 
 	function select<T>(
-		selector: (data: (typeof missing_data)[keyof typeof missing_data]) => T,
+		selector: (data: (typeof missing_data)[keyof typeof missing_data]) => T
 	) {
 		return Object.fromEntries(
-			STRUCTURE_TYPES.map((type) => [type, selector(missing_data[type])]),
+			STRUCTURE_TYPES.map((type) => [type, selector(missing_data[type])])
 		)
 	}
 
 	return {
 		structures_with_unknown_properties: select(
-			(data) => data.structures_with_unknown_properties,
+			(data) => data.structures_with_unknown_properties
 		),
 		unknown_totals: select((data) => data.total_unknown_property_pairs),
 		undistinguishable_pairs: select((data) => data.undistinguishable_structure_pairs),
 		missing_combinations: select((data) => data.missing_combinations),
-		categories_with_missing_morphisms,
+		categories_with_missing_morphisms
 	}
 }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -7,7 +7,7 @@
 	import {
 		assignment_level,
 		ASSIGNMENT_LEVELS,
-		update_assignment_level,
+		update_assignment_level
 	} from '$lib/states/assignment_level.svelte'
 	import { theme, THEMES, update_theme } from '$lib/states/theme.svelte'
 	import MetaData from '$components/MetaData.svelte'

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,10 +7,10 @@ const config = {
 	kit: {
 		alias: {
 			$components: './src/components',
-			$pages: './src/pages',
+			$pages: './src/pages'
 		},
-		adapter: adapter(),
-	},
+		adapter: adapter()
+	}
 }
 
 export default config

--- a/tests/categories.spec.ts
+++ b/tests/categories.spec.ts
@@ -9,15 +9,15 @@ test('user can navigate to a category', async ({ page }) => {
 	await nav
 		.getByRole('link', {
 			name: 'Categories',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'List of categories',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category-list')
@@ -25,15 +25,15 @@ test('user can navigate to a category', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'category of commutative rings',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'category of commutative rings',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category/CRing')
@@ -45,8 +45,8 @@ test('user can view category details', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'category of commutative rings',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page.getByText('objects: commutative rings')).toBeVisible()
@@ -58,11 +58,11 @@ test('user can view category details', async ({ page }) => {
 	await expect(page.getByText('terminal object: zero ring')).toBeVisible()
 	await expect(page.getByText('coproducts: tensor products')).toBeVisible()
 	await expect(
-		page.getByText('regular epimorphisms: surjective homomorphisms'),
+		page.getByText('regular epimorphisms: surjective homomorphisms')
 	).toBeVisible()
 
 	const unknown_properties_section = page.locator('section', {
-		hasText: 'Unknown properties',
+		hasText: 'Unknown properties'
 	})
 	await expect(unknown_properties_section.locator('li')).toHaveCount(0)
 })
@@ -74,13 +74,13 @@ test('user may see unknown properties', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'category of sheaves',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const unknown_properties_section = page
 		.locator('section', {
-			hasText: 'Unknown properties',
+			hasText: 'Unknown properties'
 		})
 		.first()
 
@@ -95,15 +95,15 @@ test('user can navigate to a related category', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'category of sets',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'category of sets',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category/Set')
@@ -121,8 +121,8 @@ test('user can open and close a proof for a category', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Proof',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const popup = page.locator('.popup').filter({ hasText: 'Proof' })
@@ -138,8 +138,8 @@ test('user can open and close a proof for a category', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Proof',
-			exact: true,
-		}),
+			exact: true
+		})
 	).not.toBeVisible()
 })
 
@@ -155,7 +155,7 @@ test('user can open a derived proof for a category', async ({ page }) => {
 	const popup = page.locator('.popup').filter({ hasText: 'Proof' })
 
 	await expect(
-		popup.getByText('Since it is finitary algebraic, it has a generator'),
+		popup.getByText('Since it is finitary algebraic, it has a generator')
 	).toBeVisible()
 })
 
@@ -168,29 +168,29 @@ test('user can navigate to a category property', async ({ page }) => {
 	await nav
 		.getByRole('link', {
 			name: 'Properties',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Properties of categories',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await page
 		.getByRole('link', {
 			name: 'finitely accessible',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'finitely accessible',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category-property/finitely_accessible')
@@ -202,8 +202,8 @@ test('user can view category property details', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'finitely accessible',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page.getByText('A category is finitely accessible if')).toBeVisible()
@@ -211,61 +211,61 @@ test('user can view category property details', async ({ page }) => {
 	await expect(
 		page.getByRole('link', {
 			name: 'accessible',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const examples = page
 		.getByRole('heading', {
 			name: 'Examples',
-			exact: true,
+			exact: true
 		})
 		.locator('xpath=following-sibling::ul[1]')
 
 	await expect(
 		examples.getByRole('link', {
 			name: 'category of fields',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		examples.getByRole('link', {
 			name: 'category of vector spaces',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const counterexamples = page
 		.getByRole('heading', {
 			name: 'Counterexamples',
-			exact: true,
+			exact: true
 		})
 		.locator('xpath=following-sibling::ul[1]')
 
 	await expect(
 		counterexamples.getByRole('link', {
 			name: 'category of finite sets',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		counterexamples.getByRole('link', {
 			name: 'category of topological spaces',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 })
 
 test('user sees no unknown categories for the property of being additive', async ({
-	page,
+	page
 }) => {
 	await page.goto('/category-property/additive')
 	await expect(
 		page.getByText(
-			'There are 0 categories for which the database has no information on whether they satisfy this property',
-		),
+			'There are 0 categories for which the database has no information on whether they satisfy this property'
+		)
 	).toBeVisible()
 })
 
@@ -278,15 +278,15 @@ test('user can navigate to a category implication', async ({ page }) => {
 	await nav
 		.getByRole('link', {
 			name: 'Implications',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Category implications',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const item = page.locator('li', { hasText: /cartesian closed.+finite products/ })
@@ -297,8 +297,8 @@ test('user can navigate to a category implication', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Implication Details',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category-implication/ccc_condition')
@@ -310,22 +310,22 @@ test('user can see the details of an implication', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Implication Details',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'cartesian closed',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'finite products',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page.getByText('Proof: This holds by definition')).toBeVisible()

--- a/tests/compare.spec.ts
+++ b/tests/compare.spec.ts
@@ -9,15 +9,15 @@ test('user can navigate to compare page', async ({ page }) => {
 	await nav
 		.getByRole('link', {
 			name: 'Compare',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Compare categories',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category-comparison')
@@ -29,8 +29,8 @@ test('user can select categories for comparison', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Compare categories',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const textbox = page.getByRole('textbox', { name: 'Category' })
@@ -47,15 +47,15 @@ test('user can select categories for comparison', async ({ page }) => {
 		await expect(
 			page.getByRole('button', {
 				name: category,
-				exact: true,
-			}),
+				exact: true
+			})
 		).toBeVisible()
 	}
 
 	await page
 		.getByRole('button', {
 			name: 'Compare',
-			exact: true,
+			exact: true
 		})
 		.click()
 
@@ -64,8 +64,8 @@ test('user can select categories for comparison', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Comparison of categories',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 })
 
@@ -75,8 +75,8 @@ test('user can view comparison table', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Comparison of categories',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page.getByText('category of rings')).toBeVisible()
@@ -89,13 +89,13 @@ test('user can view comparison table', async ({ page }) => {
 		abelian: ['no', 'no'],
 		generator: ['yes', 'yes'],
 		cocomplete: ['yes', 'yes'],
-		coextensive: ['no', 'yes'],
+		coextensive: ['no', 'yes']
 	}
 
 	for (const [prop, values] of Object.entries(table_except)) {
 		const row = table
 			.locator('tbody tr', {
-				has: page.getByRole('link', { name: prop, exact: true }),
+				has: page.getByRole('link', { name: prop, exact: true })
 			})
 			.first()
 		await expect(row).toBeVisible()

--- a/tests/functors.spec.ts
+++ b/tests/functors.spec.ts
@@ -6,7 +6,7 @@ test('user can navigate to a functor', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'functors',
-			exact: true,
+			exact: true
 		})
 		.first()
 		.click()
@@ -17,15 +17,15 @@ test('user can navigate to a functor', async ({ page }) => {
 	await nav
 		.getByRole('link', {
 			name: 'Functors',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'List of functors',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/functor-list')
@@ -33,15 +33,15 @@ test('user can navigate to a functor', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'fundamental group functor',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'fundamental group functor',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/functor/pi_1')
@@ -53,8 +53,8 @@ test('user can view functor details', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'fundamental group functor',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page.getByText('group of homotopy classes of loops')).toBeVisible()
@@ -72,15 +72,15 @@ test('user can navigate to a related functor', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'forgetful functor for groups',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'forgetful functor for groups',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/functor/forget_group')
@@ -92,15 +92,15 @@ test('user can navigate to the source category', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'category of rings',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'category of rings',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category/Ring')
@@ -112,15 +112,15 @@ test('user can navigate to the target category', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'category of groups',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'category of groups',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category/Grp')
@@ -132,15 +132,15 @@ test('user can navigate to the left adjoint functor', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'forgetful functor from groups to monoids',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'forgetful functor from groups to monoids',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/functor/forget_inverses')
@@ -152,15 +152,15 @@ test('user can navigate to the right adjoint functor', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'indiscrete topology functor',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'indiscrete topology functor',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/functor/indiscrete_topology')
@@ -178,14 +178,14 @@ test('user can open and close a derived proof for a functor', async ({ page }) =
 	await expect(
 		page.getByRole('heading', {
 			name: 'Proof',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const popup = page.locator('.popup').filter({ hasText: 'Proof' })
 
 	await expect(
-		popup.getByText('Since it is a left adjoint, it is cocontinuous'),
+		popup.getByText('Since it is a left adjoint, it is cocontinuous')
 	).toBeVisible()
 
 	await popup.getByRole('button', { name: 'close' }).click()
@@ -193,8 +193,8 @@ test('user can open and close a derived proof for a functor', async ({ page }) =
 	await expect(
 		page.getByRole('heading', {
 			name: 'Proof',
-			exact: true,
-		}),
+			exact: true
+		})
 	).not.toBeVisible()
 })
 
@@ -207,29 +207,29 @@ test('user can navigate to a functor property', async ({ page }) => {
 	await nav
 		.getByRole('link', {
 			name: 'Properties',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Properties of functors',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await page
 		.getByRole('link', {
 			name: 'faithful',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'faithful',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/functor-property/faithful')
@@ -241,8 +241,8 @@ test('user can view functor property details', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'faithful',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page.getByText('is faithful when')).toBeVisible()
@@ -251,50 +251,50 @@ test('user can view functor property details', async ({ page }) => {
 		page
 			.getByRole('link', {
 				name: 'fully faithful',
-				exact: true,
+				exact: true
 			})
-			.first(),
+			.first()
 	).toBeVisible()
 
 	const examples = page
 		.getByRole('heading', {
 			name: 'Examples',
-			exact: true,
+			exact: true
 		})
 		.locator('xpath=following-sibling::ul[1]')
 
 	await expect(
 		examples.getByRole('link', {
 			name: 'forgetful functor for rings',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		examples.getByRole('link', {
 			name: 'free group functor',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const counterexamples = page
 		.getByRole('heading', {
 			name: 'Counterexamples',
-			exact: true,
+			exact: true
 		})
 		.locator('xpath=following-sibling::ul[1]')
 
 	await expect(
 		counterexamples.getByRole('link', {
 			name: 'abelianization functor for groups',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		counterexamples.getByRole('link', {
 			name: 'fundamental group functor',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 })

--- a/tests/missing.spec.ts
+++ b/tests/missing.spec.ts
@@ -6,15 +6,15 @@ test('user can navigate to the page with missing data', async ({ page }) => {
 	await page
 		.getByRole('link', {
 			name: 'Missing data',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Missing data',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/missing')
@@ -28,12 +28,12 @@ test('user can see categories with missing data', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Missing data',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const categories_section = page.locator('section', {
-		hasText: 'Categories with unknown properties',
+		hasText: 'Categories with unknown properties'
 	})
 
 	await expect(categories_section).toBeVisible()
@@ -55,12 +55,12 @@ test('user can see no functors with missing data', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Missing data',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const functors_section = page.locator('section', {
-		hasText: 'Functors with unknown properties',
+		hasText: 'Functors with unknown properties'
 	})
 
 	await expect(functors_section.getByRole('link')).toHaveCount(0)
@@ -70,7 +70,7 @@ test('user can see missing category combinations', async ({ page }) => {
 	await page.goto('/missing', { waitUntil: 'networkidle' })
 
 	const combinations_section = page.locator('section', {
-		hasText: 'Missing category combinations',
+		hasText: 'Missing category combinations'
 	})
 
 	await expect(combinations_section).toBeVisible()
@@ -80,7 +80,7 @@ test('user can see missing category combinations', async ({ page }) => {
 		.click()
 
 	await expect(
-		combinations_section.locator('li', { hasText: /[A-Za-z]+ ∧ ¬[A-Za-z]+/ }).first(),
+		combinations_section.locator('li', { hasText: /[A-Za-z]+ ∧ ¬[A-Za-z]+/ }).first()
 	).toBeVisible()
 })
 
@@ -88,7 +88,7 @@ test('user can see missing functor combinations', async ({ page }) => {
 	await page.goto('/missing', { waitUntil: 'networkidle' })
 
 	const combinations_section = page.locator('section', {
-		hasText: 'Missing functor combinations',
+		hasText: 'Missing functor combinations'
 	})
 
 	await expect(combinations_section).toBeVisible()
@@ -98,6 +98,6 @@ test('user can see missing functor combinations', async ({ page }) => {
 		.click()
 
 	await expect(
-		combinations_section.locator('li', { hasText: /[A-Za-z]+ ∧ ¬[A-Za-z]+/ }).first(),
+		combinations_section.locator('li', { hasText: /[A-Za-z]+ ∧ ¬[A-Za-z]+/ }).first()
 	).toBeVisible()
 })

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -11,15 +11,15 @@ test('user can navigate to the search page', async ({ page }) => {
 	await nav
 		.getByRole('link', {
 			name: 'Search',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Property combo search',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(page).toHaveURL('/category-search')
@@ -30,7 +30,7 @@ test('user can enter properties', async ({ page }) => {
 
 	const satisfied_input_field = page.getByRole('textbox', {
 		name: 'Satisfied property',
-		exact: true,
+		exact: true
 	})
 
 	for (const p of ['finitely complete', 'finitely cocomplete']) {
@@ -48,7 +48,7 @@ test('user can enter properties', async ({ page }) => {
 
 	const unsatisfied_input_field = page.getByRole('textbox', {
 		name: 'Unsatisfied property',
-		exact: true,
+		exact: true
 	})
 
 	for (const q of ['cocomplete', 'abelian']) {
@@ -67,74 +67,74 @@ test('user can enter properties', async ({ page }) => {
 	await page
 		.getByRole('button', {
 			name: 'Search',
-			exact: true,
+			exact: true
 		})
 		.click()
 
 	await expect(page).toHaveURL(
-		`/category-search/results?satisfied=finitely_complete${encoded_delimiter}finitely_cocomplete&unsatisfied=cocomplete${encoded_delimiter}abelian`,
+		`/category-search/results?satisfied=finitely_complete${encoded_delimiter}finitely_cocomplete&unsatisfied=cocomplete${encoded_delimiter}abelian`
 	)
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Search results',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 })
 
 test('user can view search results', async ({ page }) => {
 	await page.goto(
-		`/category-search/results?satisfied=finitely_complete${encoded_delimiter}finitely_cocomplete&unsatisfied=cocomplete${encoded_delimiter}abelian`,
+		`/category-search/results?satisfied=finitely_complete${encoded_delimiter}finitely_cocomplete&unsatisfied=cocomplete${encoded_delimiter}abelian`
 	)
 
 	await expect(
 		page.getByRole('heading', {
 			name: 'Search results',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'finitely complete',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'finitely cocomplete',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'cocomplete',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'abelian',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'category of finite sets',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'category of countable groups',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 })
 
@@ -148,27 +148,27 @@ test('user can dualize search', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'Search results',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'Barr-exact',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'category of finite groups',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	const dualize_link = page.getByRole('link', {
 		name: 'Dualize search',
-		exact: true,
+		exact: true
 	})
 
 	await expect(dualize_link).toBeVisible()
@@ -179,21 +179,21 @@ test('user can dualize search', async ({ page }) => {
 	await expect(
 		page.getByRole('link', {
 			name: 'Barr-coexact',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 
 	await expect(
 		page.getByRole('link', {
 			name: 'category of finite groups',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toHaveCount(0)
 
 	await expect(
 		page.getByRole('link', {
 			name: 'poset of natural numbers',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 })

--- a/tests/structure_selector.spec.ts
+++ b/tests/structure_selector.spec.ts
@@ -6,7 +6,7 @@ test('categories are selected by default', async ({ page }) => {
 	const selector = page
 		.getByRole('combobox', {
 			name: 'Structure',
-			exact: true,
+			exact: true
 		})
 		.first()
 
@@ -20,7 +20,7 @@ test('user can switch to functors', async ({ page }) => {
 	const selector = page
 		.getByRole('combobox', {
 			name: 'Structure',
-			exact: true,
+			exact: true
 		})
 		.first()
 
@@ -34,8 +34,8 @@ test('user can switch to functors', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', {
 			name: 'List of functors',
-			exact: true,
-		}),
+			exact: true
+		})
 	).toBeVisible()
 })
 
@@ -45,7 +45,7 @@ test('functors are selected on a functor route', async ({ page }) => {
 	const selector = page
 		.getByRole('combobox', {
 			name: 'Structure',
-			exact: true,
+			exact: true
 		})
 		.first()
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,5 @@ import { defineConfig } from 'vite'
 import { sveltekit } from '@sveltejs/kit/vite'
 
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [sveltekit()]
 })


### PR DESCRIPTION
Update the Prettier setting for trailing comma formatting: instead of `all`, use `none`.

There is a small advantage to having trailing commas for cleaner Git diffs, but most of the time, especially in function calls with long parameter objects such as `db.prepare(...)`, they are simply annoying.

Remark: `pnpm format` formats all files.