### PR TITLE
Add quasitopos property

### DIFF
--- a/databases/catdat/data/categories/CompHaus.yaml
+++ b/databases/catdat/data/categories/CompHaus.yaml
@@ -55,11 +55,6 @@ satisfied_properties:
   - property: extensive
     proof: This follows as for <a href="/category/Top">$\Top$</a> or <a href="/category/Haus">$\Haus$</a> since finite coproducts in $\CompHaus$ are formed as disjoint union spaces with the disjoint union topology.
 
-  - property: epi-regular
-    proof: |-
-      First, any epimorphism $f : X \to Y$ is surjective: if not, its image would be a proper subset of $Y$, which is compact and hence closed. Then by Urysohn's lemma, there would be a non-zero continuous function $g : Y \to [0, 1]$ which is $0$ on the image; but then $g \circ f = 0 \circ f$, giving a contradiction.
-      Now the identity morphism from $Y$, with the quotient topology of $f$, to $Y$ with its given topology is a bijective continuous function between compact Hausdorff spaces, so it is a homeomorphism. In other words, $f$ is a quotient map. Therefore, we see that if $g, h : E \rightrightarrows X$ is the kernel pair of $f$, and $U : \CompHaus \to \Top$ is the forgetful functor, then $U(f)$ is the coequalizer of $U(g)$ and $U(h)$. Since $U$ is fully faithful, that implies $f$ is the coequalizer of $g$ and $h$.
-
   - property: cofiltered-limit-stable epimorphisms
     proof: 'Suppose we have a cofiltered diagram of epimorphisms $(f_i : X_i \to Y_i)$, and $y = (y_i) \in \lim_i Y_i$. Then by lemma 1 <a href="/content/comphaus_copresentable">here</a>, the limit of $f_i^{-1}(\{ y_i \})$ is non-empty. If $x$ is in this limit, that implies that $(\lim_i f_i)(x) = y$.'
 

--- a/databases/catdat/data/categories/Mono.yaml
+++ b/databases/catdat/data/categories/Mono.yaml
@@ -77,20 +77,6 @@ satisfied_properties:
 
       Therefore, any finite coproduct of $(1, 0)$ and $(1, 1)$ is finitely presentable; this means any object of the form $([n], [m])$ with $m, n \in \IN$ and $m \le n$ is finitely presentable. All such objects form a small set. Moreover, any object $(X,X')$ of $\Mono$ is a filtered colimit of the subobjects $(F, F \cap X')$ where $F$ is a finite subset of $X$, and each $(F, F \cap X')$ is isomorphic to some $([n], [m])$.
 
-  - property: coregular
-    proof: >-
-      It suffices to show regular monomorphisms are stable under pushouts. Thus, suppose we have two morphisms $f : (X, X') \to (Y, Y')$ and $g : (X, X') \to (Z, Z')$ where $f$ is a regular monomorphism, which means $f$ is injective and $X' = f^{-1}(Y')$. Then we can construct a pushout diagram
-      $$\begin{CD}
-      (X, X') @> f >> (Y, Y') \\
-      @V g VV @VV i_1 VV \\
-      (Z, Z') @>> i_2 > ((Y \setminus f(X)) \sqcup Z, i_1(Y') \cup i_2(Z')).
-      \end{CD}$$
-      Here $i_1$ sends $f(x) \mapsto g(x) \in Z$ for $x \in X$, and otherwise it sends $y \mapsto y$ for $y \in Y \setminus f(X)$; and $i_2$ is the inclusion of $Z$. We certainly have $i_2$ is injective; it remains to show $i_2^{-1}(i_1(Y') \cup i_2(Z')) = Z'$. However, we have
-      $$i_2^{-1}(i_1(Y') \cup i_2(Z')) = i_2^{-1}(i_1(Y')) \cup i_2^{-1}(i_2(Z'))$$
-      and obviously $i_2^{-1}(i_2(Z')) = Z'$. Therefore, it suffices to show $i_2^{-1}(i_1(Y')) \subseteq Z'$. Thus, suppose we have $z \in Z$ such that $i_2(z) \in i_1(Y')$. That means there exists $y' \in Y'$ such that $z = i_1(y')$. But in order for $i_1(y')$ to land in the $Z$ portion of $(Y \setminus f(X)) \sqcup Z$, we must have $y' \in f(X)$. That means there exists $x \in X$ such that $f(x) = y'$; and by the assumption on $f$, in fact $x \in X'$. Therefore,
-      $$i_2(g(x)) = i_1(f(x)) = i_1(y') = z = i_2(z),$$
-      so $z = g(x) \in Z'$.
-
   - property: co-Malcev
     proof: >-
       Suppose we have a coreflexive corelation $p : (X \sqcup X, X' \sqcup X') \twoheadrightarrow (E, E')$ with coreflexivity morphism $r : (E, E') \to (X, X')$. From the assumption that $p$ is an epimorphism, we have that $p : X \sqcup X \to E$ is a surjective function. Since <a href="/category/Set">$\Set$</a> is co-Malcev, it follows that $E \cong X \sqcup_Y X$ for some subset $Y \subseteq X$. It remains to show that $E' = i_1(X') \cup i_2(X') \subseteq X \sqcup_Y X$. Certainly, since we have a morphism $(X \sqcup_Y X, i_1(X') \cup i_2(X')) \to (E, E')$ induced by $p$, we must have $i_1(X') \cup i_2(X') \subseteq E'$. On the other hand, any element of $E'$ is an element of $E$ and hence is equal to either $i_1(x)$ or $i_2(x)$ for $x \in X$. In the first case, we must have $x = r(i_1(x)) \in X'$, so $i_1(x) \in i_1(X')$; and similarly for the second case.

--- a/databases/catdat/data/categories/Prost.yaml
+++ b/databases/catdat/data/categories/Prost.yaml
@@ -45,9 +45,6 @@ unsatisfied_properties:
   - property: regular
     proof: See Example 3.14 at the <a href="https://ncatlab.org/nlab/show/regular+category" target="_blank">nLab</a>.
 
-  - property: balanced
-    proof: The inclusion $\{0,1\} \to \{0 < 1\}$ provides a counterexample (where in the domain there is no relation between $0$ and $1$).
-
   - property: skeletal
     proof: This is trivial.
 

--- a/databases/catdat/data/categories/Set_c.yaml
+++ b/databases/catdat/data/categories/Set_c.yaml
@@ -32,9 +32,6 @@ satisfied_properties:
   - property: subobject classifier
     proof: This is because $\{0,1\}$ is a subobject classifier in <a href="/category/Set">$\Set$</a>, which is countable, and the monomorphisms coincide.
 
-  - property: epi-regular
-    proof: If $X \to Y$ is an epimorphism in $\Set_\c$, i.e. a surjective map, it is coequalizer of the two maps $X \times_Y X \rightrightarrows X$ in $\Set$ and hence also in $\Set_\c$.
-
   - property: generator
     proof: The one-point set is clearly a generator.
 

--- a/databases/catdat/data/categories/Set_pointed.yaml
+++ b/databases/catdat/data/categories/Set_pointed.yaml
@@ -30,9 +30,6 @@ satisfied_properties:
   - property: cogenerator
     proof: The pointed set $(\{0,1\},1)$ is a cogenerator.
 
-  - property: epi-regular
-    proof: Every epimorphism is surjective for this category, and in an algebraic category every surjective homomorphism is a regular epimorphism.
-
   - property: coregular
     proof: From the other properties we know that (co-)limits exist and that monomorphisms coincide with injective pointed maps. So it suffices to prove that these maps are stable under pushouts. This follows from the corresponding fact for <a href="/category/Set">$\Set$</a> and the observation that the forgetful functor $\Set_* \to \Set$ preserves pushouts.
     check_redundancy: false

--- a/databases/catdat/data/categories/Z.yaml
+++ b/databases/catdat/data/categories/Z.yaml
@@ -28,10 +28,6 @@ satisfied_properties:
   - property: exact filtered colimits
     proof: This follows immediately from the fact for <a href="/category/Set">$\Set$</a>.
 
-  - property: mono-regular
-    proof: This follows immediately from the fact for <a href="/category/Set">$\Set$</a>.
-    check_redundancy: false
-
   - property: regular
     proof: This follows immediately from the fact for <a href="/category/Set">$\Set$</a>.
 

--- a/databases/catdat/data/categories/Z.yaml
+++ b/databases/catdat/data/categories/Z.yaml
@@ -32,9 +32,6 @@ satisfied_properties:
     proof: This follows immediately from the fact for <a href="/category/Set">$\Set$</a>.
     check_redundancy: false
 
-  - property: epi-regular
-    proof: This follows immediately from the fact for <a href="/category/Set">$\Set$</a>.
-
   - property: regular
     proof: This follows immediately from the fact for <a href="/category/Set">$\Set$</a>.
 

--- a/databases/catdat/data/category-implications/congruences.yaml
+++ b/databases/catdat/data/category-implications/congruences.yaml
@@ -18,6 +18,15 @@
   proof: The regularity condition gives a bijection between the collection of quotients of $X$ and the collection of effective congruences on $X$, where the latter is a subcollection of the collection of subobjects of $X\times X$.
   is_equivalence: false
 
+- id: regular_balanced_epi-regular
+  assumptions:
+    - regular
+    - balanced
+  conclusions:
+    - epi-regular
+  proof: 'Given any epimorphism $f : X \twoheadrightarrow Y$ in a regular category, we have the factorization into a regular epimorphism $X \twoheadrightarrow \im(f)$ followed by a monomorphism $\im(f) \hookrightarrow Y$. Because the composition is an epimorphism, the monomorphism $\im(f) \hookrightarrow Y$ must also be an epimorphism, and therefore an isomorphism. It follows that $f$ is in fact a regular epimorphism.'
+  is_equivalence: false
+
 - id: congruence_quotients_are_reflexive_coequalizers
   assumptions:
     - reflexive coequalizers

--- a/databases/catdat/data/category-implications/topos.yaml
+++ b/databases/catdat/data/category-implications/topos.yaml
@@ -32,10 +32,10 @@
 
 - id: topos_implies_coregular
   assumptions:
-    - elementary topos
+    - quasitopos
   conclusions:
     - coregular
-  proof: This is proven in <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, A2.6.3 (for every quasitopos).
+  proof: This is proven in <a href="https://ncatlab.org/nlab/show/Sketches+of+an+Elephant" target="_blank">Johnstone</a>, A2.6.3.
   is_equivalence: false
 
 - id: grothendieck_topos_definition
@@ -84,5 +84,16 @@
   conclusions:
     - Barr-exact
     - extensive
+  proof: This is true by definition.
+  is_equivalence: true
+
+- id: quasitopos_definition
+  assumptions:
+    - quasitopos
+  conclusions:
+    - finitely complete
+    - finitely cocomplete
+    - locally cartesian closed
+    - regular subobject classifier
   proof: This is true by definition.
   is_equivalence: true

--- a/databases/catdat/data/category-properties/elementary topos.yaml
+++ b/databases/catdat/data/category-properties/elementary topos.yaml
@@ -12,6 +12,7 @@ related:
   - natural numbers object
   - subobject classifier
   - pretopos
+  - quasitopos
 
 tags:
   - topos theory

--- a/databases/catdat/data/category-properties/quasitopos.yaml
+++ b/databases/catdat/data/category-properties/quasitopos.yaml
@@ -1,0 +1,20 @@
+id: quasitopos
+relation: is a
+description: >-
+  A <i>quasitopos</i> is a category which is finitely complete, finitely cocomplete, locally cartesian closed, and has a regular subobject classifier. This gives the category properties similar to those of an elementary topos; a major difference is that a quasitopos need not be balanced.
+
+  Note that some authors use a strong subobject classifier in place of a regular subobject classifier in the definition, i.e. a morphism $\top : 1 \to \Omega$ which classifies strong monomorphisms. For the equivalence of these definitions, see <a href="https://math.stackexchange.com/q/4335533" target="_blank">MSE/4335533</a>.
+nlab_link: https://ncatlab.org/nlab/show/quasitopos
+dual: null
+invariant_under_equivalences: true
+
+related:
+  - finitely complete
+  - finitely cocomplete
+  - locally cartesian closed
+  - regular subobject classifier
+  - elementary topos
+  - balanced
+
+tags:
+  - topos theory

--- a/databases/catdat/data/category-properties/regular subobject classifier.yaml
+++ b/databases/catdat/data/category-properties/regular subobject classifier.yaml
@@ -12,6 +12,7 @@ invariant_under_equivalences: true
 related:
   - finitely complete
   - subobject classifier
+  - quasitopos
 
 tags:
   - topos theory

--- a/databases/catdat/data/macros.yaml
+++ b/databases/catdat/data/macros.yaml
@@ -49,7 +49,6 @@
 \im: \operatorname{im}
 \lcm: \operatorname{lcm}
 \Spec: \operatorname{Spec}
-\Sh: \operatorname{Sh}
 \ord: \operatorname{ord}
 \diag: \operatorname{diag}
 \Sub: \operatorname{Sub}
@@ -123,3 +122,4 @@
 \Span: \mathbf{Span}
 \Arr: \mathbf{Arr}
 \Mono: \mathbf{Mono}
+\Sh: \mathbf{Sh}

--- a/databases/catdat/scripts/expected-data/Ab.json
+++ b/databases/catdat/scripts/expected-data/Ab.json
@@ -169,5 +169,6 @@
 	"subobject-trivial": false,
 	"quotient-trivial": false,
 	"locally finite": false,
-	"pretopos": false
+	"pretopos": false,
+	"quasitopos": false
 }

--- a/databases/catdat/scripts/expected-data/Set.json
+++ b/databases/catdat/scripts/expected-data/Set.json
@@ -112,6 +112,7 @@
 	"ℵ₂-small powers": true,
 	"ℵ₂-small copowers": true,
 	"pretopos": true,
+	"quasitopos": true,
 
 	"Grothendieck abelian": false,
 	"Malcev": false,

--- a/databases/catdat/scripts/expected-data/Top.json
+++ b/databases/catdat/scripts/expected-data/Top.json
@@ -169,5 +169,6 @@
 	"locally finite": false,
 	"Barr-coexact": false,
 	"Barr-exact": false,
-	"pretopos": false
+	"pretopos": false,
+	"quasitopos": false
 }


### PR DESCRIPTION
This is meant to be a more focused portion of the previous PR which adds just the one property (with more PRs based on portions of the previous one to come).

One adjustment I made already was to drop the explicit implication of quasitopos + balanced -> elementary topos, and instead add an easy proof that regular + balanced -> epi-regular, so that the auto implications should be able to deduce quasitopos + balanced -> coregular -> regular subobject classifier + mono-regular -> subobject classifier and the rest is trivial.