### PR TITLE
Check that environment variables are up-to-date

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "pnpm env:check && vite dev",
 		"dev:remote": "vite dev --mode prod",
 		"dev:host": "vite dev --host",
 		"build": "vite build",
@@ -14,6 +14,7 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check .",
 		"prepare": "husky",
+		"env:check": "tsx scripts/env.check",
 		"db:shell": "sqlite3 databases/catdat/catdat.db",
 		"db:kill": "rm -rf databases/catdat/catdat.db",
 		"db:setup:catdat": "pnpm db:kill && tsx databases/catdat/scripts/setup.ts",

--- a/scripts/env.check.ts
+++ b/scripts/env.check.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs'
+
+if (process.env.CI) {
+	process.exit(0)
+}
+
+function get_environment_variables(path: string): string[] {
+	let file = ''
+	try {
+		file = readFileSync(path, 'utf8')
+	} catch (_) {
+		console.error(`❌ ${path} does not exist. Please create it first.`)
+		process.exit(1)
+	}
+
+	return file
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line !== '' && !line.startsWith('#'))
+		.map((line) => line.split('=', 1)[0].trim())
+}
+
+const actual_variables = get_environment_variables('.env')
+const example_variables = get_environment_variables('.env.example')
+
+if (!actual_variables.length) {
+	console.error(
+		'❌ .env does not contain any environment variables. Please update it from .env.example.'
+	)
+	process.exit(1)
+}
+
+const are_the_same =
+	actual_variables.length === example_variables.length &&
+	example_variables.every((v) => actual_variables.includes(v))
+
+if (are_the_same) {
+	console.info('✅ Environment variables are up to date.')
+} else {
+	console.error('❌ .env is out of date. Please update it to match .env.example.')
+	process.exit(1)
+}


### PR DESCRIPTION
When a new environment variable is added or an existing one is removed, this change is currently only reflected in `.env.example`, since `.env` is not tracked in the repository. As a result, contributors may end up with a broken development server without any notification that their local `.env` file needs to be updated.

This PR adds a check to detect this situation.

Whenever the development server is started, a script verifies that the environment variables defined in `.env` match those in `.env.example`. If they differ, an error is thrown with a message asking the developer to update their `.env` file.

The script intentionally does not run with the test or build commands. These commands run in CI, where no `.env` file exists; environment variables are provided via GitHub secrets instead.