### PR TITLE
Automatic deduction of special morphisms

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -182,6 +182,7 @@
 		"injectivity",
 		"invertibility",
 		"Isbell",
+		"isos",
 		"Johnstone",
 		"Jónsson",
 		"Kashiwara",

--- a/database/data/categories/2.yaml
+++ b/database/data/categories/2.yaml
@@ -32,19 +32,4 @@ unsatisfied_properties:
 
 special_objects: {}
 
-special_morphisms:
-  isomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  epimorphisms:
-    description: every morphism
-    proof: This is clear since it is discrete.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.
+special_morphisms: {}

--- a/database/data/categories/Ab.yaml
+++ b/database/data/categories/Ab.yaml
@@ -51,5 +51,5 @@ special_objects:
 
 special_morphisms:
   epimorphisms:
-    description: surjective homomorphisms
+    description: surjective morphisms
     proof: 'For the non-trivial direction, if $f : A \to B$ is an epimorphism, then $p \circ f = 0$ for the projection  $p : B \to B/f(A)$ implies that $p = 0$, so that $B = f(A)$.'

--- a/database/data/categories/Ab.yaml
+++ b/database/data/categories/Ab.yaml
@@ -50,18 +50,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective homomorphisms
     proof: 'For the non-trivial direction, if $f : A \to B$ is an epimorphism, then $p \circ f = 0$ for the projection  $p : B \to B/f(A)$ implies that $p = 0$, so that $B = f(A)$.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Ab_fg.yaml
+++ b/database/data/categories/Ab_fg.yaml
@@ -72,9 +72,3 @@ special_morphisms:
   epimorphisms:
     description: surjective homomorphisms
     proof: Use the same proof as for abelian groups.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Ab_fg.yaml
+++ b/database/data/categories/Ab_fg.yaml
@@ -65,7 +65,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective homomorphisms
-    proof: This follows exactly as for abelian groups.
+    proof: It is a full subcategory of $\Ab$, for which we know that isomorphisms are bijective homomorphisms.
   monomorphisms:
     description: injective homomorphisms
     proof: 'Let $f : A \to B$ be a monomorphism of finitely generated abelian groups. Let $a \in A$ be in the kernel of $a$. Then we may view $a$ as a morphism $a : \IZ \to A$ with $f \circ a = 0$, and $\IZ$ is finitely generated. Hence, $a = 0$.'

--- a/database/data/categories/Alg(R).yaml
+++ b/database/data/categories/Alg(R).yaml
@@ -77,13 +77,4 @@ special_objects:
   products:
     description: direct products with pointwise operations
 
-special_morphisms:
-  isomorphisms:
-    description: bijective ring homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective ring homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.
+special_morphisms: {}

--- a/database/data/categories/B.yaml
+++ b/database/data/categories/B.yaml
@@ -51,19 +51,4 @@ unsatisfied_properties:
 
 special_objects: {}
 
-special_morphisms:
-  isomorphisms:
-    description: every morphism
-    proof: It is a groupoid by construction.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  epimorphisms:
-    description: every morphism
-    proof: This is trivial.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.
+special_morphisms: {}

--- a/database/data/categories/BG_c.yaml
+++ b/database/data/categories/BG_c.yaml
@@ -41,19 +41,4 @@ unsatisfied_properties:
 
 special_objects: {}
 
-special_morphisms:
-  isomorphisms:
-    description: every morphism
-    proof: It is a groupoid.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  epimorphisms:
-    description: every morphism
-    proof: This holds because it is a groupoid.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+special_morphisms: {}

--- a/database/data/categories/BG_f.yaml
+++ b/database/data/categories/BG_f.yaml
@@ -42,19 +42,4 @@ unsatisfied_properties:
 
 special_objects: {}
 
-special_morphisms:
-  isomorphisms:
-    description: every morphism
-    proof: It is a groupoid.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  epimorphisms:
-    description: every morphism
-    proof: This holds because it is a groupoid.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+special_morphisms: {}

--- a/database/data/categories/BG_u.yaml
+++ b/database/data/categories/BG_u.yaml
@@ -41,19 +41,4 @@ unsatisfied_properties:
 
 special_objects: {}
 
-special_morphisms:
-  isomorphisms:
-    description: every morphism
-    proof: It is a groupoid.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  epimorphisms:
-    description: every morphism
-    proof: This holds because it is a groupoid.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+special_morphisms: {}

--- a/database/data/categories/BN.yaml
+++ b/database/data/categories/BN.yaml
@@ -59,15 +59,3 @@ special_morphisms:
   isomorphisms:
     description: only the number $0$
     proof: The $0$ is the only natural number which has an additive inverse, since for $n > 0$ we have $n + m > 0$ for all $m$.
-  monomorphisms:
-    description: every morphism
-    proof: This is because addition of natural numbers is cancellative.
-  epimorphisms:
-    description: every morphism
-    proof: Addition of natural numbers is cancellative.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/BOn.yaml
+++ b/database/data/categories/BOn.yaml
@@ -78,15 +78,9 @@ special_morphisms:
   isomorphisms:
     description: only the ordinal $0$
     proof: The $0$ is the only ordinal which has an additive inverse, since for $\alpha > 0$ we have $\alpha + \beta > 0$ for all $\beta$.
-  monomorphisms:
-    description: every ordinal number
-    proof: This is because ordinal addition is left cancellative.
   epimorphisms:
     description: finite ordinal numbers
     proof: See <a href="https://math.stackexchange.com/questions/5029605" target="_blank">MSE/5029605</a>.
   regular monomorphisms:
     description: ordinals of the form $\alpha \cdot \omega$, where $\alpha$ is any ordinal
     proof: This results from the proof that equalizers exist, see <a href="https://math.stackexchange.com/questions/5029668" target="_blank">MSE/5029668</a>.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/CAlg(R).yaml
+++ b/database/data/categories/CAlg(R).yaml
@@ -70,15 +70,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: a homomorphism of algebras which is an epimorphism of commutative rings
     proof: The forgetful functor $\CAlg(R) \to \CRing$ is faithful and hence reflects epimorphisms, but it also preserves epimorphisms since it preserves pushouts (since $\CAlg(R) \cong R / \CRing$). For epimorphisms of commutative rings see the page for <a href="/category/CRing">$\CRing$</a>.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/CMon.yaml
+++ b/database/data/categories/CMon.yaml
@@ -67,18 +67,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: A morphism in $\CMon$ is an epimorphism iff it is an epimorphism in $\Mon$, which in turn can be characterized by <a href="https://en.wikipedia.org/wiki/Isbell's_zigzag_theorem" target="_blank">Isbell's zigzag theorem</a>.
-    proof:
-      "If $f : M \\to N$ is a homomorphism of commutative monoids which is an epimorphism in $\\Mon$, then it is trivially also an epimorphism in $\\CMon$. The converse requires a proof, which can be found at <a href=\"https://math.stackexchange.com/a/5133596/1650\">MSE/5133488</a>.
-
-      \t"
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.
+    proof: 'If $f : M \to N$ is a homomorphism of commutative monoids which is an epimorphism in $\Mon$, then it is trivially also an epimorphism in $\CMon$. The converse requires a proof, which can be found at <a href="https://math.stackexchange.com/a/5133596/1650">MSE/5133488</a>.'

--- a/database/data/categories/CRing.yaml
+++ b/database/data/categories/CRing.yaml
@@ -73,15 +73,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective ring homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective ring homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: 'A ring map $f : R \to S$ is an epimorphism iff $S$ equals the <i>dominion</i> of $f(R) \subseteq S$, meaning that for every $s \in S$ there is some matrix factorization $(s) = Y X Z$ with $X \in M_{n \times n}(R)$, $Y \in M_{1 \times n}(S)$, and $Z \in M_{n \times 1}(S)$.'
     proof: See <a href="https://stacks.math.columbia.edu/tag/04VM" target="_blank">Stacks Project</a> ,or, for many more results, the seminar <a href="https://www.numdam.org/issues/SAC_1967-1968__2_/">Les épimorphismes d'anneaux</a>. See also <a href="https://mathoverflow.net/questions/109/" target="_blank">MO/109</a> for some results.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/CompHaus.yaml
+++ b/database/data/categories/CompHaus.yaml
@@ -109,9 +109,3 @@ special_morphisms:
   epimorphisms:
     description: surjective continuous maps (which are automatically quotient maps)
     proof: For the non-trivial direction, and for a proof of the parenthetical remark, see the proof above that $\CompHaus$ is epi-regular.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/CompHaus.yaml
+++ b/database/data/categories/CompHaus.yaml
@@ -102,7 +102,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: homeomorphisms
-    proof: This is easy.
+    proof: It is a full subcategory of $\Top$, for which isomorphisms are known to be homeomorphisms.
   monomorphisms:
     description: injective continuous maps (which are automatically closed embeddings)
     proof: 'For the non-trivial direction, the forgetful functor to $\Set$ is representable (by the terminal object), hence preserves monomorphisms. To prove the parenthetical remark, given an injective continuous function $f : X \to Y$ between compact Hausdorff spaces, the image of $f$ is a closed subset. Also, the induced map from $X$ to $\im(f)$ with the subspace topology is a bijective continuous map between compact Hausdorff spaces, so it is a homeomorphism.'

--- a/database/data/categories/CompHaus.yaml
+++ b/database/data/categories/CompHaus.yaml
@@ -108,4 +108,6 @@ special_morphisms:
     proof: 'For the non-trivial direction, the forgetful functor to $\Set$ is representable (by the terminal object), hence preserves monomorphisms. To prove the parenthetical remark, given an injective continuous function $f : X \to Y$ between compact Hausdorff spaces, the image of $f$ is a closed subset. Also, the induced map from $X$ to $\im(f)$ with the subspace topology is a bijective continuous map between compact Hausdorff spaces, so it is a homeomorphism.'
   epimorphisms:
     description: surjective continuous maps (which are automatically quotient maps)
-    proof: For the non-trivial direction, and for a proof of the parenthetical remark, see the proof above that $\CompHaus$ is epi-regular.
+    proof: >-
+      For the non-trivial direction, let $f : X \to Y$ be an epimorphism. If it is not surjective, its image would be a proper subset of $Y$, which is compact and hence closed. Then by Urysohn's lemma, there would be a non-zero continuous function $g : Y \to [0, 1]$ which is $0$ on the image; but then $g \circ f = 0 \circ f$, giving a contradiction.
+      To prove that $f$ is a quotient map, it suffices to prove that $f$ maps closed subsets onto closed subsets. If $A \subseteq X$ is a closed subset, it is compact since $X$ is compact. Hence, $f(A) \subseteq Y$ is compact. Since $Y$ is Hausdorff, this implies that $f(A)$ is closed.

--- a/database/data/categories/Delta.yaml
+++ b/database/data/categories/Delta.yaml
@@ -107,9 +107,3 @@ special_morphisms:
   epimorphisms:
     description: surjective order-preserving maps
     proof: We can use the same proof as for <a href="/category/FinOrd">$\FinOrd$</a> since this has merely used the non-empty ordered set $\{0 < 1\}$.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/FI.yaml
+++ b/database/data/categories/FI.yaml
@@ -80,15 +80,6 @@ special_morphisms:
   isomorphisms:
     description: bijective maps
     proof: This follows exactly as for sets.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
   epimorphisms:
     description: bijective maps
     proof: 'Take an epimorphism $X \to Y$ in this category, w.l.o.g. the inclusion of a subset $X \subseteq Y$. This means that for two injective maps $f,g : Y \rightrightarrows T$ with $f|_X = g|_X$ we must have $f = g$. Let $T \coloneqq Y + (Y \setminus X)$ (disjoint union), $f$ be the inclusion into the first summand, $g|_X$ be the inclusion into the first summand, and $g|_{Y \setminus X}$ be the inclusion into the second summand. Then $f$ and $g$ are injective with $f|_X = g|_X$, so that $f = g$. But this means $X = Y$.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/FS.yaml
+++ b/database/data/categories/FS.yaml
@@ -116,9 +116,3 @@ special_morphisms:
   epimorphisms:
     description: every morphism
     proof: This is trivial.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/FS.yaml
+++ b/database/data/categories/FS.yaml
@@ -113,6 +113,3 @@ special_morphisms:
   monomorphisms:
     description: bijective maps
     proof: 'Assume that $f : X \to Y$ is a monomorphism in this category. If $a,b \in X$ are such that $a \neq b$ but $f(a) = f(b)$, let $h : X \to X$ be the transposition that swaps $a$, $b$. Then $f \circ \id_X = f = f \circ h$, so by assumption $\id_X = h$, a contradiction. This shows that $f$ is bijective.'
-  epimorphisms:
-    description: every morphism
-    proof: This is trivial.

--- a/database/data/categories/FiltVect.yaml
+++ b/database/data/categories/FiltVect.yaml
@@ -99,19 +99,15 @@ special_morphisms:
   isomorphisms:
     description: 'A filtered linear map $f : (V,F) \to (W,G)$ is an isomorphism if $f : V \to W$ is bijective and $f_*(F^n(V)) = G^n(W)$ for all $n \in \IZ$.'
     proof: This is straightforward to verify.
-
   monomorphisms:
     description: injective filtered linear maps
     proof: For the non-trivial direction, the forgetful functor $\FiltVect \to \Set$ is representable (by $K$ equipped with the trivial filtration), and therefore preserves monomorphisms.
-
   epimorphisms:
     description: surjective filtered linear maps
     proof: We saw above that the category has cokernels, and that these are preserved by the forgetful functor to $\Vect$. Moreover, a morphism is an epimorphism if and only if its cokernel is zero, and a filtered vector space is zero if and only if its underlying vector space is zero. Therefore, the claim follows from the classification of epimorphisms in $\Vect$.
-
   regular monomorphisms:
     description: 'A filtered linear map $f : (V,F) \to (W,G)$ is a regular monomorphism if and only if $f : V \to W$ is injective and $F^n(V) = f^*(G^n(W))$ for all $n \in \IZ$.'
     proof: 'Every kernel (and hence every equalizer) satisfies this property by the construction of kernels. Conversely, suppose that $f : (V,F) \to (W,G)$ is a filtered linear map satisfying this condition. Then $f$ induces an isomorphism between $(V,F)$ and $(U,G)$, where $U \coloneqq \im(f) \subseteq W$ is equipped with the induced filtration $G^n(U) \coloneqq U \cap G^n(W)$. Endow $W/U$ with the induced filtration $G^n(W/U) \coloneqq \pi_*(G^n(W))$, where $\pi : W \to W/U$ is the quotient map. Then $\pi : (W,G) \to (W/U,G)$ is a filtered linear map, and by the general construction of kernels, its kernel is the vector space $U$ equipped with the induced filtration. Hence, $f : (V,F) \to (W,G)$ is a kernel of $\pi : (W,G) \to (W/U,G)$.'
-
   regular epimorphisms:
     description: 'A filtered linear map $f : (V,F) \to (W,G)$ is a regular epimorphism if and only if $f : V \to W$ is surjective and $G^n(W) = f_*(F^n(V))$ for all $n \in \IZ$.'
     proof: >-

--- a/database/data/categories/FinAb.yaml
+++ b/database/data/categories/FinAb.yaml
@@ -67,9 +67,3 @@ special_morphisms:
   epimorphisms:
     description: surjective homomorphisms
     proof: Use the same proof as for abelian groups.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/FinAb.yaml
+++ b/database/data/categories/FinAb.yaml
@@ -60,7 +60,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective homomorphisms
-    proof: This follows exactly as for abelian groups.
+    proof: It is a full subcategory of $\Ab$, for which we know that isomorphisms are bijective homomorphisms.
   monomorphisms:
     description: injective homomorphisms
     proof: 'Let $f : A \to B$ be a monomorphism of finite abelian groups. Let $a \in A$ be in the kernel of $a$, say of order $n$. Then we may view $a$ as a morphism $a : \IZ/n \to A$ with $f \circ a = 0$, and $\IZ/n$ is finite. Hence, $a = 0$.'

--- a/database/data/categories/FinGrp.yaml
+++ b/database/data/categories/FinGrp.yaml
@@ -88,7 +88,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective homomorphisms
-    proof: This follows exactly as for <a href="/category/Grp">$\Grp$</a>.
+    proof: It is a full subcategory of $\Grp$, for which we know that isomorphisms are bijective homomorphisms.
   monomorphisms:
     description: injective homomorphisms
     proof: 'Let $f : A \to B$ be a monomorphism of finite groups. Let $a \in A$ be in the kernel of $a$, say of order $n$. Then we may view $a$ as a morphism $a : C_n \to A$ with $f \circ a = 1$ (the trivial homomorphism), and $C_n$ is finite. Hence, $a = 1$.'

--- a/database/data/categories/FinGrp.yaml
+++ b/database/data/categories/FinGrp.yaml
@@ -95,9 +95,3 @@ special_morphisms:
   epimorphisms:
     description: surjective homomorphisms
     proof: 'For the non-trivial direction, if $f : G \to H$ is an epimorphism, we may factor it as $G \to f(G) \to H$, and $f(G) \to H$ is still an epimorphism, but also an inclusion and hence a monomorphism. Since we already know that the category is mono-regular, $f(G) \to H$ must be an isomorphism.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/FinOrd.yaml
+++ b/database/data/categories/FinOrd.yaml
@@ -98,9 +98,3 @@ special_morphisms:
   epimorphisms:
     description: surjective order-preserving maps
     proof: 'The proof is similar to the one for <a href="/category/Set">$\Set$</a>: If $f : X \to Y$ is an epimorphism of (finite) orders, in particular for all morphisms $g,h : Y \to \{0 < 1\}$ with $g \circ f = h \circ f$ we have $g = h$. This means for all upper sets $A,B \subseteq Y$ with $f^*(A) = f^*(B)$ we have $A = B$. If $y \in Y$, apply this to the intervals $A = Y_{\geq y}$ and $B = Y_{> y}$, which are different. Hence, there is some $x \in f^*(A) \setminus f^*(B)$, which means $f(x) \geq y$ but not $f(x) > y$, so that $f(x) = y$.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/FinSet.yaml
+++ b/database/data/categories/FinSet.yaml
@@ -70,7 +70,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective maps
-    proof: This follows exactly as for sets.
+    proof: It is a full subcategory of $\Set$, for which we know that isomorphisms are bijective maps.
   monomorphisms:
     description: injective maps
     proof: For the non-trivial direction, the forgetful functor to $\Set$ is representable (by the terminal object), hence preserves monomorphisms.

--- a/database/data/categories/FinSet.yaml
+++ b/database/data/categories/FinSet.yaml
@@ -77,9 +77,3 @@ special_morphisms:
   epimorphisms:
     description: surjective maps
     proof: Use the same proof as for sets.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/FinVect_c.yaml
+++ b/database/data/categories/FinVect_c.yaml
@@ -62,11 +62,9 @@ special_morphisms:
   isomorphisms:
     description: bijective linear maps
     proof: It is a full subcategory of $\Vect_K$, for which we know that isomorphisms are bijective linear maps.
-
   monomorphisms:
     description: injective linear maps
     proof: For the non-trivial direction, the forgetful functor $\FinVect_K \to \Set$ is representable (by $K$), and therefore preserves monomorphisms.
-
   epimorphisms:
     description: surjective linear maps
     proof: 'For the non-trivial direction, it suffices to observe that every epimorphism in $\FinVect_K$ is also an epimorphism in $\Vect_K$, where epimorphisms are already classified. Namely, let $f : V \to W$ be an epimorphism in $\FinVect_K$ and let $g : W \to T$ be a linear map with $g \circ f = 0$. Then $g$ factors as $g = i \circ h$, where $i : \im(g) \hookrightarrow T$ is the inclusion of the image and $h : W \twoheadrightarrow \im(g)$ is the corestriction of $g$. Then $h \circ f = 0$, and since $\im(g)$ is finite-dimensional, it follows that $h = 0$. Hence $g = 0$.'

--- a/database/data/categories/FinVect_c.yaml
+++ b/database/data/categories/FinVect_c.yaml
@@ -61,7 +61,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective linear maps
-    proof: This is easy to check.
+    proof: It is a full subcategory of $\Vect_K$, for which we know that isomorphisms are bijective linear maps.
 
   monomorphisms:
     description: injective linear maps

--- a/database/data/categories/FinVect_c.yaml
+++ b/database/data/categories/FinVect_c.yaml
@@ -70,11 +70,3 @@ special_morphisms:
   epimorphisms:
     description: surjective linear maps
     proof: 'For the non-trivial direction, it suffices to observe that every epimorphism in $\FinVect_K$ is also an epimorphism in $\Vect_K$, where epimorphisms are already classified. Namely, let $f : V \to W$ be an epimorphism in $\FinVect_K$ and let $g : W \to T$ be a linear map with $g \circ f = 0$. Then $g$ factors as $g = i \circ h$, where $i : \im(g) \hookrightarrow T$ is the inclusion of the image and $h : W \twoheadrightarrow \im(g)$ is the corestriction of $g$. Then $h \circ f = 0$, and since $\im(g)$ is finite-dimensional, it follows that $h = 0$. Hence $g = 0$.'
-
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This holds because the category is abelian.
-
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This holds because the category is abelian.

--- a/database/data/categories/FinVect_f.yaml
+++ b/database/data/categories/FinVect_f.yaml
@@ -62,11 +62,9 @@ special_morphisms:
   isomorphisms:
     description: bijective linear maps
     proof: It is a full subcategory of $\Vect_K$, for which we know that isomorphisms are bijective linear maps.
-
   monomorphisms:
     description: injective linear maps
     proof: For the non-trivial direction, the forgetful functor $\FinVect_K \to \Set$ is representable (by $K$), and therefore preserves monomorphisms.
-
   epimorphisms:
     description: surjective linear maps
     proof: 'For the non-trivial direction, it suffices to observe that every epimorphism in $\FinVect_K$ is also an epimorphism in $\Vect_K$, where epimorphisms are already classified. Namely, let $f : V \to W$ be an epimorphism in $\FinVect_K$ and let $g : W \to T$ be a linear map with $g \circ f = 0$. Then $g$ factors as $g = i \circ h$, where $i : \im(g) \hookrightarrow T$ is the inclusion of the image and $h : W \twoheadrightarrow \im(g)$ is the corestriction of $g$. Then $h \circ f = 0$, and since $\im(g)$ is finite-dimensional, it follows that $h = 0$. Hence $g = 0$.'

--- a/database/data/categories/FinVect_f.yaml
+++ b/database/data/categories/FinVect_f.yaml
@@ -61,7 +61,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective linear maps
-    proof: This is easy to check.
+    proof: It is a full subcategory of $\Vect_K$, for which we know that isomorphisms are bijective linear maps.
 
   monomorphisms:
     description: injective linear maps

--- a/database/data/categories/FinVect_f.yaml
+++ b/database/data/categories/FinVect_f.yaml
@@ -70,11 +70,3 @@ special_morphisms:
   epimorphisms:
     description: surjective linear maps
     proof: 'For the non-trivial direction, it suffices to observe that every epimorphism in $\FinVect_K$ is also an epimorphism in $\Vect_K$, where epimorphisms are already classified. Namely, let $f : V \to W$ be an epimorphism in $\FinVect_K$ and let $g : W \to T$ be a linear map with $g \circ f = 0$. Then $g$ factors as $g = i \circ h$, where $i : \im(g) \hookrightarrow T$ is the inclusion of the image and $h : W \twoheadrightarrow \im(g)$ is the corestriction of $g$. Then $h \circ f = 0$, and since $\im(g)$ is finite-dimensional, it follows that $h = 0$. Hence $g = 0$.'
-
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This holds because the category is abelian.
-
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This holds because the category is abelian.

--- a/database/data/categories/FinVect_u.yaml
+++ b/database/data/categories/FinVect_u.yaml
@@ -62,11 +62,9 @@ special_morphisms:
   isomorphisms:
     description: bijective linear maps
     proof: It is a full subcategory of $\Vect_K$, for which we know that isomorphisms are bijective linear maps.
-
   monomorphisms:
     description: injective linear maps
     proof: For the non-trivial direction, the forgetful functor $\FinVect_K \to \Set$ is representable (by $K$), and therefore preserves monomorphisms.
-
   epimorphisms:
     description: surjective linear maps
     proof: 'For the non-trivial direction, it suffices to observe that every epimorphism in $\FinVect_K$ is also an epimorphism in $\Vect_K$, where epimorphisms are already classified. Namely, let $f : V \to W$ be an epimorphism in $\FinVect_K$ and let $g : W \to T$ be a linear map with $g \circ f = 0$. Then $g$ factors as $g = i \circ h$, where $i : \im(g) \hookrightarrow T$ is the inclusion of the image and $h : W \twoheadrightarrow \im(g)$ is the corestriction of $g$. Then $h \circ f = 0$, and since $\im(g)$ is finite-dimensional, it follows that $h = 0$. Hence $g = 0$.'

--- a/database/data/categories/FinVect_u.yaml
+++ b/database/data/categories/FinVect_u.yaml
@@ -61,7 +61,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective linear maps
-    proof: This is easy to check.
+    proof: It is a full subcategory of $\Vect_K$, for which we know that isomorphisms are bijective linear maps.
 
   monomorphisms:
     description: injective linear maps

--- a/database/data/categories/FinVect_u.yaml
+++ b/database/data/categories/FinVect_u.yaml
@@ -70,11 +70,3 @@ special_morphisms:
   epimorphisms:
     description: surjective linear maps
     proof: 'For the non-trivial direction, it suffices to observe that every epimorphism in $\FinVect_K$ is also an epimorphism in $\Vect_K$, where epimorphisms are already classified. Namely, let $f : V \to W$ be an epimorphism in $\FinVect_K$ and let $g : W \to T$ be a linear map with $g \circ f = 0$. Then $g$ factors as $g = i \circ h$, where $i : \im(g) \hookrightarrow T$ is the inclusion of the image and $h : W \twoheadrightarrow \im(g)$ is the corestriction of $g$. Then $h \circ f = 0$, and since $\im(g)$ is finite-dimensional, it follows that $h = 0$. Hence $g = 0$.'
-
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This holds because the category is abelian.
-
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This holds because the category is abelian.

--- a/database/data/categories/Fld.yaml
+++ b/database/data/categories/Fld.yaml
@@ -77,15 +77,9 @@ special_morphisms:
   isomorphisms:
     description: bijective field homomorphisms
     proof: This is easy.
-  monomorphisms:
-    description: every morphism
-    proof: It is well-known that field homomorphisms are injective.
   epimorphisms:
     description: purely inseparable homomorphisms
     proof: See <a href="https://math.stackexchange.com/questions/687869" target="_blank">MSE/687869</a>.
   regular monomorphisms:
     description: A Galois extension is a regular monomorphism iff it is procyclic, and the general case can be reduced to this situation; see the reference for details.
     proof: See <a href="https://math.stackexchange.com/questions/5129895" target="_blank">MSE/5129895</a>.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/Fld.yaml
+++ b/database/data/categories/Fld.yaml
@@ -76,7 +76,7 @@ special_objects: {}
 special_morphisms:
   isomorphisms:
     description: bijective field homomorphisms
-    proof: This is easy.
+    proof: It is a full subcategory of $\CRing$, for which we know that isomorphisms are bijective homomorphisms.
   epimorphisms:
     description: purely inseparable homomorphisms
     proof: See <a href="https://math.stackexchange.com/questions/687869" target="_blank">MSE/687869</a>.

--- a/database/data/categories/FreeAb.yaml
+++ b/database/data/categories/FreeAb.yaml
@@ -74,7 +74,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective homomorphisms
-    proof: This follows exactly as for abelian groups.
+    proof: It is a full subcategory of $\Ab$, for which we know that isomorphisms are bijective homomorphisms.
   monomorphisms:
     description: injective homomorphisms
     proof: 'Let $f : A \to B$ be a monomorphism of free abelian groups. Let $a \in A$ be in the kernel of $a$. Then we may view $a$ as a morphism $a : \IZ \to A$ with $f \circ a = 0$, and $\IZ$ is free. Hence, $a = 0$.'

--- a/database/data/categories/Grp.yaml
+++ b/database/data/categories/Grp.yaml
@@ -88,5 +88,5 @@ special_objects:
 
 special_morphisms:
   epimorphisms:
-    description: surjective homomorphisms
+    description: surjective morphisms
     proof: 'For the non-trivial direction, if $f : G \to H$ is an epimorphism, we may factor it as $G \to f(G) \to H$, and $f(G) \to H$ is still an epimorphism, but also an inclusion and hence a monomorphism. Since we already know that the category is balanced, $f(G) \to H$ must be an isomorphism.'

--- a/database/data/categories/Grp.yaml
+++ b/database/data/categories/Grp.yaml
@@ -87,18 +87,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective homomorphisms
     proof: 'For the non-trivial direction, if $f : G \to H$ is an epimorphism, we may factor it as $G \to f(G) \to H$, and $f(G) \to H$ is still an epimorphism, but also an inclusion and hence a monomorphism. Since we already know that the category is balanced, $f(G) \to H$ must be an isomorphism.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/Grp_c.yaml
+++ b/database/data/categories/Grp_c.yaml
@@ -117,9 +117,3 @@ special_morphisms:
   epimorphisms:
     description: surjective homomorphisms
     proof: 'For the non-trivial direction, if $f : G \to H$ is an epimorphism, we may factor it as $G \to f(G) \to H$, and $f(G) \to H$ is still an epimorphism, but also an inclusion and hence a monomorphism. Since we already know that the category is mono-regular, $f(G) \to H$ must be an isomorphism.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Grp_c.yaml
+++ b/database/data/categories/Grp_c.yaml
@@ -110,7 +110,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective homomorphisms
-    proof: This is easy.
+    proof: It is a full subcategory of $\Grp$, for which we know that isomorphisms are bijective homomorphisms.
   monomorphisms:
     description: injective homomorphisms
     proof: For the non-trivial direction, the forgetful functor to $\Set$ is representable (by the countable group $\IZ$), hence preserves monomorphisms.

--- a/database/data/categories/J2.yaml
+++ b/database/data/categories/J2.yaml
@@ -50,18 +50,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective morphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective morphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective morphisms
     proof: 'For the non-trivial direction: The category is epi-regular (since it is an elementary topos), and every regular epimorphism is surjective (this holds in any algebraic category).'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/M-Set.yaml
+++ b/database/data/categories/M-Set.yaml
@@ -48,4 +48,4 @@ special_objects:
 special_morphisms:
   epimorphisms:
     description: surjective $M$-maps
-    proof: This holds in every functor category $[\C,\Set]$, here applied to the case that $\C$ has just one object.
+    proof: More generally, epimorphisms in functor categories $[\C,\Set]$ can be detected pointwise, since pushouts can be constructed pointwise. This is applied here to the one-object category corresponding to $M$.

--- a/database/data/categories/M-Set.yaml
+++ b/database/data/categories/M-Set.yaml
@@ -47,5 +47,5 @@ special_objects:
 
 special_morphisms:
   epimorphisms:
-    description: surjective $M$-maps
+    description: surjective morphisms
     proof: More generally, epimorphisms in functor categories $[\C,\Set]$ can be detected pointwise, since pushouts can be constructed pointwise. This is applied here to the one-object category corresponding to $M$.

--- a/database/data/categories/M-Set.yaml
+++ b/database/data/categories/M-Set.yaml
@@ -46,18 +46,6 @@ special_objects:
     description: direct products with the evident $M$-action
 
 special_morphisms:
-  isomorphisms:
-    description: bijective $M$-maps
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective $M$-maps
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective $M$-maps
     proof: This holds in every functor category $[\C,\Set]$, here applied to the case that $\C$ has just one object.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/Mon.yaml
+++ b/database/data/categories/Mon.yaml
@@ -87,15 +87,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: 'A monoid map $f : T \to S$ is an epimorphism iff $S$ equals the <i>dominion</i> of $U \coloneqq f(T) \subseteq S$, meaning that for every $s \in S$ there are $u_1,\dotsc,u_{m+1} \in U$, $v_1,\dotsc,v_m \in U$, $x_1,\dotsc,x_m \in S$ and $y_1,\dotsc,y_m \in S$ such that $s = x_1 u_1$, $u_1 = v_1 y_1$, $x_{i-1} v_{i-1} = x_i u_i$, $u_i y_{i-1} = v_i y_i$, $x_m v_m = u_{m+1}$ and $u_{m+1} y_m = s$.'
     proof: This is <a href="https://en.wikipedia.org/wiki/Isbell's_zigzag_theorem" target="_blank">Isbell's zigzag Theorem</a>, see references there.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/N.yaml
+++ b/database/data/categories/N.yaml
@@ -55,16 +55,4 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: only the identity morphisms
-    proof: This is true for every poset (regarded as a category).
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+    proof: This is true for every poset (regarded as a thin category).

--- a/database/data/categories/N_oo.yaml
+++ b/database/data/categories/N_oo.yaml
@@ -60,16 +60,4 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: only the identity morphisms
-    proof: This is true for every poset (regarded as a category).
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+    proof: This is true for every poset (regarded as a thin category).

--- a/database/data/categories/On.yaml
+++ b/database/data/categories/On.yaml
@@ -58,16 +58,4 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: only the identities
-    proof: This is true for every poset (regarded as a category).
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+    proof: This is true for every partially ordered collection (regarded as a thin category).

--- a/database/data/categories/R-Mod.yaml
+++ b/database/data/categories/R-Mod.yaml
@@ -48,5 +48,5 @@ special_objects:
 
 special_morphisms:
   epimorphisms:
-    description: surjective $R$-linear maps
+    description: surjective morphisms
     proof: The forgetful functor to abelian groups is faithful and preserves colimits, hence reflects and preserves epimorphisms. Alternatively, use the same proof as for abelian groups.

--- a/database/data/categories/R-Mod.yaml
+++ b/database/data/categories/R-Mod.yaml
@@ -47,18 +47,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective $R$-linear maps
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective $R$-linear maps
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective $R$-linear maps
     proof: The forgetful functor to abelian groups is faithful and preserves colimits, hence reflects and preserves epimorphisms. Alternatively, use the same proof as for abelian groups.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/R-Mod_div.yaml
+++ b/database/data/categories/R-Mod_div.yaml
@@ -42,5 +42,5 @@ special_objects:
 
 special_morphisms:
   epimorphisms:
-    description: surjective $R$-linear maps
+    description: surjective morphisms
     proof: The forgetful functor to abelian groups is faithful and preserves colimits, hence reflects and preserves epimorphisms. Alternatively, use the same proof as for abelian groups.

--- a/database/data/categories/R-Mod_div.yaml
+++ b/database/data/categories/R-Mod_div.yaml
@@ -41,18 +41,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective $R$-linear maps
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective $R$-linear maps
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective $R$-linear maps
     proof: The forgetful functor to abelian groups is faithful and preserves colimits, hence reflects and preserves epimorphisms. Alternatively, use the same proof as for abelian groups.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/Ring.yaml
+++ b/database/data/categories/Ring.yaml
@@ -80,13 +80,4 @@ special_objects:
   products:
     description: direct products with pointwise operations
 
-special_morphisms:
-  isomorphisms:
-    description: bijective ring homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective ring homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.
+special_morphisms: {}

--- a/database/data/categories/Rng.yaml
+++ b/database/data/categories/Rng.yaml
@@ -90,13 +90,4 @@ special_objects:
   products:
     description: direct products with pointwise operations
 
-special_morphisms:
-  isomorphisms:
-    description: bijective rng homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective rng homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.
+special_morphisms: {}

--- a/database/data/categories/SemiGrp.yaml
+++ b/database/data/categories/SemiGrp.yaml
@@ -110,15 +110,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective ring homomorphisms
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective semigroup homomorphisms
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: 'A semigroup homomorphism $f : T \to S$ is an epimorphism iff $S$ equals the <i>dominion</i> of $U \coloneqq f(T) \subseteq S$, meaning that for every $s \in S$ there are $u_1,\dotsc,u_{m+1} \in U$, $v_1,\dotsc,v_m \in U$, $x_1,\dotsc,x_m \in S$ and $y_1,\dotsc,y_m \in S$ such that $s = x_1 u_1$, $u_1 = v_1 y_1$, $x_{i-1} v_{i-1} = x_i u_i$, $u_i y_{i-1} = v_i y_i$, $x_m v_m = u_{m+1}$ and $u_{m+1} y_m = s$.'
     proof: This is <a href="https://en.wikipedia.org/wiki/Isbell's_zigzag_theorem" target="_blank">Isbell's zigzag Theorem</a>, see references there.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/Set.yaml
+++ b/database/data/categories/Set.yaml
@@ -52,7 +52,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective maps
-    proof: This is easy.
+    proof: This is an elementary fact from set theory.
   monomorphisms:
     description: injective maps
     proof: 'For the non-trivial direction, if $f : X \to Y$ is a monomorphism of sets and $a,b \in X$ satisfy $f(a) = f(b)$, then $f \circ a = f \circ b$ when we regard $a,b$ as morphisms $a,b : 1 \to X$. Hence, $a = b$. More generally, if $\C$ is a category that admits a faithful and representable functor $U : \C \to \Set$, then the monomorphisms in $\C$ are precisely the morphisms whose $U$-image is injective.'

--- a/database/data/categories/Set.yaml
+++ b/database/data/categories/Set.yaml
@@ -59,9 +59,3 @@ special_morphisms:
   epimorphisms:
     description: surjective maps
     proof: 'For the non-trivial direction, if $f : X \to Y$ is an epimorphism of sets, then in particular $f^* : \Hom(Y,2) \to \Hom(X,2)$ is injective, which identifies with $f^* : P(Y) \to P(X)$. Then for all $y \in Y$ we have $f^*(\{y\}) \neq f^*(\varnothing) = \varnothing$, so that $y$ has a preimage.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/Set_arrow.yaml
+++ b/database/data/categories/Set_arrow.yaml
@@ -64,9 +64,3 @@ special_morphisms:
   epimorphisms:
     description: pairs $(\ell, r)$ where $\ell$ and $r$ are both surjective
     proof: For the non-trivial direction, use the fact that the category is epi-regular, so any epimorphism is a coequalizer; and the fact that coequalizers can be calculated component-wise.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Set_c.yaml
+++ b/database/data/categories/Set_c.yaml
@@ -91,7 +91,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective maps
-    proof: This is easy.
+    proof: It is a full subcategory of $\Set$, for which we know that isomorphisms are bijective maps.
   monomorphisms:
     description: injective maps
     proof: For the non-trivial direction, the forgetful functor to $\Set$ is representable (by the terminal object), hence preserves monomorphisms.

--- a/database/data/categories/Set_c.yaml
+++ b/database/data/categories/Set_c.yaml
@@ -98,9 +98,3 @@ special_morphisms:
   epimorphisms:
     description: surjective maps
     proof: 'For the non-trivial direction, if $f : X \to Y$ is an epimorphism of countable sets, then in particular $f^* : \Hom(Y,2) \to \Hom(X,2)$ is injective, which identifies with $f^* : P(Y) \to P(X)$. Then for all $y \in Y$ we have $f^*(\{y\}) \neq f^*(\varnothing) = \varnothing$, so that $y$ has a preimage.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Set_f.yaml
+++ b/database/data/categories/Set_f.yaml
@@ -97,9 +97,3 @@ special_morphisms:
   epimorphisms:
     description: surjective maps with finite fibers
     proof: 'For the non-trivial direction, if $f : X \to Y$ is an epimorphism in this category, then in particular $f^* : \Hom(Y,2) \to \Hom(X,2)$ is injective, which identifies with $f^* : E(Y) \to E(X)$, where $E(-)$ denotes the set of finite subsets. Then for all $y \in Y$ we have $f^*(\{y\}) \neq f^*(\varnothing) = \varnothing$, so that $y$ has a preimage.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Set_pointed.yaml
+++ b/database/data/categories/Set_pointed.yaml
@@ -78,5 +78,5 @@ special_objects:
 
 special_morphisms:
   epimorphisms:
-    description: surjective pointed maps
+    description: surjective morphisms
     proof: 'If $f : X \to Y$ is an epimorphism of pointed sets, then the inclusion $i : f(X) \hookrightarrow Y$ is an epimorphism as well. But it is also a split monomorphism (we may map everything in $Y \setminus f(X)$ to the base point of $f(X)$, and do not touch the rest), hence an isomorphism.'

--- a/database/data/categories/Set_pointed.yaml
+++ b/database/data/categories/Set_pointed.yaml
@@ -77,18 +77,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective pointed maps
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective pointed maps
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective pointed maps
     proof: 'If $f : X \to Y$ is an epimorphism of pointed sets, then the inclusion $i : f(X) \hookrightarrow Y$ is an epimorphism as well. But it is also a split monomorphism (we may map everything in $Y \setminus f(X)$ to the base point of $f(X)$, and do not touch the rest), hence an isomorphism.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/Setne.yaml
+++ b/database/data/categories/Setne.yaml
@@ -90,7 +90,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective maps
-    proof: This follows exactly as for sets.
+    proof: It is a full subcategory of $\Set$, for which we know that isomorphisms are bijective maps.
   monomorphisms:
     description: injective maps
     proof: For the non-trivial direction, the forgetful functor to $\Set$ is representable (by the terminal object), hence preserves monomorphisms.

--- a/database/data/categories/Setne.yaml
+++ b/database/data/categories/Setne.yaml
@@ -97,9 +97,3 @@ special_morphisms:
   epimorphisms:
     description: surjective maps
     proof: 'For the non-trivial direction, let $f : X \to Y$ be an epimorphism of non-empty sets. Then the inclusion $f(X) \hookrightarrow Y$ is an epimorphism as well, but also a split monomorphism (we can just map everything in $Y \setminus f(X)$ to a fixed element of $f(X)$). As such, it must be an isomorphism.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/SetxSet.yaml
+++ b/database/data/categories/SetxSet.yaml
@@ -57,9 +57,3 @@ special_morphisms:
   epimorphisms:
     description: pairs of surjective maps
     proof: This follows from the fact for the category of sets.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Sh(X).yaml
+++ b/database/data/categories/Sh(X).yaml
@@ -57,9 +57,3 @@ special_morphisms:
   epimorphisms:
     description: 'morphisms of sheaves $f : F \to G$ that are "locally surjective": for every local section $g \in G(U)$ there is an open covering $U = \bigcup_{i \in I} U_i$ such that each $g|_{U_i} \in G(U_i)$ is contained in the image of $f(U_i) : F(U_i) \to G(U_i)$.'
     proof: 'The one direction is easy. For the other one, assume that $f : F \to G$ is an epimorphism of sheaves. For every $x \in X$ the map on stalks $f_x : F_x \to G_x$ is an epimorphism because the stalk functor $\Sh(X) \to \Set$ admits a right adjoint: take skyscraper sheaves. For $x \in U$ then $g_x \in G_x$ has a preimage in $F_x$, say represented by some $f \in F(V_x)$ for some $x \in V_x \subseteq U$. By construction of the stalk $G_x$, there is some $x \in U_x \subseteq V_x$ with $f(U_x)(f|_{U_x}) = g|_{U_x}$. Hence, the sets $(U_x)$ provide the open covering.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Sh(X,Ab).yaml
+++ b/database/data/categories/Sh(X,Ab).yaml
@@ -51,9 +51,3 @@ special_morphisms:
   epimorphisms:
     description: 'morphisms of abelian sheaves $f : F \to G$ that are "locally surjective": for every local section $g \in G(U)$ there is an open covering $U = \bigcup_{i \in I} U_i$ such that each $g|_{U_i} \in G(U_i)$ is contained in the image of $f(U_i) : F(U_i) \to G(U_i)$.'
     proof: 'The one direction is easy. For the other one, assume that $f : F \to G$ is an epimorphism of abelian sheaves. For every $x \in X$ the homomorphism on stalks $f_x : F_x \to G_x$ is an epimorphism because the stalk functor  $\Sh(X,\Ab) \to \Ab$ admits a right adjoint: take skyscraper sheaves. For $x \in U$ then $g_x \in G_x$ has a preimage in $F_x$, say represented by some $f \in F(V_x)$ for some $x \in V_x \subseteq U$. By construction of the stalk $G_x$, there is some $x \in U_x \subseteq V_x$ with $f(U_x)(f|_{U_x}) = g|_{U_x}$. Hence, the sets $(U_x)$ provide the open covering.'
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Sp.yaml
+++ b/database/data/categories/Sp.yaml
@@ -77,9 +77,3 @@ special_morphisms:
   epimorphisms:
     description: pointwise surjective natural transformations
     proof: This holds in every functor category $[\C,\Set]$.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Sp.yaml
+++ b/database/data/categories/Sp.yaml
@@ -73,7 +73,7 @@ special_morphisms:
     proof: This is true for every functor category.
   monomorphisms:
     description: pointwise injective natural transformations
-    proof: 'If $a : F \to G$ is a monomorphism of species, then the diagonal morphism $F \to F \times_G F$ is an isomorphism, so that for every $x$ the diagonal morphism $F(x) \to F(x) \times_{G(x)} F(x)$ is an isomorphism, i.e., $a(x) : F(x) \to G(x)$ is a monomorphism. This argument works for every functor category where the target has fiber products.'
+    proof: This holds in every functor category $[\C,\Set]$ since pullbacks can be constructed pointwise.
   epimorphisms:
     description: pointwise surjective natural transformations
-    proof: This holds in every functor category $[\C,\Set]$.
+    proof: This holds in every functor category $[\C,\Set]$ since pushouts can be constructed pointwise.

--- a/database/data/categories/Sp.yaml
+++ b/database/data/categories/Sp.yaml
@@ -70,7 +70,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: natural isomorphisms
-    proof: This is the for every functor category.
+    proof: This is true for every functor category.
   monomorphisms:
     description: pointwise injective natural transformations
     proof: 'If $a : F \to G$ is a monomorphism of species, then the diagonal morphism $F \to F \times_G F$ is an isomorphism, so that for every $x$ the diagonal morphism $F(x) \to F(x) \times_{G(x)} F(x)$ is an isomorphism, i.e., $a(x) : F(x) \to G(x)$ is a monomorphism. This argument works for every functor category where the target has fiber products.'

--- a/database/data/categories/TorsAb.yaml
+++ b/database/data/categories/TorsAb.yaml
@@ -74,9 +74,3 @@ special_morphisms:
   epimorphisms:
     description: surjective homomorphisms
     proof: Clearly, surjective homomorphisms are epimorphisms. The converse follows since the forgetful functor $\TorsAb \to \Ab$ has a right adjoint, hence preserves epimorphisms.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/TorsAb.yaml
+++ b/database/data/categories/TorsAb.yaml
@@ -67,7 +67,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective group homomorphisms
-    proof: This is easy.
+    proof: It is a full subcategory of $\Ab$, for which we know that isomorphisms are bijective homomorphisms.
   monomorphisms:
     description: injective group homomorphisms
     proof: 'For the non-trivial direction, assume $f : A \to B$ is a monomorphism and $a \in A$ satisfies $f(a)=0$. Choose $n \geq 1$ with $n a = 0$. Then $a$ corresponds to a homomorphism of torsion abelian groups $\tilde{a} : \IZ/n \to A$ satisfying $f \circ \tilde{a} = 0$. Hence, $\tilde{a} = 0$, which means $a = 0$.'

--- a/database/data/categories/TorsFreeAb.yaml
+++ b/database/data/categories/TorsFreeAb.yaml
@@ -67,7 +67,7 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: bijective group homomorphisms
-    proof: This is easy.
+    proof: It is a full subcategory of $\Ab$, for which we know that isomorphisms are bijective homomorphisms.
   monomorphisms:
     description: injective group homomorphisms
     proof: For the non-trivial direction, the forgetful functor to $\Set$ is representable (by the group $\IZ$), hence preserves monomorphisms.

--- a/database/data/categories/Vect.yaml
+++ b/database/data/categories/Vect.yaml
@@ -46,18 +46,6 @@ special_objects:
     description: direct products with pointwise operations
 
 special_morphisms:
-  isomorphisms:
-    description: bijective linear maps
-    proof: This characterization holds in every algebraic category.
-  monomorphisms:
-    description: injective linear maps
-    proof: 'This holds in every finitary algebraic category: the forgetful functor to $\Set$ is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
   epimorphisms:
     description: surjective linear maps
     proof: The forgetful functor to abelian groups is faithful and preserves colimits, hence reflects and preserves epimorphisms. Alternatively, just use the same proof as for abelian groups.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: surjective homomorphisms
-    proof: This holds in every finitary algebraic category.

--- a/database/data/categories/Vect.yaml
+++ b/database/data/categories/Vect.yaml
@@ -47,5 +47,5 @@ special_objects:
 
 special_morphisms:
   epimorphisms:
-    description: surjective linear maps
+    description: surjective morphisms
     proof: The forgetful functor to abelian groups is faithful and preserves colimits, hence reflects and preserves epimorphisms. Alternatively, just use the same proof as for abelian groups.

--- a/database/data/categories/Z.yaml
+++ b/database/data/categories/Z.yaml
@@ -87,9 +87,3 @@ special_morphisms:
   epimorphisms:
     description: objectwise surjective natural transformations
     proof: This holds in every functor category $[\C,\Set]$, here applied to the case that $\C$ has just one object.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/Z_div.yaml
+++ b/database/data/categories/Z_div.yaml
@@ -57,15 +57,3 @@ special_morphisms:
   isomorphisms:
     description: 'the identities $(a,a) : a \to a$ and the isomorphisms $(a,-a) : a \to -a$ for $a \in \IZ$'
     proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/real_interval.yaml
+++ b/database/data/categories/real_interval.yaml
@@ -55,16 +55,4 @@ special_objects:
 special_morphisms:
   isomorphisms:
     description: only the identity morphisms
-    proof: This is true for every poset (regarded as a category).
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+    proof: This is true for every poset (regarded as a thin category).

--- a/database/data/categories/sSet.yaml
+++ b/database/data/categories/sSet.yaml
@@ -57,9 +57,3 @@ special_morphisms:
   epimorphisms:
     description: pointwise surjective transformations
     proof: This holds in every functor category $[\C,\Set]$.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/sSet.yaml
+++ b/database/data/categories/sSet.yaml
@@ -53,7 +53,7 @@ special_morphisms:
     proof: This is true for all functor categories.
   monomorphisms:
     description: pointwise injective transformations
-    proof: 'If $a : F \to G$ is a monomorphism of simplicial sets, then the diagonal morphism $F \to F \times_G F$ is an isomorphism, so that for every $n$ the diagonal morphism $F(n) \to F(n) \times_{G(n)} F(n)$ is an isomorphism, i.e., $a(n) : F(n) \to G(n)$ is a monomorphism. This argument works for every functor category where the target has fiber products.'
+    proof: This holds in every functor category $[\C,\Set]$ since pullbacks can be constructed pointwise.
   epimorphisms:
     description: pointwise surjective transformations
-    proof: This holds in every functor category $[\C,\Set]$.
+    proof: This holds in every functor category $[\C,\Set]$ since pushouts can be constructed pointwise.

--- a/database/data/categories/walking_commutative_square.yaml
+++ b/database/data/categories/walking_commutative_square.yaml
@@ -57,15 +57,3 @@ special_morphisms:
   isomorphisms:
     description: the four identities
     proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/walking_composable_pair.yaml
+++ b/database/data/categories/walking_composable_pair.yaml
@@ -54,15 +54,3 @@ special_morphisms:
   isomorphisms:
     description: the three identities
     proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/walking_coreflexive_pair.yaml
+++ b/database/data/categories/walking_coreflexive_pair.yaml
@@ -85,9 +85,3 @@ special_morphisms:
   epimorphisms:
     description: the identities and $p$
     proof: Since $pi = \id$, but $ip \neq \id$, we conclude that $p$ is an epimorphism, but $i$ is not. Hence, also $ip$ is not an epimorphism. Likewise, $j$ and $jp$ are no epimorphisms.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/categories/walking_fork.yaml
+++ b/database/data/categories/walking_fork.yaml
@@ -66,15 +66,9 @@ special_morphisms:
   isomorphisms:
     description: the three identities
     proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: This is easily checked.
   epimorphisms:
     description: the identities and $f,g$
     proof: This is easily checked.
   regular monomorphisms:
     description: the identities and $i$
     proof: First, $i$ is the equalizer of $f,g$. The morphism $f$ is an epimorphism (and a monomorphism), but no isomorphism, hence cannot be a regular monomorphism. The same holds for $g$.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/walking_isomorphism.yaml
+++ b/database/data/categories/walking_isomorphism.yaml
@@ -42,19 +42,4 @@ special_objects:
   products:
     description: $0 \times 0 = 0$
 
-special_morphisms:
-  isomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
-  epimorphisms:
-    description: every morphism
-    proof: This holds because it is a groupoid.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.
+special_morphisms: {}

--- a/database/data/categories/walking_morphism.yaml
+++ b/database/data/categories/walking_morphism.yaml
@@ -59,15 +59,3 @@ special_morphisms:
   isomorphisms:
     description: the two identities
     proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/walking_pair.yaml
+++ b/database/data/categories/walking_pair.yaml
@@ -55,6 +55,3 @@ special_morphisms:
   isomorphisms:
     description: the two identities
     proof: This is trivial.
-  epimorphisms:
-    description: every morphism
-    proof: Each $0 \to 1$ is an epimorphism since the only morphism starting at $1$ is the identity.

--- a/database/data/categories/walking_pair.yaml
+++ b/database/data/categories/walking_pair.yaml
@@ -55,15 +55,6 @@ special_morphisms:
   isomorphisms:
     description: the two identities
     proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: This is trivial.
   epimorphisms:
     description: every morphism
     proof: Each $0 \to 1$ is an epimorphism since the only morphism starting at $1$ is the identity.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is left cancellative.

--- a/database/data/categories/walking_span.yaml
+++ b/database/data/categories/walking_span.yaml
@@ -53,15 +53,3 @@ special_morphisms:
   isomorphisms:
     description: the three identities
     proof: This is trivial.
-  monomorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  epimorphisms:
-    description: every morphism
-    proof: It is a thin category.
-  regular monomorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.
-  regular epimorphisms:
-    description: same as isomorphisms
-    proof: This is because the category is right cancellative.

--- a/database/data/categories/walking_splitting.yaml
+++ b/database/data/categories/walking_splitting.yaml
@@ -74,9 +74,3 @@ special_morphisms:
   epimorphisms:
     description: the identities and $p$
     proof: The morphism $p$ is even a split monomorphism. The morphism $i$ is not an epimorphism since $\id_1 \circ i = ip \circ i$. The morphism $ip$ is not a epimorphism since it would imply that $i$ is an epimorphism.
-  regular monomorphisms:
-    description: same as monomorphisms
-    proof: This is because the category is mono-regular.
-  regular epimorphisms:
-    description: same as epimorphisms
-    proof: This is because the category is epi-regular.

--- a/database/data/special-morphism-rules.yaml
+++ b/database/data/special-morphism-rules.yaml
@@ -1,0 +1,59 @@
+- property: groupoid
+  type: isomorphisms
+  description: every morphism
+  proof: The category is a groupoid.
+
+- property: thin
+  type: monomorphisms
+  description: every morphism
+  proof: It is a thin category.
+
+- property: thin
+  type: epimorphisms
+  description: every morphism
+  proof: It is a thin category.
+
+- property: left cancellative
+  type: monomorphisms
+  description: every morphism
+  proof: The category is left cancellative.
+
+- property: right cancellative
+  type: epimorphisms
+  description: every morphism
+  proof: The category is right cancellative.
+
+- property: left cancellative
+  type: regular epimorphisms
+  description: same as isomorphisms
+  proof: The category is left cancellative, and a regular epimorphism which is a monomorphism must be an isomorphism.
+
+- property: right cancellative
+  type: regular monomorphisms
+  description: same as isomorphisms
+  proof: The category is right cancellative, and a regular monomorphism which is an epimorphism must be an isomorphism.
+
+- property: finitary algebraic
+  type: isomorphisms
+  description: bijective morphisms
+  proof: 'This holds in every finitary algebraic category: the inverse of a bijective morphism is again a morphism.'
+
+- property: finitary algebraic
+  type: monomorphisms
+  description: injective morphisms
+  proof: 'This holds in every finitary algebraic category: the forgetful functor to sets is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
+
+- property: finitary algebraic
+  type: regular epimorphisms
+  description: surjective morphisms
+  proof: 'This holds in every finitary algebraic category: the construction of coequalizers shows that every regular epimorphism is surjective. Conversely, the fundamental theorem on homomorphisms states that every surjective homomorphism $A \to B$ is the coequalizer of the two projections $A \times_B A \rightrightarrows A$.'
+
+- property: mono-regular
+  type: regular monomorphisms
+  description: same as monomorphisms
+  proof: The category is mono-regular.
+
+- property: epi-regular
+  type: regular epimorphisms
+  description: same as epimorphisms
+  proof: The category is epi-regular.

--- a/database/schema/006_special-morphisms.sql
+++ b/database/schema/006_special-morphisms.sql
@@ -18,3 +18,15 @@ CREATE TABLE special_morphisms (
 );
 
 CREATE INDEX idx_special_morphisms_by_category ON special_morphisms (category_id);
+
+CREATE TABLE special_morphism_rules (
+    id INTEGER PRIMARY KEY,
+    property_id TEXT NOT NULL,
+    property_type TEXT NOT NULL DEFAULT 'category',
+    type TEXT NOT NULL,
+    description TEXT NOT NULL,
+    proof TEXT NOT NULL,
+    FOREIGN KEY (property_id, property_type)
+        REFERENCES properties (id, type) ON DELETE CASCADE,
+    FOREIGN KEY (type) REFERENCES special_morphism_types (type) ON DELETE RESTRICT
+);

--- a/database/scripts/deduce-special-morphisms.ts
+++ b/database/scripts/deduce-special-morphisms.ts
@@ -3,13 +3,10 @@ import { devlog } from '$shared/utils'
 
 const db = get_client({ readonly: false })
 
-// TODO: deduce further morphisms,
-// e.g. isomorphisms = bijective morphisms in algebraic categories,
-// e.g. regular monomorphisms = same as monomorphisms in mono-regular categories
-
 export function deduce_special_morphisms() {
 	console.info('\n--- Deduce special morphisms ---')
 	clear_deduced_special_morphisms()
+	deduce_special_morphisms_by_rules()
 	deduce_special_morphisms_of_dual_categories()
 }
 
@@ -21,8 +18,144 @@ function clear_deduced_special_morphisms() {
 }
 
 /**
+ * A rule specifies how a certain type of special morphism can be deduced.
+ * TODO: move this to the database.
+ */
+type Rule = {
+	property: string
+	type: string
+	description: string
+	proof: string
+}
+
+/**
+ * Rules for deducing special morphisms in categories that satisfy a given property.
+ * TODO: move this to the database.
+ */
+const RULES: Rule[] = [
+	{
+		property: 'groupoid',
+		type: 'isomorphisms',
+		description: 'every morphism',
+		proof: 'The category is a groupoid.'
+	},
+	{
+		property: 'finitary algebraic',
+		type: 'isomorphisms',
+		proof: 'bijective morphisms',
+		description:
+			'This characterization holds in every finitary algebraic category: the inverse of a bijective morphism is again a morphism.'
+	},
+	{
+		property: 'finitary algebraic',
+		type: 'monomorphisms',
+		description: 'injective morphisms',
+		proof: 'This holds in every finitary algebraic category: the forgetful functor to sets is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
+	},
+	{
+		property: 'finitary algebraic',
+		type: 'regular epimorphisms',
+		description: 'surjective morphisms',
+		proof: 'This holds in every finitary algebraic category: the construction of coequalizers shows that every regular epimorphism is surjective. Conversely, the fundamental theorem on homomorphisms states that every surjective homomorphism $A \\to B$ is the coequalizer of the two projections $A \\times_B A \\rightrightarrows A$.'
+	},
+	{
+		property: 'thin',
+		type: 'monomorphisms',
+		description: 'every morphism',
+		proof: 'It is a thin category.'
+	},
+	{
+		property: 'thin',
+		type: 'epimorphisms',
+		description: 'every morphism',
+		proof: 'It is a thin category.'
+	},
+	{
+		property: 'left cancellative',
+		type: 'monomorphisms',
+		description: 'every morphism',
+		proof: 'The category is left cancellative.'
+	},
+	{
+		property: 'right cancellative',
+		type: 'epimorphisms',
+		description: 'every morphism',
+		proof: 'The category is right cancellative.'
+	},
+	{
+		property: 'left cancellative',
+		type: 'regular epimorphisms',
+		description: 'same as isomorphisms',
+		proof: 'The category is left cancellative, and a regular epimorphism which is a monomorphism must be an isomorphism.'
+	},
+	{
+		property: 'right cancellative',
+		type: 'regular monomorphisms',
+		description: 'same as isomorphisms',
+		proof: 'The category is right cancellative, and a regular monomorphism which is an epimorphism must be an isomorphism.'
+	},
+	{
+		property: 'mono-regular',
+		type: 'regular monomorphisms',
+		description: 'same as monomorphisms',
+		proof: 'The category is mono-regular.'
+	},
+	{
+		property: 'epi-regular',
+		type: 'regular epimorphisms',
+		description: 'same as epimorphisms',
+		proof: 'The category is epi-regular.'
+	}
+]
+
+/**
+ * Deduces special morphisms as specified by a rule.
+ * We ignore duplicate assignments here because of overlaps
+ * with previous deductions.
+ */
+function deduce_special_morphisms_by_rule(rule: Rule) {
+	const { property, type, description, proof } = rule
+
+	const res = db
+		.prepare(
+			`INSERT INTO special_morphisms (
+                category_id,
+                type,
+                description,
+                proof,
+                is_deduced
+            )
+            SELECT
+                structure_id,
+                ?,
+                ?,
+                ?,
+                TRUE
+            FROM property_assignments
+            WHERE type = 'category'
+            AND property_id = ?
+            AND is_satisfied = TRUE
+            ON CONFLICT (category_id, type) DO NOTHING`
+		)
+		.run(type, description, proof, property)
+
+	devlog(`Deduced ${res.changes} descriptions of ${type} in ${property} categories`)
+}
+
+/**
+ * Deduces special morphisms for all rules.
+ */
+function deduce_special_morphisms_by_rules() {
+	for (const rule of RULES) {
+		deduce_special_morphisms_by_rule(rule)
+	}
+}
+
+/**
  * Deduce special morphisms in dual categories.
  * For example, monomorphisms in C describe epimorphisms in C^op.
+ * We ignore duplicate assignments here because of overlaps
+ * with previous deductions.
  */
 function deduce_special_morphisms_of_dual_categories() {
 	const res = db
@@ -43,7 +176,8 @@ function deduce_special_morphisms_of_dual_categories() {
             FROM structures c
             INNER JOIN special_morphisms m ON m.category_id = c.id
             INNER JOIN special_morphism_types t ON t.type = m.type
-            WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL`
+            WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL
+            ON CONFLICT (category_id, type) DO NOTHING`
 		)
 		.run()
 

--- a/database/scripts/deduce-special-morphisms.ts
+++ b/database/scripts/deduce-special-morphisms.ts
@@ -18,136 +18,53 @@ function clear_deduced_special_morphisms() {
 }
 
 /**
- * A rule specifies how a certain type of special morphism can be deduced.
- * TODO: move this to the database.
- */
-type Rule = {
-	property: string
-	type: string
-	description: string
-	proof: string
-}
-
-/**
- * Rules for deducing special morphisms in categories that satisfy a given property.
- * TODO: move this to the database.
- */
-const RULES: Rule[] = [
-	{
-		property: 'groupoid',
-		type: 'isomorphisms',
-		description: 'every morphism',
-		proof: 'The category is a groupoid.'
-	},
-	{
-		property: 'finitary algebraic',
-		type: 'isomorphisms',
-		proof: 'bijective morphisms',
-		description:
-			'This characterization holds in every finitary algebraic category: the inverse of a bijective morphism is again a morphism.'
-	},
-	{
-		property: 'finitary algebraic',
-		type: 'monomorphisms',
-		description: 'injective morphisms',
-		proof: 'This holds in every finitary algebraic category: the forgetful functor to sets is faithful, hence reflects monomorphisms, and it is continuous (even representable), hence preserves monomorphisms.'
-	},
-	{
-		property: 'finitary algebraic',
-		type: 'regular epimorphisms',
-		description: 'surjective morphisms',
-		proof: 'This holds in every finitary algebraic category: the construction of coequalizers shows that every regular epimorphism is surjective. Conversely, the fundamental theorem on homomorphisms states that every surjective homomorphism $A \\to B$ is the coequalizer of the two projections $A \\times_B A \\rightrightarrows A$.'
-	},
-	{
-		property: 'thin',
-		type: 'monomorphisms',
-		description: 'every morphism',
-		proof: 'It is a thin category.'
-	},
-	{
-		property: 'thin',
-		type: 'epimorphisms',
-		description: 'every morphism',
-		proof: 'It is a thin category.'
-	},
-	{
-		property: 'left cancellative',
-		type: 'monomorphisms',
-		description: 'every morphism',
-		proof: 'The category is left cancellative.'
-	},
-	{
-		property: 'right cancellative',
-		type: 'epimorphisms',
-		description: 'every morphism',
-		proof: 'The category is right cancellative.'
-	},
-	{
-		property: 'left cancellative',
-		type: 'regular epimorphisms',
-		description: 'same as isomorphisms',
-		proof: 'The category is left cancellative, and a regular epimorphism which is a monomorphism must be an isomorphism.'
-	},
-	{
-		property: 'right cancellative',
-		type: 'regular monomorphisms',
-		description: 'same as isomorphisms',
-		proof: 'The category is right cancellative, and a regular monomorphism which is an epimorphism must be an isomorphism.'
-	},
-	{
-		property: 'mono-regular',
-		type: 'regular monomorphisms',
-		description: 'same as monomorphisms',
-		proof: 'The category is mono-regular.'
-	},
-	{
-		property: 'epi-regular',
-		type: 'regular epimorphisms',
-		description: 'same as epimorphisms',
-		proof: 'The category is epi-regular.'
-	}
-]
-
-/**
- * Deduces special morphisms as specified by a rule.
- * We ignore duplicate assignments here because of overlaps
+ * Deduces special morphisms from the rules from the special_morphism_rules
+ * table. We ignore duplicate assignments here because of overlaps
  * with previous deductions.
  */
-function deduce_special_morphisms_by_rule(rule: Rule) {
-	const { property, type, description, proof } = rule
-
-	const res = db
-		.prepare(
-			`INSERT INTO special_morphisms (
-                category_id,
-                type,
-                description,
-                proof,
-                is_deduced
-            )
-            SELECT
-                structure_id,
-                ?,
-                ?,
-                ?,
-                TRUE
-            FROM property_assignments
-            WHERE type = 'category'
-            AND property_id = ?
-            AND is_satisfied = TRUE
-            ON CONFLICT (category_id, type) DO NOTHING`
-		)
-		.run(type, description, proof, property)
-
-	devlog(`Deduced ${res.changes} descriptions of ${type} in ${property} categories`)
-}
-
-/**
- * Deduces special morphisms for all rules.
- */
 function deduce_special_morphisms_by_rules() {
-	for (const rule of RULES) {
-		deduce_special_morphisms_by_rule(rule)
+	type Rule = {
+		property_id: string
+		type: string
+		description: string
+		proof: string
+	}
+
+	const rules = db
+		.prepare<[], Rule>(
+			`SELECT property_id, type, description, proof
+			FROM special_morphism_rules
+			ORDER BY id`
+		)
+		.all()
+
+	for (const { property_id, type, description, proof } of rules) {
+		const res = db
+			.prepare(
+				`INSERT INTO special_morphisms (
+                    category_id,
+                    type,
+                    description,
+                    proof,
+                    is_deduced
+                )
+                SELECT
+                    pa.structure_id,
+                    ?,
+                    ?,
+                    ?,
+                    TRUE
+                FROM property_assignments pa
+                WHERE pa.type = 'category'
+                    AND pa.property_id = ?
+                    AND pa.is_satisfied = TRUE
+                ON CONFLICT (category_id, type) DO NOTHING`
+			)
+			.run(type, description, proof, property_id)
+
+		devlog(
+			`Deduced ${res.changes} descriptions of ${type} in ${property_id} categories`
+		)
 	}
 }
 

--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -7,6 +7,7 @@ import type {
 	ImplicationYaml,
 	FunctorYaml,
 	PropertyEntry,
+	SpecialMorphismRuleYaml,
 	StructureYaml,
 	PropertyYaml,
 	MorphismYaml
@@ -32,6 +33,7 @@ function seed() {
 	seed_config()
 
 	seed_properties({ type: 'category', folder: 'category-properties' })
+	seed_special_morphism_rules()
 	seed_implications({ type: 'category', folder: 'category-implications' })
 	seed_structures({ type: 'category', folder: 'categories', extra: insert_category })
 
@@ -68,6 +70,7 @@ function clear_all_tables() {
 	const tx = db.transaction(() => {
 		db.pragma('defer_foreign_keys = ON')
 
+		db.prepare(`DELETE FROM special_morphism_rules`).run()
 		db.prepare(`DELETE FROM special_morphisms`).run()
 		db.prepare(`DELETE FROM special_morphism_types`).run()
 		db.prepare(`DELETE FROM special_objects`).run()
@@ -154,6 +157,30 @@ function seed_config() {
 	}
 
 	seed_file(db, 'config', path.join(data_folder, 'config.yaml'), insert_config)
+}
+
+/**
+ * Seeds special morphism deduction rules from a YAML file.
+ */
+function seed_special_morphism_rules() {
+	const rule_insert = db.prepare(
+		`INSERT INTO special_morphism_rules
+			(property_id, type, description, proof)
+		VALUES (?, ?, ?, ?)`
+	)
+
+	function insert_rules(rules: SpecialMorphismRuleYaml[]) {
+		for (const { property, type, description, proof } of rules) {
+			rule_insert.run(property, type, description, proof)
+		}
+	}
+
+	seed_file(
+		db,
+		'special morphism rules',
+		path.join(data_folder, 'special-morphism-rules.yaml'),
+		insert_rules
+	)
 }
 
 /**

--- a/database/scripts/utils/seed.types.ts
+++ b/database/scripts/utils/seed.types.ts
@@ -21,6 +21,13 @@ export type ConfigYaml = {
 	}[]
 }
 
+export type SpecialMorphismRuleYaml = {
+	property: string
+	type: string
+	description: string
+	proof: string
+}
+
 export type PropertyEntry = {
 	property: string
 	proof: string

--- a/tests/categories.spec.ts
+++ b/tests/categories.spec.ts
@@ -113,7 +113,7 @@ test('user can view category details', async ({ page }) => {
 	await expect(page.getByText('terminal object: zero ring')).toBeVisible()
 	await expect(page.getByText('coproducts: tensor products')).toBeVisible()
 	await expect(
-		page.getByText('regular epimorphisms: surjective homomorphisms')
+		page.getByText('regular epimorphisms: surjective morphisms')
 	).toBeVisible()
 })
 


### PR DESCRIPTION
Many assignments of special morphisms are quite repetitive and can be automated. This PR adds functions to the deduction script that perform this automation.

## Rules

- in a groupoid, every morphism is an isomorphism
- in a thin category, every morphism is a monomorphism
- in a thin category, every morphism is an epimorphism
- in a left cancellative category, every morphism is a monomorphism
- in a right cancellative category, every morphism is an epimorphism
- in a left cancellative category, every regular epimorphism is an isomorphism
- in a right cancellative category, every regular monomorphism is an isomorphism
- in a finitary algebraic category, the isomorphisms are the bijective morphisms
- in a finitary algebraic category, the monomorphisms are the injective morphisms
- in a finitary algebraic category, the regular epimorphisms are the surjective morphisms
- in a mono-regular category, every monomorphism is a regular monomorphism
- in an epi-regular category, every epimorphism is a regular epimorphism

Existing assignments are ignored and not overwritten. For example, the rules for left cancellative categories ignore the rules that were already applied for thin categories.

## Statistics

In the main branch, there are currently **406** assignments of special morphisms, of which only **10** are deduced.

After this PR, we have **408** assignments, of which **204** are deduced. That is exactly half of them!

About the difference of two assignments: When I found out that **Rel** is mono-regular (and hence epi-regular), I forgot to add the obvious resulting classification of regular monomorphisms (and regular epimorphisms). This PR inserts it automatically. Thus, in future, it cannot be forgotten anymore.

## Logs

```
--- Deduce special morphisms ---
Deduced 6 descriptions of isomorphisms in groupoid categories
Deduced 11 descriptions of monomorphisms in thin categories
Deduced 11 descriptions of epimorphisms in thin categories
Deduced 10 descriptions of monomorphisms in left cancellative categories
Deduced 7 descriptions of epimorphisms in right cancellative categories
Deduced 21 descriptions of regular epimorphisms in left cancellative categories
Deduced 18 descriptions of regular monomorphisms in right cancellative categories
Deduced 16 descriptions of isomorphisms in finitary algebraic categories
Deduced 16 descriptions of monomorphisms in finitary algebraic categories
Deduced 17 descriptions of regular epimorphisms in finitary algebraic categories
Deduced 36 descriptions of regular monomorphisms in mono-regular categories
Deduced 27 descriptions of regular epimorphisms in epi-regular categories
Deduced 8 special morphisms by duality
```

## Other

This PR also adds back the proof for the epis in **CompHaus** which has been accidentally removed in #273. See my comment [here](https://github.com/ScriptRaccoon/CatDat/pull/273#issuecomment-4954855910).