### PR TITLE
Human-readable display of implications

### DIFF
--- a/database/schema/003_implications.sql
+++ b/database/schema/003_implications.sql
@@ -4,10 +4,7 @@ CREATE TABLE implications (
     proof TEXT NOT NULL CHECK (length(proof) > 0),
     is_equivalence INTEGER NOT NULL DEFAULT FALSE,
     is_deduced INTEGER NOT NULL DEFAULT FALSE,
-    dualized_from TEXT,
     UNIQUE (id, type),
-    CHECK (dualized_from IS NULL OR is_deduced = TRUE),
-    FOREIGN KEY (dualized_from, type) REFERENCES implications (id, type) ON DELETE RESTRICT,
     FOREIGN KEY (type) REFERENCES structure_types (type) ON DELETE RESTRICT
 );
 
@@ -65,7 +62,6 @@ CREATE VIEW implications_view AS
         i.type,
         i.is_equivalence,
         i.is_deduced,
-        i.dualized_from,
         i.proof,
         (
             SELECT json_group_array(a.property_id)

--- a/database/scripts/deduce-implications.ts
+++ b/database/scripts/deduce-implications.ts
@@ -82,8 +82,8 @@ export function create_dualized_implications(type: StructureType) {
 
 	const implication_insert = db.prepare(`
 		INSERT INTO implications
-			(id, type, is_equivalence, proof, is_deduced, dualized_from)
-		VALUES (?, ?, ?, ?, TRUE, ?)	
+			(id, type, is_equivalence, proof, is_deduced)
+		VALUES (?, ?, ?, ?, TRUE)	
 	`)
 
 	const assumption_insert = db.prepare(`
@@ -136,8 +136,7 @@ export function create_dualized_implications(type: StructureType) {
 				dual_id,
 				type,
 				impl.is_equivalence,
-				'This follows from the dual implication.',
-				impl.id
+				`This follows from the <a href="/${type}-implication/${impl.id}">dual implication</a>.`
 			)
 
 			for (const a of dual_assumptions) {

--- a/src/lib/commons/types.ts
+++ b/src/lib/commons/types.ts
@@ -82,7 +82,6 @@ export type ImplicationDB = {
 	id: string
 	is_equivalence: 0 | 1
 	is_deduced: 0 | 1
-	dualized_from: string | null
 	proof: string
 	assumptions: string
 	conclusions: string

--- a/src/lib/server/fetchers/implication.ts
+++ b/src/lib/server/fetchers/implication.ts
@@ -15,7 +15,6 @@ export function fetch_implication(type: StructureType, id: string) {
                 id,
                 is_equivalence,
                 is_deduced,
-                dualized_from,
                 proof,
                 assumptions,
                 conclusions,
@@ -24,6 +23,12 @@ export function fetch_implication(type: StructureType, id: string) {
             WHERE id = ?`
 		)
 		.get(id)
+
+	if (!implication_db) {
+		error(404, `Could not find implication with ID '${id}'`)
+	}
+
+	const implication = display_implication(implication_db)
 
 	const structures = db
 		.prepare<[StructureType, string], StructureShort>(
@@ -42,12 +47,6 @@ export function fetch_implication(type: StructureType, id: string) {
             WHERE type = ?`
 		)
 		.all(type)
-
-	if (!implication_db) {
-		error(404, `Could not find implication with ID '${id}'`)
-	}
-
-	const implication = display_implication(implication_db)
 
 	const mapped_types: MappedTypes = {}
 

--- a/src/lib/server/fetchers/implication.ts
+++ b/src/lib/server/fetchers/implication.ts
@@ -7,8 +7,11 @@ import type {
 	StructureType
 } from '$lib/commons/types'
 import { display_implication } from '$lib/server/transforms'
+import { fetch_property_relation_dict } from './properties'
 
 export function fetch_implication(type: StructureType, id: string) {
+	const property_relation_dict = fetch_property_relation_dict()
+
 	const implication_db = db
 		.prepare<[string], ImplicationDB>(
 			`SELECT
@@ -54,5 +57,5 @@ export function fetch_implication(type: StructureType, id: string) {
 		mapped_types[map] = mapped_type
 	}
 
-	return { type, implication, structures, mapped_types }
+	return { type, implication, property_relation_dict, structures, mapped_types }
 }

--- a/src/lib/server/fetchers/implications.ts
+++ b/src/lib/server/fetchers/implications.ts
@@ -9,7 +9,6 @@ export function fetch_implications(type: StructureType) {
 				id,
 				is_equivalence,
 				is_deduced,
-				dualized_from,
 				proof,
 				assumptions,
 				conclusions,

--- a/src/lib/server/fetchers/properties.ts
+++ b/src/lib/server/fetchers/properties.ts
@@ -16,6 +16,24 @@ export function get_property_ids(type: StructureType) {
 		.all(type)
 }
 
+export function fetch_property_relation_dict() {
+	const rows = db
+		.prepare<
+			never[],
+			{ id: string; type: string; relation: string }
+		>(`SELECT id, type, relation FROM properties`)
+		.all()
+
+	const dict: Record<string, Record<string, string>> = {}
+
+	for (const { id, type, relation } of rows) {
+		dict[type] ??= {}
+		dict[type][id] = relation
+	}
+
+	return dict
+}
+
 export function fetch_grouped_properties_and_tags(type: StructureType) {
 	const properties = db
 		.prepare<[StructureType], GroupedPropertyShort>(

--- a/src/lib/server/fetchers/property.ts
+++ b/src/lib/server/fetchers/property.ts
@@ -57,7 +57,6 @@ export function fetch_property(type: StructureType, id: string) {
                 id,
                 is_equivalence,
                 is_deduced,
-                dualized_from,
                 proof,
                 assumptions,
                 conclusions,

--- a/src/lib/server/transforms.ts
+++ b/src/lib/server/transforms.ts
@@ -35,7 +35,6 @@ export function display_implication(implication: ImplicationDB): ImplicationDisp
 		id: implication.id,
 		is_equivalence: Boolean(implication.is_equivalence),
 		is_deduced: Boolean(implication.is_deduced),
-		dualized_from: implication.dualized_from,
 		proof: implication.proof,
 		assumptions: JSON.parse(implication.assumptions),
 		conclusions: JSON.parse(implication.conclusions),

--- a/src/pages/ImplicationPage.svelte
+++ b/src/pages/ImplicationPage.svelte
@@ -4,8 +4,6 @@
 	import SuggestionForm from '$components/SuggestionForm.svelte'
 	import { pluralize } from '$shared/utils'
 	import { get_property_url } from '$shared/property.utils'
-	import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
-	import Fa from 'svelte-fa'
 	import type {
 		ImplicationDisplay,
 		MappedTypes,
@@ -19,9 +17,15 @@
 		implication: ImplicationDisplay
 		structures: StructureShort[]
 		mapped_types: MappedTypes
+		property_relation_dict: Record<string, Record<string, string>>
 	}
 
-	let { type, implication, structures, mapped_types }: Props = $props()
+	let { type, implication, structures, mapped_types, property_relation_dict }: Props =
+		$props()
+
+	let has_additional_assumptions = $derived(
+		Object.values(implication.mapped_assumptions).some((list) => list?.size)
+	)
 </script>
 
 <MetaData title="Implication Details" />
@@ -29,62 +33,59 @@
 <h2>Implication Details</h2>
 
 <p>
-	<strong>Assumptions:</strong>
-
+	<strong>Claim:</strong>
+	{#if has_additional_assumptions}
+		Given a {type}
+		{#each Object.entries(implication.mapped_assumptions) as [map, set], ind}
+			{#if set}
+				whose
+				{map}
+				{#each set as property, index}
+					{property_relation_dict[mapped_types[map]][property]}
+					<a href={get_property_url(property, mapped_types[map])}>{property}</a
+					>{#if index < set.size - 1}
+						&nbsp;and&nbsp;
+					{/if}
+				{/each}{#if ind < Object.entries(implication.mapped_assumptions).length - 1}
+					, and&nbsp;
+				{/if}
+			{/if}
+		{/each},
+		{#if implication.is_equivalence}
+			it
+		{:else}
+			if it
+		{/if}
+	{:else if implication.is_equivalence}
+		A {type}
+	{:else}
+		If a {type}
+	{/if}
 	{#each implication.assumptions as property, index}
+		{property_relation_dict[type][property]}
 		<a href={get_property_url(property, type)}>{property}</a
 		>{#if index < implication.assumptions.length - 1}
-			,&nbsp;
+			&nbsp;and&nbsp;
 		{/if}
-	{/each}
-</p>
-
-{#each Object.entries(implication.mapped_assumptions) as [map, set]}
-	{#if set?.size}
-		<p>
-			<strong>Requirements of the {map}:</strong>
-
-			{#each set as property, index}
-				<a href={get_property_url(property, mapped_types[map])}>{property}</a
-				>{#if index < set.size - 1}
-					,&nbsp;
-				{/if}
-			{/each}
-		</p>
+	{/each}{#if implication.is_equivalence}
+		&nbsp;if and only if it
+	{:else}
+		, then it
 	{/if}
-{/each}
-
-<p>
-	<strong>Conclusions:</strong>
 	{#each implication.conclusions as property, index}
+		{property_relation_dict[type][property]}
 		<a href={get_property_url(property, type)}>{property}</a
 		>{#if index < implication.conclusions.length - 1}
-			,&nbsp;
+			&nbsp;and&nbsp;
+		{:else}.
 		{/if}
 	{/each}
 </p>
 
-{#if implication.is_equivalence}
-	<p>
-		<Fa icon={faInfoCircle} />
-		This is an equivalence.
-	</p>
-{/if}
-
-{#if implication.dualized_from}
-	<p>
-		This implication has been dualized from <a
-			href="/{type}-implication/{implication.dualized_from}"
-		>
-			this implication
-		</a>.
-	</p>
-{:else}
-	<p>
-		<strong>Proof:</strong>
-		{@html implication.proof}
-	</p>
-{/if}
+<p>
+	<strong>Proof:</strong>
+	{@html implication.proof}
+</p>
 
 {#if structures.length > 0}
 	<details>


### PR DESCRIPTION
On the implication detail page, implications (or claims) are now displayed in a human-readable form. Previously, they were shown in a very "database-like" format. As in other parts of the application, relations are rendered properly as well (e.g. "**has** products" and "**is** regular").

## Example

### Before

<img width="550" src="https://github.com/user-attachments/assets/adccd2b4-2128-460a-a358-be27415c3174" /><br />

### After

<img width="550" src="https://github.com/user-attachments/assets/c0544ba3-304f-4f77-a8ac-54c5cf806a35" /><br />

## Equivalences

The wording of equivalences has also been improved.

### Before

<img width="550" src="https://github.com/user-attachments/assets/0c779953-64f2-44d9-9ee4-516492bd79dc" /><br />

### After

<img width="550" src="https://github.com/user-attachments/assets/dbe89cea-baf8-4b24-bce6-6fb9f175e47d" /><br />

## Mapped assumptions

For functors and morphisms, where implications may have mapped assumptions, the display has also been improved.

### Before

<img width="550" src="https://github.com/user-attachments/assets/e6003018-43a9-48bf-8448-14f10c3581e1" /><br />

### After

<img width="550" src="https://github.com/user-attachments/assets/5db6a9c8-6850-4bbe-b8fd-284c9327728a" /><br />

## Special Adjoint Functor Theorem

The Special Adjoint Functor Theorem now reads as follows:

> Given a functor whose source has a cogenerating set and is complete and is locally essentially small and is well-powered, and whose target is locally essentially small, if it is continuous, then it is a right adjoint.

## Further ideas

The claims are generated automatically from the database entries, so it is somewhat challenging to formulate them exactly as mathematicians would. For example, instead of saying

> If a functor is conservative and is full, then it is full on isomorphisms.

(which is the current formulation), we would normally say

> If a functor is conservative and full, then it is full on isomorphisms.

In some cases, the relation can be omitted, but not always. This could be improved in a future PR, although I think it is a low priority.