### PR TITLE
Rename "source" to "domain", and "target" to "codomain"

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -30,7 +30,7 @@ To mark properties as assumptions or conclusions of an implication, there are tw
 
 These tables are abstracted through the `implications_view` view.
 
-Functor implications may also depend on properties of the source or target category. Such dependencies are stored in the table:
+Functor implications may also depend on properties of the domain or codomain category. Such dependencies are stored in the table:
 
 - `mapped_assumptions`
 

--- a/content/foundations.md
+++ b/content/foundations.md
@@ -41,8 +41,8 @@ A collection is called _countable_ if it admits a surjective map from $\IN$. In 
 A _category_ $\C$ consists of a pair of collections $O, M$, whose elements are called _objects_ and _morphisms_, respectively, together with maps
 
 - $i : O \to M$ (_identity_),
-- $s : M \to O$ (_source_),
-- $t : M \to O$ (_target_),
+- $s : M \to O$ (_source_ or _domain_),
+- $t : M \to O$ (_target_ or _codomain_),
 - $c : M \times_O M \to M$ (_composition_),
 
 such that the usual [axioms of a category](<https://en.wikipedia.org/wiki/Category_(mathematics)>) are satisfied. The domain of $c$ consists of all pairs of morphisms $(f,g)$ with $s(f) = t(g)$, and we write $f \circ g \coloneqq c(f,g)$ for their composition. Instead of $i(X)$ one usually writes $\id_X$ for the identity morphism of $X$. Formally, a category is a tuple

--- a/database/data/categories/Cat.yaml
+++ b/database/data/categories/Cat.yaml
@@ -79,7 +79,7 @@ unsatisfied_properties:
       0 \mapsto (0,0),~ 1 \mapsto (0,1),~ 2 \mapsto (1,1); \\
       0 \mapsto (0,0),~ 1 \mapsto (1,0),~ 2 \mapsto (1,1).
       \end{align*}$$
-      This equalizer contains the unique morphism $0 \to 2$. On the other hand, if for the target we instead use the free category on the square diagram, in this case the equalizer does not contain the unique morphism $0 \to 2$. However, in both cases, the pullbacks of these equalizers to $\{ 0 \to 1 \}$ and to $\{ 1 \to 2 \}$ will be the same. Namely, the pullback of each to $\{ 0 \to 1 \}$ will be the subcategory with just the object $0$ and its identity morphism; and the pullback of each to $\{ 1 \to 2 \}$ will be the subcategory with just the object $2$ and its identity morphism.
+      This equalizer contains the unique morphism $0 \to 2$. On the other hand, if for the codomain we instead use the free category on the square diagram, in this case the equalizer does not contain the unique morphism $0 \to 2$. However, in both cases, the pullbacks of these equalizers to $\{ 0 \to 1 \}$ and to $\{ 1 \to 2 \}$ will be the same. Namely, the pullback of each to $\{ 0 \to 1 \}$ will be the subcategory with just the object $0$ and its identity morphism; and the pullback of each to $\{ 1 \to 2 \}$ will be the subcategory with just the object $2$ and its identity morphism.
 
       This shows that the comparison function
       $$\Sub_{\reg}(\{ 0 \to 1 \to 2 \}) \to \Sub_{\reg}(\{ 0 \to 1 \}) \times_{\Sub_{\reg}(\{1\})} \Sub_{\reg}(\{ 1 \to 2 \})$$

--- a/database/data/categories/Z.yaml
+++ b/database/data/categories/Z.yaml
@@ -83,7 +83,7 @@ special_morphisms:
     proof: This is true for all functor categories.
   monomorphisms:
     description: pointwise injective natural transformations
-    proof: 'If $a : F \to G$ is a monomorphism of Z-functors, then the diagonal morphism $F \to F \times_G F$ is an isomorphism, so that for every $R$ the diagonal morphism $F(R) \to F(R) \times_{G(R)} F(R)$ is an isomorphism, i.e., $a(R) : F(R) \to G(R)$ is a monomorphism. This argument works for every functor category where the target has fiber products.'
+    proof: 'If $a : F \to G$ is a monomorphism of Z-functors, then the diagonal morphism $F \to F \times_G F$ is an isomorphism, so that for every $R$ the diagonal morphism $F(R) \to F(R) \times_{G(R)} F(R)$ is an isomorphism, i.e., $a(R) : F(R) \to G(R)$ is a monomorphism. This argument works for every functor category where the codomain has fiber products.'
   epimorphisms:
     description: objectwise surjective natural transformations
     proof: This holds in every functor category $[\C,\Set]$, here applied to the case that $\C$ has just one object.

--- a/database/data/category-implications/cancellative.yaml
+++ b/database/data/category-implications/cancellative.yaml
@@ -34,5 +34,5 @@
     - effective cocongruences
     - effective congruences
     - reflexive coequalizers
-  proof: Any parallel pair of morphisms with a common section (or retraction) must be a pair of equal isomorphisms. In particular, they are the kernel pair of the identity morphism on the target, and the cokernel pair of the identity morphism on the source.
+  proof: 'Any parallel pair of morphisms $f,g : A \rightrightarrows B$ with a common section (or retraction) must be a pair of equal isomorphisms. In particular, they are the kernel pair of $\id_B$, and the cokernel pair of $\id_A$.'
   is_equivalence: false

--- a/database/data/functor-implications/adjoints.yaml
+++ b/database/data/functor-implications/adjoints.yaml
@@ -10,12 +10,12 @@
   assumptions:
     - continuous
   mapped_assumptions:
-    source:
+    domain:
       - cogenerating set
       - complete
       - locally essentially small
       - well-powered
-    target:
+    codomain:
       - locally essentially small
   conclusions:
     - right adjoint

--- a/database/data/functor-implications/limits preservation.yaml
+++ b/database/data/functor-implications/limits preservation.yaml
@@ -34,8 +34,8 @@
       - finite products
   conclusions:
     - preserves finite products
-  proof: This is because finite products can be constructed recursively via $X_1 \times \cdots \times X_{n+1} = (X_1 \times \cdots \times X_n) \times X_{n+1}$. We need the assumption on the source category since otherwise $X_1 \times \cdots \times X_n$ might not exist.
-  is_equivalence: true
+  proof: This is because finite products can be constructed recursively via $X_1 \times \cdots \times X_{n+1} = (X_1 \times \cdots \times X_n) \times X_{n+1}$. We need the assumption on the source category since otherwise $X_1 \times \cdots \times X_n$ might not exist. See <a href="https://math.stackexchange.com/questions/5142961" target="_blank">MSE/5142961</a>.
+  is_equivalence: false
 
 - id: continuous_criterion
   assumptions:

--- a/database/data/functor-implications/limits preservation.yaml
+++ b/database/data/functor-implications/limits preservation.yaml
@@ -30,11 +30,11 @@
     - preserves terminal objects
     - preserves binary products
   mapped_assumptions:
-    source:
+    domain:
       - finite products
   conclusions:
     - preserves finite products
-  proof: This is because finite products can be constructed recursively via $X_1 \times \cdots \times X_{n+1} = (X_1 \times \cdots \times X_n) \times X_{n+1}$. We need the assumption on the source category since otherwise $X_1 \times \cdots \times X_n$ might not exist. See <a href="https://math.stackexchange.com/questions/5142961" target="_blank">MSE/5142961</a>.
+  proof: This is because finite products can be constructed recursively via $X_1 \times \cdots \times X_{n+1} = (X_1 \times \cdots \times X_n) \times X_{n+1}$. We need the assumption on the domain since otherwise $X_1 \times \cdots \times X_n$ might not exist. See <a href="https://math.stackexchange.com/questions/5142961" target="_blank">MSE/5142961</a>.
   is_equivalence: false
 
 - id: continuous_criterion
@@ -42,7 +42,7 @@
     - preserves equalizers
     - preserves products
   mapped_assumptions:
-    source:
+    domain:
       - products
   conclusions:
     - continuous
@@ -54,7 +54,7 @@
     - cofinitary
     - left exact
   mapped_assumptions:
-    source:
+    domain:
       - finitely complete
   conclusions:
     - continuous
@@ -66,7 +66,7 @@
     - cofinitary
     - preserves finite products
   mapped_assumptions:
-    source:
+    domain:
       - finite products
   conclusions:
     - preserves products
@@ -100,7 +100,7 @@
     - preserves equalizers
     - preserves finite products
   mapped_assumptions:
-    source:
+    domain:
       - finite products
   conclusions:
     - left exact
@@ -129,7 +129,7 @@
     - preserves coreflexive equalizers
     - preserves binary products
   mapped_assumptions:
-    source:
+    domain:
       - binary products
   conclusions:
     - preserves equalizers
@@ -140,7 +140,7 @@
   assumptions:
     - preserves regular monomorphisms
   mapped_assumptions:
-    source:
+    domain:
       - mono-regular
   conclusions:
     - preserves monomorphisms
@@ -151,7 +151,7 @@
   assumptions:
     - preserves monomorphisms
   mapped_assumptions:
-    target:
+    codomain:
       - mono-regular
   conclusions:
     - preserves regular monomorphisms
@@ -162,7 +162,7 @@
   assumptions:
     - preserves coreflexive equalizers
   mapped_assumptions:
-    source:
+    domain:
       - pushouts
   conclusions:
     - preserves regular monomorphisms
@@ -173,9 +173,9 @@
   assumptions:
     - preserves terminal objects
   mapped_assumptions:
-    source:
+    domain:
       - pointed
-    target:
+    codomain:
       - pointed
   conclusions:
     - preserves initial objects
@@ -186,9 +186,9 @@
   assumptions:
     - preserves finite products
   mapped_assumptions:
-    source:
+    domain:
       - biproducts
-    target:
+    codomain:
       - biproducts
   conclusions:
     - preserves finite coproducts

--- a/database/data/functor-implications/misc.yaml
+++ b/database/data/functor-implications/misc.yaml
@@ -12,11 +12,11 @@
     - conservative
     - preserves equalizers
   mapped_assumptions:
-    source:
+    domain:
       - equalizers
   conclusions:
     - faithful
-  proof: 'Let $f,g : X \rightrightarrows Y$ be two morphisms in the source category, and choose an equalizer $E \hookrightarrow X$. By assumption, $F(E) \to F(X)$ is the equalizer of $F(f),F(g) : F(X) \rightrightarrows F(Y)$. Thus, if $F(f) = F(g)$, then $F(E) \to F(X)$ is an isomorphism. Since $F$ is conservative, $E \to X$ is an isomorphism, which means $f = g$.'
+  proof: 'Let $f,g : X \rightrightarrows Y$ be two morphisms in the domain, and choose an equalizer $E \hookrightarrow X$. By assumption, $F(E) \to F(X)$ is the equalizer of $F(f),F(g) : F(X) \rightrightarrows F(Y)$. Thus, if $F(f) = F(g)$, then $F(E) \to F(X)$ is an isomorphism. Since $F$ is conservative, $E \to X$ is an isomorphism, which means $f = g$.'
   is_equivalence: false
 
 - id: conservative_criterion

--- a/database/data/functor-implications/monadic.yaml
+++ b/database/data/functor-implications/monadic.yaml
@@ -14,7 +14,7 @@
     - conservative
     - preserves reflexive coequalizers
   mapped_assumptions:
-    source:
+    domain:
       - reflexive coequalizers
   conclusions:
     - monadic

--- a/database/data/functor-properties/preserves coproducts.yaml
+++ b/database/data/functor-properties/preserves coproducts.yaml
@@ -1,6 +1,6 @@
 id: preserves coproducts
 relation: preserves
-description: A functor $F$ <i>preserves coproducts</i> when for every family of objects $(A_i)$ in the source whose coproduct $\prod_i A_i$ exists, also the coproduct $\coprod_i F(A_i)$ exists in the target and such that the canonical morphism $\coprod_i F(A_i) \to F(\coprod_i A_i)$ is an isomorphism.
+description: A functor $F$ <i>preserves coproducts</i> when for every family of objects $(A_i)$ in the domain whose coproduct $\prod_i A_i$ exists, also the coproduct $\coprod_i F(A_i)$ exists in the codomain and such that the canonical morphism $\coprod_i F(A_i) \to F(\coprod_i A_i)$ is an isomorphism.
 nlab_link: https://ncatlab.org/nlab/show/preserved+colimit
 invariant_under_equivalences: true
 dual: preserves products

--- a/database/data/functor-properties/preserves finite coproducts.yaml
+++ b/database/data/functor-properties/preserves finite coproducts.yaml
@@ -1,6 +1,6 @@
 id: preserves finite coproducts
 relation: preserves
-description: A functor $F$ <i>preserves finite coproducts</i> when for every family of objects $(A_i)$ in the source whose coproduct $\prod_i A_i$ exists, also the coproduct $\coprod_i F(A_i)$ exists in the target and such that the canonical morphism $\coprod_i F(A_i) \to F(\coprod_i A_i)$ is an isomorphism.
+description: A functor $F$ <i>preserves finite coproducts</i> when for every family of objects $(A_i)$ in the domain whose coproduct $\prod_i A_i$ exists, also the coproduct $\coprod_i F(A_i)$ exists in the codomain and such that the canonical morphism $\coprod_i F(A_i) \to F(\coprod_i A_i)$ is an isomorphism.
 nlab_link: https://ncatlab.org/nlab/show/preserved+colimit
 invariant_under_equivalences: true
 dual: preserves finite products

--- a/database/data/functor-properties/preserves finite products.yaml
+++ b/database/data/functor-properties/preserves finite products.yaml
@@ -1,6 +1,6 @@
 id: preserves finite products
 relation: preserves
-description: A functor $F$ <i>preserves finite products</i> when for every finite family of objects $(A_i)$ in the source whose product $\prod_i A_i$ exists, also the product $\prod_i F(A_i)$ exists in the target and such that the canonical morphism $F(\prod_i A_i) \to \prod_i F(A_i)$ is an isomorphism.
+description: A functor $F$ <i>preserves finite products</i> when for every finite family of objects $(A_i)$ in the domain whose product $\prod_i A_i$ exists, also the product $\prod_i F(A_i)$ exists in the codomain and such that the canonical morphism $F(\prod_i A_i) \to \prod_i F(A_i)$ is an isomorphism.
 nlab_link: https://ncatlab.org/nlab/show/preserved+limit
 invariant_under_equivalences: true
 dual: preserves finite coproducts

--- a/database/data/functor-properties/preserves initial objects.yaml
+++ b/database/data/functor-properties/preserves initial objects.yaml
@@ -1,6 +1,6 @@
 id: preserves initial objects
 relation: preserves
-description: A functor $F$ <i>preserves initial objects</i> when it maps every initial object to an initial object. It is not assumed that the source category has a initial object.
+description: A functor $F$ <i>preserves initial objects</i> when it maps every initial object to an initial object. It is not assumed that the domain has an initial object.
 nlab_link: https://ncatlab.org/nlab/show/preserved+colimit
 invariant_under_equivalences: true
 dual: preserves terminal objects

--- a/database/data/functor-properties/preserves products.yaml
+++ b/database/data/functor-properties/preserves products.yaml
@@ -1,6 +1,6 @@
 id: preserves products
 relation: preserves
-description: A functor $F$ <i>preserves products</i> when for every family of objects $(A_i)$ in the source whose product $\prod_i A_i$ exists, also the product $\prod_i F(A_i)$ exists in the target and such that the canonical morphism $F(\prod_i A_i) \to \prod_i F(A_i)$ is an isomorphism.
+description: A functor $F$ <i>preserves products</i> when for every family of objects $(A_i)$ in the domain whose product $\prod_i A_i$ exists, also the product $\prod_i F(A_i)$ exists in the codomain and such that the canonical morphism $F(\prod_i A_i) \to \prod_i F(A_i)$ is an isomorphism.
 nlab_link: https://ncatlab.org/nlab/show/preserved+limit
 invariant_under_equivalences: true
 dual: preserves coproducts

--- a/database/data/functor-properties/preserves terminal objects.yaml
+++ b/database/data/functor-properties/preserves terminal objects.yaml
@@ -1,6 +1,6 @@
 id: preserves terminal objects
 relation: preserves
-description: A functor $F$ <i>preserves terminal objects</i> when it maps every terminal object to a terminal object. It is not assumed that the source category has a terminal object.
+description: A functor $F$ <i>preserves terminal objects</i> when it maps every terminal object to a terminal object. It is not assumed that the domain has a terminal object.
 nlab_link: https://ncatlab.org/nlab/show/preserved+limit
 invariant_under_equivalences: true
 dual: preserves initial objects

--- a/database/data/functors/abelianization.yaml
+++ b/database/data/functors/abelianization.yaml
@@ -1,8 +1,8 @@
 id: abelianization
 name: abelianization functor for groups
 notation: $(-)^{\ab}$
-source: Grp
-target: Ab
+domain: Grp
+codomain: Ab
 description: This functor maps a group $G$ to its abelianization $G^{\ab} \coloneqq G/[G,G]$.
 nlab_link: https://ncatlab.org/nlab/show/abelianization
 left_adjoint: null

--- a/database/data/functors/binary_coproduct_sets.yaml
+++ b/database/data/functors/binary_coproduct_sets.yaml
@@ -1,8 +1,8 @@
 id: binary_coproduct_sets
 name: binary coproduct functor on sets
 notation: $+$
-source: SetxSet
-target: Set
+domain: SetxSet
+codomain: Set
 description: This functor maps a pair of sets $(X,Y)$ to their coproduct $X + Y$. It is an example of a right-invertible left adjoint functor which is not a reflector.
 nlab_link: null
 left_adjoint: null

--- a/database/data/functors/binary_product_sets.yaml
+++ b/database/data/functors/binary_product_sets.yaml
@@ -1,8 +1,8 @@
 id: binary_product_sets
 name: binary product functor on sets
 notation: $\times$
-source: SetxSet
-target: Set
+domain: SetxSet
+codomain: Set
 description: This functor maps a pair of sets $(X,Y)$ to their product $X \times Y$. It is an example of a right-invertible right adjoint functor which is not a coreflector.
 nlab_link: null
 left_adjoint: diagonal_sets

--- a/database/data/functors/continuous-functions.yaml
+++ b/database/data/functors/continuous-functions.yaml
@@ -1,8 +1,8 @@
 id: continuous_functions
 name: functor of continuous functions
 notation: $C$
-source: Top_op
-target: CAlg(R) # TODO: specify that R is IR
+domain: Top_op
+codomain: CAlg(R) # TODO: specify that R is IR
 description: 'This functor maps a topological space $X$ to the commutative $\IR$-algebra $C(X)$ of continuous functions $X \to \IR$. A continuous map $f : X \to Y$ is mapped to the algebra homomorphism $f^* : C(Y) \to C(X)$, $u \mapsto u \circ f$.'
 nlab_link: null
 left_adjoint: null

--- a/database/data/functors/countable_copower_sets.yaml
+++ b/database/data/functors/countable_copower_sets.yaml
@@ -1,8 +1,8 @@
 id: countable_copower_sets
 name: countable copower functor on sets
 notation: $\IN \times (-)$
-source: Set
-target: Set
+domain: Set
+codomain: Set
 description: This functor maps a set $X$ to the product $\IN \times X$, which can also be seen as the copower $\IN \otimes X = \coprod_{n \in \IN} X$. It is an example of a polynomial functor.
 nlab_link: null
 left_adjoint: null

--- a/database/data/functors/diagonal_sets.yaml
+++ b/database/data/functors/diagonal_sets.yaml
@@ -1,8 +1,8 @@
 id: diagonal_sets
 name: binary diagonal functor on the category of sets
 notation: $\Delta$
-source: Set
-target: SetxSet
+domain: Set
+codomain: SetxSet
 description: 'Every category $\C$ has a (binary) diagonal functor $\Delta : \C \to \C^2$, $X \mapsto (X,X)$. Here, we specify that $\C$ is the category of sets.'
 nlab_link: https://ncatlab.org/nlab/show/diagonal+functor
 left_adjoint: binary_coproduct_sets

--- a/database/data/functors/discrete_topology.yaml
+++ b/database/data/functors/discrete_topology.yaml
@@ -1,8 +1,8 @@
 id: discrete_topology
 name: discrete topology functor
 notation: $D$
-source: Set
-target: Top
+domain: Set
+codomain: Top
 description: This functor maps a set $X$ to the discrete topological space $D(X) \coloneqq (X, P(X))$ in which every subset is open.
 nlab_link: https://ncatlab.org/nlab/show/discrete+and+indiscrete+topology
 left_adjoint: null

--- a/database/data/functors/doubling_sets.yaml
+++ b/database/data/functors/doubling_sets.yaml
@@ -1,8 +1,8 @@
 id: doubling_sets
 name: doubling functor on sets
 notation: $2(-)$
-source: Set
-target: Set
+domain: Set
+codomain: Set
 description: This functor maps a set $X$ to its double $2 X \coloneqq X + X$. It is a simple example of a polynomial functor.
 nlab_link: null
 left_adjoint: null

--- a/database/data/functors/enveloping_group.yaml
+++ b/database/data/functors/enveloping_group.yaml
@@ -1,8 +1,8 @@
 id: enveloping_group
 name: enveloping group functor
 notation: $F_{\Mon,\Grp}$
-source: Mon
-target: Grp
+domain: Mon
+codomain: Grp
 description: 'This functor maps a monoid $M$ to the group $F(M)$ that is equipped with a universal homomorphism $i_M : M \to F(M)$. It is called the (universal) enveloping group or the group completion of $M$; in the commutative case, it is known as the Grothendieck group of $M$. As a possible construction of $F(M)$, take the free group on generators $\underline{m}$ for $m \in M$ subject to the relations $\underline{1} = 1$ and $\underline{m \cdot n} = \underline{m} \cdot \underline{n}$.'
 nlab_link: https://ncatlab.org/nlab/show/free+functor
 left_adjoint: null

--- a/database/data/functors/forget_abelian.yaml
+++ b/database/data/functors/forget_abelian.yaml
@@ -1,8 +1,8 @@
 id: forget_abelian
 name: forgetful functor from abelian groups to groups
 notation: $U_{\Ab,\Grp}$
-source: Ab
-target: Grp
+domain: Ab
+codomain: Grp
 description: This functor maps an abelian group to itself, considered merely as a group.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: abelianization

--- a/database/data/functors/forget_addition.yaml
+++ b/database/data/functors/forget_addition.yaml
@@ -1,8 +1,8 @@
 id: forget_addition
 name: forgetful functor from rings to monoids
 notation: $U_{\Ring,\Mon}$
-source: Ring
-target: Mon
+domain: Ring
+codomain: Mon
 description: This functor maps a ring to its underlying multiplicative monoid, which as "forgotten" the addition of the ring.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: monoid_ring

--- a/database/data/functors/forget_group.yaml
+++ b/database/data/functors/forget_group.yaml
@@ -1,8 +1,8 @@
 id: forget_group
 name: forgetful functor for groups
 notation: $U_{\Grp}$
-source: Grp
-target: Set
+domain: Grp
+codomain: Set
 description: This functor maps a group $G$ to its underlying set $U_{\Grp}(G)$.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: free_group

--- a/database/data/functors/forget_group_pointed.yaml
+++ b/database/data/functors/forget_group_pointed.yaml
@@ -1,8 +1,8 @@
 id: forget_group_pointed
 name: forgetful functor from groups to pointed sets
 notation: $U_{\Grp,\Set_*}$
-source: Grp
-target: Set_*
+domain: Grp
+codomain: Set_*
 description: This functor maps a group $G$ to its underlying pointed set $U_{\Grp,\Set_*}(G)$, whose base point is the identity element of $G$. It is an example of an essentially surjective functor which is not right-invertible.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: null

--- a/database/data/functors/forget_inverses.yaml
+++ b/database/data/functors/forget_inverses.yaml
@@ -1,8 +1,8 @@
 id: forget_inverses
 name: forgetful functor from groups to monoids
 notation: $U_{\Grp,\Mon}$
-source: Grp
-target: Mon
+domain: Grp
+codomain: Mon
 description: This functor maps a group to its underlying monoid. We view groups as structured sets $(X,m,e,i)$ (consisting of a set, a multiplication, a neutral element, and an inverse operation), and monoids as structured sets $(X,m,e)$. This forgetful functor precisely maps $(X,m,e,i)$ to $(X,m,e)$. From this point of view, it does <i>not</i> merely forget a property; it forgets an operation. This perspective is useful in contexts where the inverse operation is no longer reducible to a property, for example, the forgetful functor from topological groups to topological monoids.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: enveloping_group

--- a/database/data/functors/forget_ring.yaml
+++ b/database/data/functors/forget_ring.yaml
@@ -1,8 +1,8 @@
 id: forget_ring
 name: forgetful functor for rings
 notation: $U_{\Ring}$
-source: Ring
-target: Set
+domain: Ring
+codomain: Set
 description: This functor maps a ring $R$ to its underlying set $U_{\Ring}(R)$.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: null

--- a/database/data/functors/forget_topology.yaml
+++ b/database/data/functors/forget_topology.yaml
@@ -1,8 +1,8 @@
 id: forget_topology
 name: forgetful functor for topological spaces
 notation: $U_{\Top}$
-source: Top
-target: Set
+domain: Top
+codomain: Set
 description: This functor maps a topological space $X$ to its underlying set $U_{\Top}(X)$.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: discrete_topology

--- a/database/data/functors/forget_vector.yaml
+++ b/database/data/functors/forget_vector.yaml
@@ -1,8 +1,8 @@
 id: forget_vector
 name: forgetful functor for vector spaces
 notation: $U_{\Vect}$
-source: Vect
-target: Set
+domain: Vect
+codomain: Set
 description: This functor maps a vector space $V$ (over a fixed field $K$) to its underlying set $U_{\Vect}(V)$.
 nlab_link: https://ncatlab.org/nlab/show/forgetful+functor
 left_adjoint: null

--- a/database/data/functors/free_group.yaml
+++ b/database/data/functors/free_group.yaml
@@ -1,8 +1,8 @@
 id: free_group
 name: free group functor
 notation: $F_{\Grp}$
-source: Set
-target: Grp
+domain: Set
+codomain: Grp
 description: This functor maps a set $X$ to the free group $F_{\Grp}(X)$ on that set. In the proofs, we abbreviate $F \coloneqq F_{\Grp}$.
 nlab_link: https://ncatlab.org/nlab/show/free+functor
 left_adjoint: null

--- a/database/data/functors/group_units.yaml
+++ b/database/data/functors/group_units.yaml
@@ -1,8 +1,8 @@
 id: group_units
 name: group of units functor
 notation: $(-)^{\times}$
-source: Mon
-target: Grp
+domain: Mon
+codomain: Grp
 description: This functor maps a monoid $M$ to its group of units $M^{\times}$, consisting of pairs $(a,b) \in M^2$ satisfying $ab=ba=1$. Equivalently, it takes the submonoid of invertible elements of $M$, equipped with the inverse operation.
 nlab_link: https://ncatlab.org/nlab/show/group+of+units
 left_adjoint: forget_inverses

--- a/database/data/functors/id_Set.yaml
+++ b/database/data/functors/id_Set.yaml
@@ -1,8 +1,8 @@
 id: id_Set
 name: identity functor on the category of sets
 notation: $\id_{\Set}$
-source: Set
-target: Set
+domain: Set
+codomain: Set
 description: 'Every category $\C$ has an identity functor $\id_{\C} : \C \to \C$. Here, we specify that $\C$ is the category of sets.'
 nlab_link: https://ncatlab.org/nlab/show/identity+functor
 left_adjoint: id_Set

--- a/database/data/functors/indiscrete_topology.yaml
+++ b/database/data/functors/indiscrete_topology.yaml
@@ -1,8 +1,8 @@
 id: indiscrete_topology
 name: indiscrete topology functor
 notation: $I$
-source: Set
-target: Top
+domain: Set
+codomain: Top
 description: This functor maps a set $X$ to the indiscrete topological space $I(X) \coloneqq (X, \{\varnothing,X\})$ in which only the empty set and $X$ are open.
 nlab_link: https://ncatlab.org/nlab/show/discrete+and+indiscrete+topology
 left_adjoint: forget_topology

--- a/database/data/functors/modulo-p.yaml
+++ b/database/data/functors/modulo-p.yaml
@@ -1,8 +1,8 @@
 id: modulo-p
 name: modulo p functor
 notation: $T^p$
-source: Ab
-target: Ab
+domain: Ab
+codomain: Ab
 description: This functor maps an abelian group $A$ to the quotient $T^p(A) \coloneqq A/pA$, where $p$ is a fixed prime number. This group can also be represented as $A \otimes \IZ/p$.
 nlab_link: null
 left_adjoint: null

--- a/database/data/functors/monoid_ring.yaml
+++ b/database/data/functors/monoid_ring.yaml
@@ -1,8 +1,8 @@
 id: monoid_ring
 name: monoid ring functor
 notation: $\IZ[-]$
-source: Mon
-target: Ring
+domain: Mon
+codomain: Ring
 description: This functor maps a monoid $M$ to the monoid ring $\IZ[M]$, which consists of finite sums of elements in $M$.
 nlab_link: https://ncatlab.org/nlab/show/group+algebra
 left_adjoint: null

--- a/database/data/functors/opposite_category.yaml
+++ b/database/data/functors/opposite_category.yaml
@@ -1,8 +1,8 @@
 id: opposite_category
 name: opposite category functor
 notation: $(-)^{\op}$
-source: Cat
-target: Cat
+domain: Cat
+codomain: Cat
 description: 'This functor maps a small category $\C$ to its opposite category $\C^{\op}$ and a functor $F : \C \to \D$ to the opposite functor $F^{\op} : \C^{\op} \to \D^{\op}$.'
 nlab_link: https://ncatlab.org/nlab/show/opposite+category
 left_adjoint: opposite_category

--- a/database/data/functors/opposite_monoid.yaml
+++ b/database/data/functors/opposite_monoid.yaml
@@ -1,8 +1,8 @@
 id: opposite_monoid
 name: opposite monoid functor
 notation: $(-)^{\op}$
-source: Mon
-target: Mon
+domain: Mon
+codomain: Mon
 description: 'This functor maps a monoid $M$ to its opposite monoid $M^{\op}$ which has the multiplication $a *^{\op} b \coloneqq a * b$. A monoid homomorphism $f : M \to N$ is also a monoid homomorphism $f^{\op} : M^{\op} \to N^{\op}$.'
 nlab_link: https://ncatlab.org/nlab/show/opposite+magma
 left_adjoint: opposite_monoid

--- a/database/data/functors/p-torsion.yaml
+++ b/database/data/functors/p-torsion.yaml
@@ -1,8 +1,8 @@
 id: p-torsion
 name: p-torsion functor
 notation: $T_p$
-source: Ab
-target: Ab
+domain: Ab
+codomain: Ab
 description: >-
   This functor maps an abelian group $A$ to its $p$-torsion subgroup
   $$T_p(A) \coloneqq \{a \in A : pa = 0\},$$

--- a/database/data/functors/pi_0.yaml
+++ b/database/data/functors/pi_0.yaml
@@ -1,8 +1,8 @@
 id: pi_0
 name: path components functor
 notation: $\pi_0$
-source: Top
-target: Set
+domain: Top
+codomain: Set
 description: This functor maps a topological space $X$ to its set $\pi_0(X)$ of path components. Thus, $\pi_0(X) = U(X) / {\sim}$, where $U(X)$ is the underlying set and $x \sim y$ when there is a path from $x$ to $y$.
 nlab_link: https://ncatlab.org/nlab/show/connected+space
 left_adjoint: null

--- a/database/data/functors/pi_1.yaml
+++ b/database/data/functors/pi_1.yaml
@@ -1,8 +1,8 @@
 id: pi_1
 name: fundamental group functor
 notation: $\pi_1$
-source: Top_*
-target: Grp
+domain: Top_*
+codomain: Grp
 description: The fundamental group $\pi_1(X,x_0)$ of a pointed topological space $(X,x_0)$ is the group of homotopy classes of loops at $x_0$. The group operation is concatenation of paths. For example, we have $\pi_1(S^1,1) \cong \IZ$ (see Hatcher's <a href="https://pi.math.cornell.edu/~hatcher/AT/ATpage.html" target="_blank">Algebraic Topology</a>, Theorem 1.7).
 nlab_link: https://ncatlab.org/nlab/show/fundamental+group
 left_adjoint: null

--- a/database/data/functors/power_set_contravariant.yaml
+++ b/database/data/functors/power_set_contravariant.yaml
@@ -1,8 +1,8 @@
 id: power_set_contravariant
 name: contravariant power set functor
 notation: $P_{\forall}$
-source: Set_op
-target: Set
+domain: Set_op
+codomain: Set
 description: 'This functor $P_{\forall}$ maps a set $X$ to its power set $P(X)$ and a map of sets $f : X \to Y$ to the induced preimage operator $f^* : P(Y) \to P(X)$.'
 nlab_link: https://ncatlab.org/nlab/show/power+set
 left_adjoint: null

--- a/database/data/functors/power_set_covariant.yaml
+++ b/database/data/functors/power_set_covariant.yaml
@@ -1,8 +1,8 @@
 id: power_set_covariant
 name: covariant power set functor
 notation: $P_{\exists}$
-source: Set
-target: Set
+domain: Set
+codomain: Set
 description: 'This functor $P_{\exists}$ maps a set $X$ to its power set $P(X)$ and a map of sets $f : X \to Y$ to the induced image operator $f_* : P(X) \to P(Y)$.'
 nlab_link: https://ncatlab.org/nlab/show/power+set
 left_adjoint: null

--- a/database/data/functors/sequences_sets.yaml
+++ b/database/data/functors/sequences_sets.yaml
@@ -1,8 +1,8 @@
 id: sequences_sets
 name: sequences functor on sets
 notation: $(-)^{\IN}$
-source: Set
-target: Set
+domain: Set
+codomain: Set
 description: This functor maps a set $X$ to the countable power $X^{\IN}$, i.e. the set of sequences in $X$. It is an example of a polynomial functor. It is also an example of a monadic functor for which the crude monadicity theorem does not apply.
 nlab_link: null
 left_adjoint: countable_copower_sets

--- a/database/data/functors/squaring_sets.yaml
+++ b/database/data/functors/squaring_sets.yaml
@@ -1,8 +1,8 @@
 id: squaring_sets
 name: squaring functor on sets
 notation: $(-)^2$
-source: Set
-target: Set
+domain: Set
+codomain: Set
 description: This functor maps a set $X$ to its square $X^2$. It is a simple example of a polynomial functor.
 nlab_link: null
 left_adjoint: doubling_sets

--- a/database/data/functors/torsion.yaml
+++ b/database/data/functors/torsion.yaml
@@ -1,8 +1,8 @@
 id: torsion
 name: torsion functor
 notation: $T$
-source: Ab
-target: Ab
+domain: Ab
+codomain: Ab
 description: >-
   This functor maps an abelian group $A$ to its torsion subgroup
   $$T(A) \coloneqq \{a \in A : \exists n \geq 1 \, (na = 0)\}.$$

--- a/database/data/functors/trivial_groups.yaml
+++ b/database/data/functors/trivial_groups.yaml
@@ -1,8 +1,8 @@
 id: trivial_groups
 name: trivial functor from the category of groups
 notation: $!$
-source: Grp
-target: '1'
+domain: Grp
+codomain: '1'
 description: 'Every category $\C$ has a unique functor $! : \C \to 1$ into the trivial category. Here, we specify that $\C$ is the category of groups. It is a basic example of a full functor which is not faithful.'
 nlab_link: null
 left_adjoint: null

--- a/database/data/functors/trivial_sets.yaml
+++ b/database/data/functors/trivial_sets.yaml
@@ -1,8 +1,8 @@
 id: trivial_sets
 name: trivial functor from the category of sets
 notation: $!$
-source: Set
-target: '1'
+domain: Set
+codomain: '1'
 description: 'Every category $\C$ has a unique functor $! : \C \to 1$ into the trivial category. Here, we specify that $\C$ is the category of sets.'
 nlab_link: null
 left_adjoint: null

--- a/database/data/functors/walking_isomorphism_object_inclusion.yaml
+++ b/database/data/functors/walking_isomorphism_object_inclusion.yaml
@@ -1,8 +1,8 @@
 id: walking_isomorphism_object_inclusion
 name: walking isomorphism object inclusion
 notation: $\iota$
-source: '1'
-target: walking_isomorphism
+domain: '1'
+codomain: walking_isomorphism
 description: 'This is the natural embedding of the trivial category with a single object $0$ into the walking isomorphism given by two objects $0,1$ and an isomorphism $0 \to 1$. This is the simplest example of an equivalence of categories which is not an isomorphism.'
 nlab_link: null
 left_adjoint: null

--- a/database/schema/001_structures.sql
+++ b/database/schema/001_structures.sql
@@ -73,6 +73,6 @@ CREATE TABLE structure_maps (
 INSERT INTO structure_maps
     (map, type, mapped_type)
 VALUES
-    ('source', 'functor', 'category'),
-    ('target', 'functor', 'category'),
+    ('domain', 'functor', 'category'),
+    ('codomain', 'functor', 'category'),
     ('category', 'morphism', 'category');

--- a/database/schema/007_functors.sql
+++ b/database/schema/007_functors.sql
@@ -1,14 +1,14 @@
 CREATE TABLE functors (
     id TEXT PRIMARY KEY,
-    source TEXT NOT NULL,
-    target TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    codomain TEXT NOT NULL,
     left_adjoint TEXT,
-    UNIQUE (id, source, target),
+    UNIQUE (id, domain, codomain),
     FOREIGN KEY (id)  REFERENCES structures (id) ON DELETE CASCADE,
-    FOREIGN KEY (source) REFERENCES categories (id) ON DELETE CASCADE,
-    FOREIGN KEY (target) REFERENCES categories (id) ON DELETE CASCADE,
-    FOREIGN KEY (left_adjoint, target, source)
-        REFERENCES functors (id, source, target)
+    FOREIGN KEY (domain) REFERENCES categories (id) ON DELETE CASCADE,
+    FOREIGN KEY (codomain) REFERENCES categories (id) ON DELETE CASCADE,
+    FOREIGN KEY (left_adjoint, codomain, domain)
+        REFERENCES functors (id, domain, codomain)
         ON DELETE CASCADE
 );
 

--- a/database/scripts/restrict-functor-properties.ts
+++ b/database/scripts/restrict-functor-properties.ts
@@ -4,7 +4,7 @@ import { devlog } from '$shared/utils'
 const db = get_client({ readonly: false })
 
 /**
- * Ensures that only functors with target Set are representable.
+ * Ensures that only functors with codomain Set are representable.
  * When necessary, this can be extended to other properties in the future.
  */
 export function restrict_representable_functors() {
@@ -26,11 +26,11 @@ export function restrict_representable_functors() {
                 'representable',
                 'functor',
                 FALSE,
-                'The target category is not $\\Set$.',
+                'The codomain is not $\\Set$.',
                 TRUE,
                 FALSE
             FROM functors f
-            WHERE f.target <> 'Set'
+            WHERE f.codomain <> 'Set'
             ON CONFLICT (structure_id, property_id)
             DO UPDATE SET
                 proof = excluded.proof,

--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -335,14 +335,14 @@ function insert_category(category: CategoryYaml) {
  */
 function insert_functor(functor: FunctorYaml) {
 	const functor_insert = db.prepare(
-		`INSERT INTO functors (id, source, target, left_adjoint)
+		`INSERT INTO functors (id, domain, codomain, left_adjoint)
 		VALUES (?, ?, ?, ?)`
 	)
 
 	functor_insert.run(
 		functor.id,
-		functor.source,
-		functor.target,
+		functor.domain,
+		functor.codomain,
 		functor.left_adjoint || null
 	)
 }

--- a/database/scripts/utils/seed.types.ts
+++ b/database/scripts/utils/seed.types.ts
@@ -66,8 +66,8 @@ export type CategoryYaml = StructureYaml & {
 }
 
 export type FunctorYaml = StructureYaml & {
-	source: string
-	target: string
+	domain: string
+	codomain: string
 	left_adjoint: string | null
 }
 

--- a/src/lib/commons/types.ts
+++ b/src/lib/commons/types.ts
@@ -138,12 +138,12 @@ export type CategorySpecificDisplay = {
 }
 
 export type FunctorSpecificDisplay = {
-	source: string
-	source_name: string
-	source_notation: string
-	target: string
-	target_name: string
-	target_notation: string
+	domain: string
+	domain_name: string
+	domain_notation: string
+	codomain: string
+	codomain_name: string
+	codomain_notation: string
 	left_adjoint: string | null
 	left_adjoint_name: string | null
 	left_adjoint_notation: string | null

--- a/src/lib/server/fetchers/category.ts
+++ b/src/lib/server/fetchers/category.ts
@@ -44,7 +44,7 @@ export function fetch_category(id: string) {
 			`SELECT f.id, s.name
 			FROM functors f
 			INNER JOIN structures s ON s.id = f.id
-			WHERE f.source = ? OR f.target = ?
+			WHERE f.domain = ? OR f.codomain = ?
 			ORDER BY lower(s.name)`
 		)
 		.all(id, id)

--- a/src/lib/server/fetchers/functor.ts
+++ b/src/lib/server/fetchers/functor.ts
@@ -6,12 +6,12 @@ export function fetch_functor(id: string) {
 	const functor = db
 		.prepare<[string], FunctorSpecificDisplay>(
 			`SELECT
-                f.source,
-                f.target,
-                source.name AS source_name,
-                source.notation AS source_notation,
-                target.name AS target_name,
-                target.notation AS target_notation,
+                f.domain,
+                f.codomain,
+                domain.name AS domain_name,
+                domain.notation AS domain_notation,
+                codomain.name AS codomain_name,
+                codomain.notation AS codomain_notation,
                 la.id AS left_adjoint,
                 la.name AS left_adjoint_name,
                 la.notation AS left_adjoint_notation,
@@ -19,8 +19,8 @@ export function fetch_functor(id: string) {
                 ra.name AS right_adjoint_name,
                 ra.notation AS right_adjoint_notation
             FROM functors f
-            INNER JOIN structures AS source ON source.id = f.source
-            INNER JOIN structures AS target ON target.id = f.target
+            INNER JOIN structures AS domain ON domain.id = f.domain
+            INNER JOIN structures AS codomain ON codomain.id = f.codomain
             LEFT JOIN structures AS la ON la.id = f.left_adjoint
             LEFT JOIN functors AS rf ON rf.left_adjoint = f.id
             LEFT JOIN structures AS ra ON ra.id = rf.id

--- a/src/pages/CategoryDetailPage.svelte
+++ b/src/pages/CategoryDetailPage.svelte
@@ -68,7 +68,7 @@
 						one: 'There is 1 functor',
 						other: 'There are {count} functors'
 					})}
-					whose source or target is the {data.structure.name}.
+					whose (co-)domain is the {data.structure.name}.
 				</p>
 				<StructureList structures={data.functors} type="functor" />
 			</section>

--- a/src/pages/CategoryDetailPage.svelte
+++ b/src/pages/CategoryDetailPage.svelte
@@ -15,11 +15,11 @@
 <StructureDetailPage {...data}>
 	{#snippet definition()}
 		<li>
-			<strong>objects:</strong>
+			<strong>Objects:</strong>
 			{@html data.objects}
 		</li>
 		<li>
-			<strong>morphisms:</strong>
+			<strong>Morphisms:</strong>
 			{@html data.morphisms}
 		</li>
 	{/snippet}

--- a/src/pages/FunctorDetailPage.svelte
+++ b/src/pages/FunctorDetailPage.svelte
@@ -10,13 +10,13 @@
 <StructureDetailPage {...data}>
 	{#snippet definition()}
 		<li>
-			<strong>Source:</strong>
-			<a href="/category/{data.source}">{data.source_name}</a>
+			<strong>Domain:</strong>
+			<a href="/category/{data.domain}">{data.domain_name}</a>
 		</li>
 
 		<li>
-			<strong>Target:</strong>
-			<a href="/category/{data.target}">{data.target_name}</a>
+			<strong>Codomain:</strong>
+			<a href="/category/{data.codomain}">{data.codomain_name}</a>
 		</li>
 
 		{#if data.left_adjoint}

--- a/src/pages/StructureDetailPage.svelte
+++ b/src/pages/StructureDetailPage.svelte
@@ -59,7 +59,7 @@
 <section aria-label="main info" class="main-info">
 	<ul class="with-margins">
 		<li>
-			<strong>notation:</strong>
+			<strong>Notation:</strong>
 			{@html structure.notation}
 		</li>
 

--- a/src/routes/[type]/[id]/+page.server.ts
+++ b/src/routes/[type]/[id]/+page.server.ts
@@ -25,7 +25,7 @@ export const load = (event) => {
 
 	if (special_structure_data.type === 'functor') {
 		structure_data.structure.notation = add_math(
-			`${strip_math(structure_data.structure.notation)}: ${strip_math(special_structure_data.source_notation)} \\to ${strip_math(special_structure_data.target_notation)}`
+			`${strip_math(structure_data.structure.notation)}: ${strip_math(special_structure_data.domain_notation)} \\to ${strip_math(special_structure_data.codomain_notation)}`
 		)
 	}
 

--- a/tests/functors.spec.ts
+++ b/tests/functors.spec.ts
@@ -162,7 +162,7 @@ test('user can navigate to a related functor', async ({ page }) => {
 	await expect(page).toHaveURL('/functor/forget_group')
 })
 
-test('user can navigate to the source category', async ({ page }) => {
+test('user can navigate to the domain category', async ({ page }) => {
 	await page.goto('/functor/forget_ring', { waitUntil: 'networkidle' })
 
 	await page
@@ -182,7 +182,7 @@ test('user can navigate to the source category', async ({ page }) => {
 	await expect(page).toHaveURL('/category/Ring')
 })
 
-test('user can navigate to the target category', async ({ page }) => {
+test('user can navigate to the codomain category', async ({ page }) => {
 	await page.goto('/functor/group_units', { waitUntil: 'networkidle' })
 
 	await page


### PR DESCRIPTION
For functors in particular, "source" has been renamed to "domain", and "target" has been renamed to "codomain". Although the terms are synonymous:

- "source" and "target" are more generic, whereas "domain" and "codomain" are standard mathematical terms
- in some implication formulations, such as the Special Adjoint Functor Theorem, phrases like "whose source is ..." sound awkward (to me). It now reads as follows (in conjunction with the previous PR #286):

> Given a functor whose codomain is locally essentially small, and whose domain has a cogenerating set and is complete and is locally essentially small and is well-powered, if it is continuous, then it is a right adjoint.

Also, the capitalization on the structure detail page has been made consistent. For example, it previously said "notation" (lowercase) but "Related categories" (capitalized). Now, all labels are consistently capitalized.