### PR TITLE
Add property "core-connected" and improve tags

### DIFF
--- a/database/data/categories/0.yaml
+++ b/database/data/categories/0.yaml
@@ -7,8 +7,7 @@ description: This is the category with no objects and no morphisms. It is the in
 nlab_link: https://ncatlab.org/nlab/show/empty+category
 
 tags:
-  - finite
-  - thin
+  - category theory
 
 related:
   - '1'

--- a/database/data/categories/1.yaml
+++ b/database/data/categories/1.yaml
@@ -7,9 +7,7 @@ description: 'This is the simplest category, consisting of a single object $0$ a
 nlab_link: https://ncatlab.org/nlab/show/terminal+category
 
 tags:
-  - finite
-  - single object
-  - thin
+  - category theory
 
 related:
   - '0'

--- a/database/data/categories/2.yaml
+++ b/database/data/categories/2.yaml
@@ -7,8 +7,7 @@ description: A concrete representation is the full subcategory of <a href="/cate
 nlab_link: null
 
 tags:
-  - finite
-  - thin
+  - category theory
 
 related:
   - '1'

--- a/database/data/categories/BG_c.yaml
+++ b/database/data/categories/BG_c.yaml
@@ -9,7 +9,6 @@ nlab_link: https://ncatlab.org/nlab/show/delooping
 tags:
   - algebra
   - category theory
-  - single object
 
 related:
   - BG_f

--- a/database/data/categories/BG_c.yaml
+++ b/database/data/categories/BG_c.yaml
@@ -23,14 +23,11 @@ satisfied_properties:
   - property: groupoid
     proof: This is trivial.
 
-  - property: connected
-    proof: This is trivial.
+  - property: core-connected
+    proof: The category has exactly one object.
 
   - property: skeletal
-    proof: There is just one object.
-
-  - property: generator
-    proof: The unique object is a generator for trivial reasons.
+    proof: The category has exactly one object.
 
   - property: countable
     proof: This is because $G$ is countable.

--- a/database/data/categories/BG_f.yaml
+++ b/database/data/categories/BG_f.yaml
@@ -9,8 +9,6 @@ nlab_link: https://ncatlab.org/nlab/show/delooping
 tags:
   - algebra
   - category theory
-  - finite
-  - single object
 
 related:
   - BG_c

--- a/database/data/categories/BG_f.yaml
+++ b/database/data/categories/BG_f.yaml
@@ -27,14 +27,11 @@ satisfied_properties:
   - property: groupoid
     proof: This is trivial.
 
-  - property: connected
-    proof: This is trivial.
+  - property: core-connected
+    proof: The category has exactly one object.
 
   - property: skeletal
-    proof: There is just one object.
-
-  - property: generator
-    proof: The unique object is a generator for trivial reasons.
+    proof: The category has exactly one object.
 
 unsatisfied_properties:
   - property: trivial

--- a/database/data/categories/BG_u.yaml
+++ b/database/data/categories/BG_u.yaml
@@ -9,7 +9,6 @@ nlab_link: https://ncatlab.org/nlab/show/delooping
 tags:
   - algebra
   - category theory
-  - single object
 
 related:
   - BG_f

--- a/database/data/categories/BG_u.yaml
+++ b/database/data/categories/BG_u.yaml
@@ -23,14 +23,11 @@ satisfied_properties:
   - property: groupoid
     proof: This is trivial.
 
-  - property: connected
-    proof: This is trivial.
+  - property: core-connected
+    proof: The category has exactly one object.
 
   - property: skeletal
-    proof: There is just one object.
-
-  - property: generator
-    proof: The unique object is a generator for trivial reasons.
+    proof: The category has exactly one object.
 
 unsatisfied_properties:
   - property: locally finite

--- a/database/data/categories/BN.yaml
+++ b/database/data/categories/BN.yaml
@@ -22,14 +22,11 @@ satisfied_properties:
   - property: countable
     proof: This is trivial.
 
-  - property: strongly connected
-    proof: This is trivial.
+  - property: core-connected
+    proof: The category has exactly one object.
 
   - property: self-dual
     proof: The identity is a self-duality since the addition is commutative.
-
-  - property: generator
-    proof: The unique object is a generator for trivial reasons.
 
   - property: left cancellative
     proof: This is because addition of natural numbers is cancellative.

--- a/database/data/categories/BN.yaml
+++ b/database/data/categories/BN.yaml
@@ -9,7 +9,6 @@ nlab_link: null
 tags:
   - category theory
   - number theory
-  - single object
 
 related:
   - BG_c

--- a/database/data/categories/BOn.yaml
+++ b/database/data/categories/BOn.yaml
@@ -8,7 +8,6 @@ nlab_link: null
 
 tags:
   - set theory
-  - single object
 
 related:
   - BN

--- a/database/data/categories/BOn.yaml
+++ b/database/data/categories/BOn.yaml
@@ -14,14 +14,8 @@ related:
   - BN
 
 satisfied_properties:
-  - property: generator
-    proof: There is just one object.
-
-  - property: cogenerator
-    proof: There is just one object.
-
-  - property: strongly connected
-    proof: This is trivial.
+  - property: core-connected
+    proof: The category has exactly one object.
 
   - property: gaunt
     proof: This is because $0$ is the only ordinal number with an additive inverse.
@@ -48,9 +42,6 @@ satisfied_properties:
     proof: A proof can be found <a href="/content/aleph1-filtered-colimits-in-deloopings">here</a> as Proposition 3.
 
 unsatisfied_properties:
-  - property: initial object
-    proof: This is trivial.
-
   - property: one-way
     proof: This is trivial.
 

--- a/database/data/categories/N.yaml
+++ b/database/data/categories/N.yaml
@@ -8,7 +8,6 @@ nlab_link: null
 
 tags:
   - number theory
-  - thin
 
 related:
   - N_oo

--- a/database/data/categories/N_oo.yaml
+++ b/database/data/categories/N_oo.yaml
@@ -8,7 +8,6 @@ nlab_link: null
 
 tags:
   - number theory
-  - thin
 
 related:
   - N

--- a/database/data/categories/On.yaml
+++ b/database/data/categories/On.yaml
@@ -8,7 +8,6 @@ nlab_link: null
 
 tags:
   - set theory
-  - thin
 
 related:
   - N

--- a/database/data/categories/Z_div.yaml
+++ b/database/data/categories/Z_div.yaml
@@ -8,7 +8,6 @@ nlab_link: null
 
 tags:
   - number theory
-  - thin
 
 related:
   - N

--- a/database/data/categories/real_interval.yaml
+++ b/database/data/categories/real_interval.yaml
@@ -8,7 +8,6 @@ nlab_link: https://ncatlab.org/nlab/show/interval
 
 tags:
   - analysis
-  - thin
 
 related:
   - N_oo

--- a/database/data/categories/walking_commutative_square.yaml
+++ b/database/data/categories/walking_commutative_square.yaml
@@ -10,8 +10,6 @@ description: >-
 nlab_link: https://ncatlab.org/nlab/show/commutative+square
 tags:
   - category theory
-  - finite
-  - thin
 
 related:
   - walking_fork

--- a/database/data/categories/walking_composable_pair.yaml
+++ b/database/data/categories/walking_composable_pair.yaml
@@ -10,8 +10,6 @@ description: >-
 nlab_link: https://ncatlab.org/nlab/show/composable+pair
 tags:
   - category theory
-  - finite
-  - thin
 
 related:
   - walking_fork

--- a/database/data/categories/walking_coreflexive_pair.yaml
+++ b/database/data/categories/walking_coreflexive_pair.yaml
@@ -10,7 +10,6 @@ description: >-
 nlab_link: null
 tags:
   - category theory
-  - finite
 
 related:
   - Delta

--- a/database/data/categories/walking_fork.yaml
+++ b/database/data/categories/walking_fork.yaml
@@ -10,7 +10,6 @@ description: >-
 nlab_link: null
 tags:
   - category theory
-  - finite
 
 related:
   - walking_commutative_square

--- a/database/data/categories/walking_idempotent.yaml
+++ b/database/data/categories/walking_idempotent.yaml
@@ -8,8 +8,6 @@ nlab_link: null
 
 tags:
   - category theory
-  - finite
-  - single object
 
 related:
   - BG_f

--- a/database/data/categories/walking_idempotent.yaml
+++ b/database/data/categories/walking_idempotent.yaml
@@ -30,8 +30,8 @@ satisfied_properties:
   - property: self-dual
     proof: This is obvious.
 
-  - property: generator
-    proof: The unique object is a generator for trivial reasons.
+  - property: core-connected
+    proof: The category has exactly one object.
 
   - property: subobject-trivial
     proof: This is because the identity is the only monomorphism.
@@ -43,9 +43,6 @@ satisfied_properties:
     proof: 'In fact, the walking idempotent is $\kappa$-filtered for every regular infinite cardinal $\kappa$: Every diagram $D : \I \to \Idem$ has the cocone $(e : D(i) \to 0)_{i \in \I}$.'
 
 unsatisfied_properties:
-  - property: terminal object
-    proof: This is obvious.
-
   - property: Cauchy complete
     proof: The idempotent $e$ does not split.
 

--- a/database/data/categories/walking_isomorphism.yaml
+++ b/database/data/categories/walking_isomorphism.yaml
@@ -10,8 +10,6 @@ description: >-
 nlab_link: https://ncatlab.org/nlab/show/walking+isomorphism
 tags:
   - category theory
-  - finite
-  - thin
 
 related:
   - '1'

--- a/database/data/categories/walking_morphism.yaml
+++ b/database/data/categories/walking_morphism.yaml
@@ -10,8 +10,6 @@ description: >-
 nlab_link: https://ncatlab.org/nlab/show/interval+category
 tags:
   - category theory
-  - finite
-  - thin
 
 related:
   - walking_commutative_square

--- a/database/data/categories/walking_pair.yaml
+++ b/database/data/categories/walking_pair.yaml
@@ -10,7 +10,6 @@ description: >-
 nlab_link: https://ncatlab.org/nlab/show/walking+structure
 tags:
   - category theory
-  - finite
 
 related:
   - walking_coreflexive_pair

--- a/database/data/categories/walking_span.yaml
+++ b/database/data/categories/walking_span.yaml
@@ -10,8 +10,6 @@ description: >-
 nlab_link: https://ncatlab.org/nlab/show/span#the_walking_span
 tags:
   - category theory
-  - finite
-  - thin
 
 related:
   - walking_morphism

--- a/database/data/categories/walking_splitting.yaml
+++ b/database/data/categories/walking_splitting.yaml
@@ -9,7 +9,6 @@ description: |-
 nlab_link: null
 tags:
   - category theory
-  - finite
 
 related:
   - walking_coreflexive_pair

--- a/database/data/category-implications/connected.yaml
+++ b/database/data/category-implications/connected.yaml
@@ -1,5 +1,4 @@
-# results on connected, semi-strongly connected and
-# strongly connected categories
+# results on connected categories and related notions
 
 - id: connected_consequence
   assumptions:
@@ -51,4 +50,37 @@
   conclusions:
     - pointed
   proof: By assumption there is a morphism $1 \to 0$. There is also a unique morphism $0 \to 1$. They are necessarily inverse to each other.
+  is_equivalence: false
+
+- id: core-connected_implies_strongly-connected
+  assumptions:
+    - core-connected
+  conclusions:
+    - strongly connected
+  proof: This is trivial.
+  is_equivalence: false
+
+- id: unique_object_generates
+  assumptions:
+    - core-connected
+  conclusions:
+    - generator
+  proof: This is trivial.
+  is_equivalence: false
+
+- id: trivial_is_core-connected
+  assumptions:
+    - trivial
+  conclusions:
+    - core-connected
+  proof: This is trivial.
+  is_equivalence: false
+
+- id: core_connected_becomes_trivial
+  assumptions:
+    - core-connected
+    - initial object
+  conclusions:
+    - trivial
+  proof: Every object is isomorphic to the initial object.
   is_equivalence: false

--- a/database/data/category-properties/connected.yaml
+++ b/database/data/category-properties/connected.yaml
@@ -9,6 +9,7 @@ related:
   - inhabited
   - semi-strongly connected
   - strongly connected
+  - core-connected
 
 tags:
   - morphism behavior

--- a/database/data/category-properties/core-connected.yaml
+++ b/database/data/category-properties/core-connected.yaml
@@ -1,0 +1,21 @@
+id: core-connected
+relation: is
+description: >-
+  We say that a category $\C$ is <i>core-connected</i> if it satisfies one of the following equivalent conditions:
+  <ol>
+  <li>The <a href="https://ncatlab.org/nlab/show/core+groupoid" target="_blank">core</a> of $\C$ is <a href="/category-property/connected">connected</a>.</li>
+  <li>There is an object $X \in \C$ such that every object of $\C$ is isomorphic to $X$.</li>
+  <li>There is a (possibly large) monoid $M$ such that $\C$ is equivalent to the one-object category $BM$.</li>
+  </ol>
+  This is not standard terminology. We have added this property to systematically handle the one-object categories in the database; a category has exactly one object iff it is core-connected and <a href="/category-property/skeletal">skeletal</a>.
+nlab_link: null
+dual: core-connected
+invariant_under_equivalences: true
+
+related:
+  - connected
+  - trivial
+  - core-thin
+
+tags:
+  - object behavior

--- a/database/data/category-properties/core-thin.yaml
+++ b/database/data/category-properties/core-thin.yaml
@@ -15,6 +15,7 @@ related:
   - gaunt
   - one-way
   - thin
+  - core-connected
 
 tags:
   - morphism behavior

--- a/database/data/category-properties/initial object.yaml
+++ b/database/data/category-properties/initial object.yaml
@@ -11,3 +11,4 @@ related:
 
 tags:
   - colimits
+  - object behavior

--- a/database/data/category-properties/multi-initial object.yaml
+++ b/database/data/category-properties/multi-initial object.yaml
@@ -11,3 +11,4 @@ related:
 
 tags:
   - colimits
+  - object behavior

--- a/database/data/category-properties/multi-terminal object.yaml
+++ b/database/data/category-properties/multi-terminal object.yaml
@@ -11,3 +11,4 @@ related:
 
 tags:
   - limits
+  - object behavior

--- a/database/data/category-properties/natural numbers object.yaml
+++ b/database/data/category-properties/natural numbers object.yaml
@@ -16,3 +16,4 @@ related:
 
 tags:
   - topos theory
+  - object behavior

--- a/database/data/category-properties/quotient object classifier.yaml
+++ b/database/data/category-properties/quotient object classifier.yaml
@@ -15,3 +15,4 @@ related:
 
 tags:
   - topos theory
+  - object behavior

--- a/database/data/category-properties/regular quotient object classifier.yaml
+++ b/database/data/category-properties/regular quotient object classifier.yaml
@@ -15,3 +15,4 @@ related:
 
 tags:
   - topos theory
+  - object behavior

--- a/database/data/category-properties/regular subobject classifier.yaml
+++ b/database/data/category-properties/regular subobject classifier.yaml
@@ -16,3 +16,4 @@ related:
 
 tags:
   - topos theory
+  - object behavior

--- a/database/data/category-properties/strict initial object.yaml
+++ b/database/data/category-properties/strict initial object.yaml
@@ -11,3 +11,4 @@ related:
 tags:
   - colimits
   - morphism behavior
+  - object behavior

--- a/database/data/category-properties/strict terminal object.yaml
+++ b/database/data/category-properties/strict terminal object.yaml
@@ -11,3 +11,4 @@ related:
 tags:
   - limits
   - morphism behavior
+  - object behavior

--- a/database/data/category-properties/subobject classifier.yaml
+++ b/database/data/category-properties/subobject classifier.yaml
@@ -16,3 +16,4 @@ related:
 
 tags:
   - topos theory
+  - object behavior

--- a/database/data/category-properties/terminal object.yaml
+++ b/database/data/category-properties/terminal object.yaml
@@ -11,3 +11,4 @@ related:
 
 tags:
   - limits
+  - object behavior

--- a/database/data/category-properties/trivial.yaml
+++ b/database/data/category-properties/trivial.yaml
@@ -5,7 +5,8 @@ nlab_link: https://ncatlab.org/nlab/show/terminal+category
 dual: trivial
 invariant_under_equivalences: true
 
-related: []
+related:
+  - core-connected
 
 tags:
   - misc

--- a/database/data/config.yaml
+++ b/database/data/config.yaml
@@ -26,6 +26,7 @@ category_property_tags:
   - colimits
   - limit–colimit interaction
   - morphism behavior
+  - object behavior
   - size
   - algebraicity
   - accessibility

--- a/database/data/config.yaml
+++ b/database/data/config.yaml
@@ -9,17 +9,13 @@ structure_tags:
   - set theory
   - topology
 
-category_tags:
-  - finite
-  - thin
-  - single object
+category_tags: []
 
 functor_tags:
   - forgetful
   - free
 
-morphism_tags:
-  - misc
+morphism_tags: []
 
 category_property_tags:
   - limits

--- a/database/scripts/expected-data/Ab.json
+++ b/database/scripts/expected-data/Ab.json
@@ -172,5 +172,6 @@
 	"pretopos": false,
 	"quasitopos": false,
 	"regular-subobject-trivial": false,
-	"regular-quotient-trivial": false
+	"regular-quotient-trivial": false,
+	"core-connected": false
 }

--- a/database/scripts/expected-data/Set.json
+++ b/database/scripts/expected-data/Set.json
@@ -172,5 +172,6 @@
 	"quotient-trivial": false,
 	"locally finite": false,
 	"regular-subobject-trivial": false,
-	"regular-quotient-trivial": false
+	"regular-quotient-trivial": false,
+	"core-connected": false
 }

--- a/database/scripts/expected-data/Top.json
+++ b/database/scripts/expected-data/Top.json
@@ -172,5 +172,6 @@
 	"pretopos": false,
 	"quasitopos": false,
 	"regular-subobject-trivial": false,
-	"regular-quotient-trivial": false
+	"regular-quotient-trivial": false,
+	"core-connected": false
 }


### PR DESCRIPTION
Let us call a category *core-connected* if it has exactly one object up to isomorphism. This PR adds this property to systematically handle the one-object categories in the database. In fact, some manual property assignments could be removed resp. replaced with implications such as `core-connected + initial object ===> trivial`.

For the property a new tag `object behavior` has been added. It has also been applied to existing properties of categories such as having an `initial object`, a `natural numbers object`, etc.

Moreover, the category tags `finite`, `thin`, `single object` have been removed. They are redundant since for the first two we have corresponding properties anyway (and it is already supported to see all categories with a given property). And a category has a single object iff it is core-connected and skeletal.