### PR TITLE
Add sanity check for implications

### DIFF
--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -99,7 +99,7 @@ function clear_all_tables() {
 	try {
 		tx()
 	} catch (err) {
-		console.error(`Error clearing data:`, err)
+		console.error(`❌ Error clearing data:`, err)
 		process.exit(1)
 	}
 }
@@ -452,6 +452,16 @@ function seed_implications({ type, folder }: { type: StructureType; folder: stri
 
 	function insert_implications(implications: ImplicationYaml[]) {
 		for (const impl of implications) {
+			if (!impl.assumptions.length) {
+				console.error(`❌ Implication ${impl.id} has no assumptions.`)
+				process.exit(1)
+			}
+
+			if (!impl.conclusions.length) {
+				console.error(`❌ Implication ${impl.id} has no conclusions.`)
+				process.exit(1)
+			}
+
 			implication_insert.run(impl.id, type, impl.proof, Number(impl.is_equivalence))
 
 			for (const assumption of impl.assumptions) {

--- a/package.json
+++ b/package.json
@@ -38,12 +38,10 @@
 		"@types/katex": "^0.16.8",
 		"@types/markdown-it": "^14.1.2",
 		"@types/node": "^25.5.0",
-		"better-sqlite3": "^12.9.0",
 		"chokidar": "^5.0.0",
 		"dotenv": "^17.3.1",
 		"gray-matter": "^4.0.3",
 		"husky": "^9.1.7",
-		"katex": "^0.16.44",
 		"markdown-it": "^14.1.1",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.5.2",
@@ -59,6 +57,8 @@
 	"dependencies": {
 		"@fortawesome/free-regular-svg-icons": "^7.2.0",
 		"@fortawesome/free-solid-svg-icons": "^7.2.0",
+		"better-sqlite3": "^12.11.1",
+		"katex": "^0.17.0",
 		"svelte-fa": "^4.0.4",
 		"yaml": "^2.8.4"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
+      better-sqlite3:
+        specifier: ^12.11.1
+        version: 12.11.1
+      katex:
+        specifier: ^0.17.0
+        version: 0.17.0
       svelte-fa:
         specifier: ^4.0.4
         version: 4.0.4(svelte@5.55.7)
@@ -48,9 +54,6 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.6.0
-      better-sqlite3:
-        specifier: ^12.9.0
-        version: 12.9.0
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -63,9 +66,6 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
-      katex:
-        specifier: ^0.16.44
-        version: 0.16.45
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -648,9 +648,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -808,8 +808,8 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  katex@0.16.45:
-    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+  katex@0.17.0:
+    resolution: {integrity: sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==}
     hasBin: true
 
   kind-of@6.0.3:
@@ -936,8 +936,8 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+  node-abi@3.94.0:
+    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
     engines: {node: '>=10'}
 
   obug@2.1.1:
@@ -1026,8 +1026,8 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1079,8 +1079,8 @@ packages:
     resolution: {integrity: sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==}
     engines: {node: '>=18'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -1537,7 +1537,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-sqlite3@12.9.0:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -1711,7 +1711,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  katex@0.16.45:
+  katex@0.17.0:
     dependencies:
       commander: 8.3.0
 
@@ -1803,9 +1803,9 @@ snapshots:
 
   napi-build-utils@2.0.0: {}
 
-  node-abi@3.89.0:
+  node-abi@3.94.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   obug@2.1.1: {}
 
@@ -1839,11 +1839,11 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
-      node-abi: 3.89.0
+      node-abi: 3.94.0
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
-      tar-fs: 2.1.4
+      tar-fs: 2.1.5
       tunnel-agent: 0.6.0
 
   prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.7):
@@ -1911,7 +1911,7 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  semver@7.7.4: {}
+  semver@7.8.5: {}
 
   set-cookie-parser@3.1.0: {}
 
@@ -1978,7 +1978,7 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  tar-fs@2.1.4:
+  tar-fs@2.1.5:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3


### PR DESCRIPTION
This small PR completes two small TODOs from my list:

1. better-sqlite3 and katex were only dev dependencies so far; I wonder why this has worked in production at all. They are now full dependencies.
2. It is checked in the seed script that every implication has at least one assumption and at least one conclusion.