### PR TITLE
Add effective epimorphisms and related properties

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -264,6 +264,7 @@
 		"setoid",
 		"Sheafifiable",
 		"simplicial",
+		"Specker",
 		"subalgebra",
 		"subbasic",
 		"subbasis",

--- a/content/dual-properties.md
+++ b/content/dual-properties.md
@@ -20,3 +20,11 @@ Given a property $P$ of functors, its dual property $P^{\op}$ is defined as foll
 For example, since a functor is [essentially injective](/functor-property/essentially_injective) if and only if its dual is essentially injective, the property "is essentially injective" is self-dual. In particular, it is _not_ dual to the property "is [essentially surjective](/functor-property/essentially_surjective)", which is itself also self-dual.
 
 Again, notice that $(P^{\op})^{\op} = P$, and that $F : \C \to \D$ satisfies $P$ if and only if $F^{\op} : \C^{\op} \to \D^{\op}$ satisfies $P^{\op}$.
+
+### Morphisms
+
+Given a property $P$ of morphisms, its dual property $P^{\op}$ is defined as follows: a morphism $f : X \to Y$ in a category $\C$ satisfies $P^{\op}$ if and only if its dual morphism $f^{\op} : Y \to X$ in the dual category $\C^{\op}$ satisfies $P$.
+
+For example, the property [monomorphism](/morphism-property/monomorphism) is dual to [epimorphism](/morphism-property/epimorphism) since $f$ is an epimorphism if and only if $f^{\op}$ is a monomorphism.
+
+Notice that $(P^{\op})^{\op} = P$, and that $f$ satisfies $P$ if and only if $f^{\op}$ satisfies $P^{\op}$.

--- a/database/data/categories/FreeAb.yaml
+++ b/database/data/categories/FreeAb.yaml
@@ -37,8 +37,8 @@ satisfied_properties:
 
   - property: regular
     proof: |-
-      This follows formally from the fact that <a href="/category/Ab">$\Ab$</a> is regular and $\FreeAb$ is closed under subobjects and finite products: By Prop. 2.5 in the <a href="https://ncatlab.org/nlab/show/regular+category">nLab</a> it suffices to prove that there are pullback-stable (reg epi, mono)-factorizations. Every homomorphism $f : A \to B$ in $\FreeAb$ factors as $f = i \circ p : A \twoheadrightarrow C \hookrightarrow B$, where $C$ is a subgroup, hence free, and $A \to C$ is surjective. Clearly, surjective homomorphisms are pullback-stable. It remains to show that they coincide with the regular epimorphisms.
-      (1) If $f : A \to B$ is surjective, it is the coequalizer of $A \times_B A \rightrightarrows A$ in $\Ab$. Since $A \times_B A$ is free abelian, $f$ is also a coequalizer in $\FreeAb$.
+      This follows formally from the fact that <a href="/category/Ab">$\Ab$</a> is regular and $\FreeAb$ is closed under subobjects and finite products: By Prop. 2.5 in the <a href="https://ncatlab.org/nlab/show/regular+category">nLab</a> it suffices to prove that there are pullback-stable (reg epi, mono)-factorizations. Every homomorphism $f : A \to B$ in $\FreeAb$ factors as $f = i \circ p : A \twoheadrightarrow C \hookrightarrow B$, where $C$ is a subgroup of $B$, hence free abelian, and $A \to C$ is surjective. Clearly, surjective homomorphisms are pullback-stable. It remains to show that they coincide with the regular epimorphisms.
+      (1) If $f : A \to B$ is surjective, it is the coequalizer of $A \times_B A \rightrightarrows A$ in $\Ab$. Since $A \times_B A$ is free abelian (as a subgroup of $A \times A$), $f$ is also a coequalizer in $\FreeAb$.
       (2) If $f : A \to B$ is a regular epimorphism in $\FreeAb$, consider the factorization $f = i \circ p$ as above. Since $f$ is an extremal epimorphism, $i$ must be an isomorphism, so that $f$ is surjective.
 
 unsatisfied_properties:
@@ -79,5 +79,11 @@ special_morphisms:
     description: injective homomorphisms
     proof: 'Let $f : A \to B$ be a monomorphism of free abelian groups. Let $a \in A$ be in the kernel of $a$. Then we may view $a$ as a morphism $a : \IZ \to A$ with $f \circ a = 0$, and $\IZ$ is free. Hence, $a = 0$.'
   epimorphisms:
-    description: 'homomorphisms $f : A \to B$ with the property that $f(A)$ is not contained in a proper direct summand of $B$.'
+    description: 'homomorphisms $f : A \to B$ with the property that $f(A)$ is not contained in a proper direct summand of $B$'
     proof: 'Let $f : A \to B$ be a morphism of free abelian groups such that $f(A)$ is not contained in a proper direct summand of $B$. Then $f$ is an epimorphism: If $t : B \to C$ is a morphism with $t \circ f = 0$, we want to show $t = 0$. Since the image of $t$ is free abelian (as a subgroup of $B$), we may assume that $t$ is surjective. Since $C$ is free, $t$ splits, so its kernel $K$ is a direct summand of $B$ (Splitting Lemma). It contains $f(A)$ because of $t \circ f = 0$. By assumption, $K = B$, so that $t = 0$. Conversely, assume that $f : A \to B$ is an epimorphism, and that $f(A)$ is contained in a direct summand $K$ of $B$. Let $L$ be a complement of $B$ (which is free abelian) and let $p : B \to L$ be the projection. Then $t \circ f = 0$, so $t = 0$. But then $L = 0$, which means $K = B$.'
+  regular monomorphisms:
+    description: 'injective homomorphisms $f : A \to B$ with the property that $B/f(A)$ is free abelian'
+    proof: 'If $f$ is injective and $B/f(A)$ is free abelian, then $f$ is a kernel of the projection $B \to B/f(A)$. Conversely, if $f$ is a kernel of some homomorphism $g : B \to C$ of free abelian groups, by applying $\Hom(\IZ,-)$ we see that it is also the kernel in $\Ab$. In particular, $f$ is injective, and the quotient $B/f(A)$ embeds into $C$ and is therefore free abelian.'
+  regular epimorphisms:
+    description: surjective homomorphisms
+    proof: See the proof above that $\FreeAb$ is regular.

--- a/database/data/categories/walking_fork.yaml
+++ b/database/data/categories/walking_fork.yaml
@@ -6,7 +6,7 @@ morphisms: 'one morphism $i : 0 \to 1$, two morphisms $f,g : 1 \rightrightarrows
 description: >-
   This category can be pictured as:
   $$\{0 \to 1 \rightrightarrows 2\}$$
-  Its name comes from the fact that a functor $\Fork \to \C$ is the same as a <a href="https://ncatlab.org/nlab/show/fork" target="_blank">fork</a> in $\C$.
+  Its name comes from the fact that a functor $\Fork \to \C$ is the same as a <a href="https://ncatlab.org/nlab/show/fork" target="_blank">fork</a> in $\C$. It can also be realized as the category of ordered sets of cardinality $\leq 2$ with injective order-preserving maps.
 nlab_link: null
 tags:
   - category theory

--- a/database/data/morphism-implications/mono-epi-iso.yaml
+++ b/database/data/morphism-implications/mono-epi-iso.yaml
@@ -3,6 +3,7 @@
     - isomorphism
   conclusions:
     - split monomorphism
+    - effective monomorphism
   proof: This is trivial.
   is_equivalence: false
 
@@ -56,11 +57,51 @@
   proof: This is the definition of a mono-regular category.
   is_equivalence: false
 
-- id: regular_epi_and_mono_is_iso
+- id: strict_epi_and_mono_is_iso
   assumptions:
-    - regular epimorphism
+    - strict epimorphism
     - monomorphism
   conclusions:
     - isomorphism
-  proof: 'If $p : A \to B$ is the coequalizer of $f,g : C \rightrightarrows A$, then $p \circ f = p \circ g$. If $p$ is also a monomorphism, this implies $f = g$. But then $\id_B$ is a coequalizer of $f,g$, so that $p$ is an isomorphism.'
+  proof: 'Assume that $p : A \to B$ is a strict epimorphism and a monomorphism. Then $p$ is the joint coequalizer of all pairs $g,h : C \rightrightarrows A$ with $p \circ g = p \circ h$, which simplifies to $g = h$. Thus, any morphism $A \to T$ automatically coequalizes these pairs and therefore factors uniquely through $p$. This shows that $p$ is an isomorphism.'
+  is_equivalence: false
+
+- id: strict_mono_is_mono
+  assumptions:
+    - strict monomorphism
+  conclusions:
+    - monomorphism
+  proof: This is trivial.
+  is_equivalence: false
+
+- id: regular_mono_is_strict
+  assumptions:
+    - regular monomorphism
+  conclusions:
+    - strict monomorphism
+  proof: 'Let $m : A \to B$ be the equalizer of $g,h : B \rightrightarrows C$. In particular, $m$ is a monomorphism. Let $t : T \to B$ be a monomorphism which equalizes all pairs that are equalized by $m$. In particular, $t$ equalizes $g,h$, i.e. $g \circ t = h \circ t$. By definition of an equalizer, this means that $t$ factors through $m$.'
+  is_equivalence: false
+
+- id: effective_mono_implies_regular_mono
+  assumptions:
+    - effective monomorphism
+  conclusions:
+    - regular monomorphism
+  proof: This is trivial.
+  is_equivalence: false
+
+- id: strict_monos_are_often_effective
+  assumptions:
+    - strict monomorphism
+  mapped_assumptions:
+    category:
+      - pushouts
+  conclusions:
+    - effective monomorphism
+  proof: >-
+    Let $m : A \to B$ be a strict monomorphism in a category with pushouts. In particular, the pushout $B \sqcup_A B$ exists (and actually, we only need this pushout) with coprojections $i_1,i_2 : B \rightrightarrows B \sqcup_A B$ satisfying $i_1 \circ m = i_2 \circ m$.
+    To show that $m$ is the equalizer of $i_1,i_2$, let $t : T \to B$ be a morphism with $i_1 \circ t = i_2 \circ t$. If $g,h : B \rightrightarrows C$ is any parallel pair with $g \circ m = h \circ m$, it induces a morphism $(g;h) : B \sqcup_A B \to C$ with $(g;h) \circ i_1 = g$ and $(g;h) \circ i_2 = h$.
+    By composing these equations with $t$, we get
+    $$g \circ t = (g;h) \circ i_1 \circ t = (g;h) \circ i_2 \circ t = h \circ t.$$
+    Thus, $t$ equalizes every parallel pair that is equalized by $m$. Since $m$ is a strict monomorphism, $t$ factors through $m$.
   is_equivalence: false

--- a/database/data/morphism-properties/effective epimorphism.yaml
+++ b/database/data/morphism-properties/effective epimorphism.yaml
@@ -1,0 +1,15 @@
+id: effective epimorphism
+relation: is an
+description: >-
+  A morphism $p : A \to B$ is an <i>effective epimorphism</i> if the pullback $A \times_B A$ exists and $p$ is the coequalizer of the two projections $p_1,p_2 : A \times_B A \rightrightarrows A$.
+
+  By the implications below, effective epimorphisms are closely related to strict and regular epimorphisms. Every effective epimorphism is regular and hence strict, and in a category with pullbacks, every strict epimorphism is effective. Thus, in categories with pullbacks, all three mentioned classes of epimorphisms coincide.
+nlab_link: https://ncatlab.org/nlab/show/effective+epimorphism
+invariant_under_equivalences: true
+dual: effective monomorphism
+related:
+  - regular epimorphism
+  - strict epimorphism
+
+tags:
+  - types of epimorphisms

--- a/database/data/morphism-properties/effective monomorphism.yaml
+++ b/database/data/morphism-properties/effective monomorphism.yaml
@@ -1,0 +1,15 @@
+id: effective monomorphism
+relation: is an
+description: >-
+  A morphism $m : A \to B$ is an <i>effective monomorphism</i> if the pushout $B \sqcup_A B$ exists and $m$ is the equalizer of the two coprojections $i_1,i_2 : B \rightrightarrows B \sqcup_A B$.
+
+  By the implications below, effective monomorphisms are closely related to strict and regular monomorphisms. Every effective monomorphism is regular and hence strict, and in a category with pushouts, every strict monomorphism is effective. Thus, in categories with pushouts, all three mentioned classes of monomorphisms coincide.
+nlab_link: https://ncatlab.org/nlab/show/effective+monomorphism
+invariant_under_equivalences: true
+dual: effective epimorphism
+related:
+  - regular monomorphism
+  - strict monomorphism
+
+tags:
+  - types of monomorphisms

--- a/database/data/morphism-properties/regular epimorphism.yaml
+++ b/database/data/morphism-properties/regular epimorphism.yaml
@@ -6,6 +6,8 @@ invariant_under_equivalences: true
 dual: regular monomorphism
 related:
   - epimorphism
+  - effective epimorphism
+  - strict epimorphism
 
 tags:
   - types of epimorphisms

--- a/database/data/morphism-properties/regular monomorphism.yaml
+++ b/database/data/morphism-properties/regular monomorphism.yaml
@@ -6,6 +6,8 @@ invariant_under_equivalences: true
 dual: regular epimorphism
 related:
   - monomorphism
+  - effective monomorphism
+  - strict monomorphism
 
 tags:
   - types of monomorphisms

--- a/database/data/morphism-properties/strict epimorphism.yaml
+++ b/database/data/morphism-properties/strict epimorphism.yaml
@@ -1,0 +1,15 @@
+id: strict epimorphism
+relation: is a
+description: >-
+  A morphism $p : A \to B$ is a <i>strict epimorphism</i> if it is the joint coequalizer of all pairs of morphisms $g,h : C \rightrightarrows A$ that it coequalizes. That is, $p$ is an epimorphism, and a morphism $t : A \to T$ factors through $p$ if we have $t \circ g = t \circ h$ for all morphisms $g,h : C \rightrightarrows A$ that satisfy $p \circ g = p \circ h$. That is, the minimal requirement for a morphism to factor through $p$ is actually sufficient.
+
+  By the implications below, strict epimorphisms are closely related to effective and regular epimorphisms. Every effective epimorphism is regular and hence strict, and in a category with pullbacks, every strict epimorphism is effective. Thus, in categories with pullbacks, all three mentioned classes of epimorphisms coincide.
+nlab_link: https://ncatlab.org/nlab/show/strict+epimorphism
+invariant_under_equivalences: true
+dual: strict monomorphism
+related:
+  - regular epimorphism
+  - effective epimorphism
+
+tags:
+  - types of epimorphisms

--- a/database/data/morphism-properties/strict monomorphism.yaml
+++ b/database/data/morphism-properties/strict monomorphism.yaml
@@ -1,0 +1,15 @@
+id: strict monomorphism
+relation: is a
+description: >-
+  A morphism $m : A \to B$ is a <i>strict monomorphism</i> if it is the joint equalizer of all pairs of morphisms $g,h : B \rightrightarrows C$ that it equalizes. That is, $m$ is a monomorphism, and a morphism $t : T \to B$ factors through $m$ if we have $g \circ t = h \circ t$ for all morphisms $g,h : B \rightrightarrows C$ that satisfy $g \circ m = h \circ m$. That is, the minimal requirement for a morphism to factor through $m$ is actually sufficient.
+
+  By the implications below, strict monomorphisms are closely related to effective and regular monomorphisms. Every effective monomorphism is regular and hence strict, and in a category with pushouts, every strict monomorphism is effective. Thus, in categories with pushouts, all three mentioned classes of monomorphisms coincide.
+nlab_link: https://ncatlab.org/nlab/show/strict+monomorphism
+invariant_under_equivalences: true
+dual: strict epimorphism
+related:
+  - regular monomorphism
+  - effective monomorphism
+
+tags:
+  - types of monomorphisms

--- a/database/data/morphisms/baer-specker-relations.yaml
+++ b/database/data/morphisms/baer-specker-relations.yaml
@@ -1,0 +1,19 @@
+id: baer-specker-relations
+name: Baer-Specker relations
+notation: $m$
+category: FreeAb
+description: 'Consider the Baer-Specker group $\IZ^\IN$ and choose a free abelian group $F$ with an epimorphism $\pi : F \to \IZ^\IN$ (for example, to make this example explicit, the free abelian group on the underlying set of $\IZ^\IN$). Let $K \subseteq F$ be its kernel (which is also free abelian). In this entry, we consider the inclusion $m : K \hookrightarrow F$. It provides an example of a strict monomorphism which is not regular.'
+nlab_link: null
+
+tags:
+  - algebra
+
+related: []
+
+satisfied_properties:
+  - property: strict monomorphism
+    proof: 'Since $m$ is an injective homomorphism, it is a monomorphism. Now let $t : T \to F$ be a homomorphism which equalizes all pairs in $\FreeAb$ that are equalized by $m$. If $p_n : \IZ^\IN \to \IZ$ denotes the $n$th projection, we have $p_n \circ \pi \circ m = 0$, so that $p_n \circ \pi, 0 : F \rightrightarrows \IZ$ is a pair that is equalized by $m$. Hence, we get $p_n \circ \pi \circ t = 0$. Since this holds for all $n$, we conclude $\pi \circ t = 0$, which means that $t$ factors through $m$.'
+
+unsatisfied_properties:
+  - property: regular monomorphism
+    proof: 'We know that a monomorphism $f : A \to B$ in <a href="/category/FreeAb">$\FreeAb$</a> is regular if and only if the quotient (taken in $\Ab$) $B/f(A)$ is free abelian. But $F/K \cong \IZ^\IN$ is the Baer-Specker group, which is not free abelian.'

--- a/database/data/morphisms/fork-handle.yaml
+++ b/database/data/morphisms/fork-handle.yaml
@@ -1,0 +1,22 @@
+id: fork-handle
+name: handle of the universal fork
+notation: $i$
+category: walking_fork
+description: 'This is the morphism $i : 0 \to 1$ from the <a href="/category/walking_fork">walking fork</a>, see details there. It provides an example of a regular monomorphism which is neither split nor effective.'
+nlab_link: null
+
+tags:
+  - category theory
+
+related: []
+
+satisfied_properties:
+  - property: regular monomorphism
+    proof: 'In fact, $i$ is the equalizer of the other two morphisms $f,g : 1 \rightrightarrows 2$.'
+
+unsatisfied_properties:
+  - property: split monomorphism
+    proof: There is no morphism $1 \to 0$.
+
+  - property: effective monomorphism
+    proof: 'If $i$ were effective, the pushout $1 \sqcup_0 1$ would exist, which is the coproduct $1 \sqcup 1$ since $0$ is initial. Since there are two morphisms $1 \to 2$, there are four morphisms $1 \sqcup 1 \to 2$. But none of the objects $0,1,2$ of the walking fork has four morphisms to $2$.'

--- a/database/data/morphisms/universal-split-epi.yaml
+++ b/database/data/morphisms/universal-split-epi.yaml
@@ -1,0 +1,19 @@
+id: universal-split-epi
+name: universal split epimorphism
+notation: $p$
+category: walking_splitting
+description: 'This is the morphism $p : 1 \to 0$ in the <a href="/category/walking_splitting">walking splitting</a>, see there for details. It can also be seen as the unique morphism $\IF_2 \to 0$ in the category of $\IF_2$-vector spaces of dimension $\leq 1$. It provides a basic example of a split epimorphism (and hence regular and strict epimorphism) which is not effective.'
+nlab_link: null
+
+tags:
+  - category theory
+
+related: []
+
+satisfied_properties:
+  - property: split epimorphism
+    proof: 'We have $p \circ i = \id_0$ for the other morphism $i : 0 \to 1$ in the category.'
+
+unsatisfied_properties:
+  - property: effective epimorphism
+    proof: If $p$ were effective, the pullback $1 \times_0 1$ would exist, which is the product $1 \times 1$ since $0$ is terminal. Each hom-set in the walking splitting has $\leq 2$ elements, but $\Hom(1, 1 \times 1) \cong \Hom(1,1)^2$ would have four elements.

--- a/src/pages/SearchResultsPage.svelte
+++ b/src/pages/SearchResultsPage.svelte
@@ -89,7 +89,10 @@
 	<p class="hint">
 		{pluralize(found_structures.length, {
 			one: `Found {count} ${type}`,
-			other: `Found {count} ${PLURALS[type]}`
+			other:
+				found_structures.length === 0
+					? `Found {count} ${PLURALS[type]}. Try to dualize the search.`
+					: `Found {count} ${PLURALS[type]}`
 		})}
 	</p>
 


### PR DESCRIPTION
This PR implements parts of #267 by adding

- effective epimorphisms
- strict epimorphisms
- effective monomorphisms
- strict monomorphisms

along with basic results about them:

- strict mono + epi ===> iso
- strict mono ===> mono
- effective mono ===> regular mono
- regular mono ===> strict mono
- strict mono ===> effective mono **in categories with pushouts**

As usual, these results are dualized automatically.

Moreover, counterexamples have been added:

- the universal split epimorphism as an example of a split epimorphism (which is hence regular and strict) that is not effective
- the "handle" of the universal fork as an example of a regular monomorphism that is neither split nor effective
- the inclusion of the Baer–Specker relations in **FreeAb** as an example of a strict monomorphism that is not regular

For the last example, the regular monomorphisms and regular epimorphisms in **FreeAb** have also been classified; this information was previously missing from the category detail page.

As a result, the page on missing data `/missing` does not list any missing consistent combinations for morphisms of the form p ∧ ¬q. It would also be interesting to check for missing consistent combinations of the forms p ∧ ¬q ∧ ¬r and p ∧ q ∧ ¬r (at least for properties of functors and morphisms; for properties of categories there would be *thousands*). This can be done in a separate PR.