### PR TITLE
Add various end-to-end tests for morphisms

### DIFF
--- a/tests/missing.spec.ts
+++ b/tests/missing.spec.ts
@@ -66,6 +66,25 @@ test('user can see no functors with missing data', async ({ page }) => {
 	await expect(functors_section.getByRole('link')).toHaveCount(0)
 })
 
+// this can be adjusted if at some point in the future a morphism
+// is not fully understood anymore
+test('user can see no morphisms with missing data', async ({ page }) => {
+	await page.goto('/missing', { waitUntil: 'networkidle' })
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Missing data',
+			exact: true
+		})
+	).toBeVisible()
+
+	const morphisms_section = page.locator('section', {
+		hasText: 'Morphisms with unknown properties'
+	})
+
+	await expect(morphisms_section.getByRole('link')).toHaveCount(0)
+})
+
 test('user can see missing category combinations', async ({ page }) => {
 	await page.goto('/missing', { waitUntil: 'networkidle' })
 

--- a/tests/morphism-implications.spec.ts
+++ b/tests/morphism-implications.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test'
+
+test('user can navigate to a morphism implication', async ({ page }) => {
+	await page.goto('/morphism-list')
+
+	const nav = page.getByRole('navigation')
+	await expect(nav).toBeVisible()
+
+	await nav
+		.getByRole('link', {
+			name: 'Implications',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Morphism implications',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism-implications')
+
+	const item = page.locator('li', {
+		hasText: /split monomorphism.+regular monomorphism/
+	})
+
+	await expect(item).toBeVisible()
+
+	await item.getByRole('link', { name: 'details' }).click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Implication Details',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism-implication/split_mono_is_regular_mono')
+})
+
+test('user can see the details of an implication', async ({ page }) => {
+	await page.goto('/morphism-implication/split_mono_is_regular_mono')
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Implication Details',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'split monomorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'regular monomorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page.getByText('Proof: Let')).toBeVisible()
+})
+
+test('user can open the list of deduced implications', async ({ page }) => {
+	await page.goto('/morphism-implications', { waitUntil: 'networkidle' })
+
+	await expect(
+		page.locator('li', { hasText: /normal monomorphism.+regular monomorphism/ })
+	).toBeVisible()
+
+	await expect(
+		page.locator('li', { hasText: /normal epimorphism.+regular epimorphism/ })
+	).toHaveCount(0)
+
+	await page
+		.getByRole('button', {
+			name: 'Show deduced implications',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.locator('li', { hasText: /normal epimorphism.+regular epimorphism/ })
+	).toBeVisible()
+})

--- a/tests/morphism-properties.spec.ts
+++ b/tests/morphism-properties.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test'
+
+test('user can navigate to a morphism property', async ({ page }) => {
+	await page.goto('/morphism-list')
+
+	const nav = page.getByRole('navigation')
+	await expect(nav).toBeVisible()
+
+	await nav
+		.getByRole('link', {
+			name: 'Properties',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Properties of morphisms',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism-properties')
+
+	await page
+		.getByRole('link', {
+			name: 'effective epimorphism',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'effective epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism-property/effective_epimorphism')
+})
+
+test('user can view morphism property details', async ({ page }) => {
+	await page.goto('/morphism-property/effective_epimorphism')
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'effective epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page.getByText('is an effective epimorphism if')).toBeVisible()
+
+	await expect(
+		page
+			.getByRole('link', {
+				name: 'regular epimorphism',
+				exact: true
+			})
+			.first()
+	).toBeVisible()
+
+	const examples = page
+		.getByRole('heading', {
+			name: 'Examples',
+			exact: true
+		})
+		.locator('xpath=following-sibling::ul[1]')
+
+	await expect(
+		examples.getByRole('link', {
+			name: 'identity map of a group',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		examples.getByRole('link', {
+			name: 'reduction modulo p',
+			exact: true
+		})
+	).toBeVisible()
+
+	const counterexamples = page
+		.getByRole('heading', {
+			name: 'Counterexamples',
+			exact: true
+		})
+		.locator('xpath=following-sibling::ul[1]')
+
+	await expect(
+		counterexamples.getByRole('link', {
+			name: 'embedding of A3 into S3',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		counterexamples.getByRole('link', {
+			name: 'universal split epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test('user can navigate to the dual property', async ({ page }) => {
+	await page.goto('/morphism-property/strict_epimorphism')
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'strict epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	const item = page.locator('li', {
+		hasText: 'Dual property'
+	})
+
+	await item
+		.getByRole('link', {
+			name: 'strict monomorphism',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'strict monomorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism-property/strict_monomorphism')
+})
+
+test('user sees no unknown morphisms for the property of being an isomorphism', async ({
+	page
+}) => {
+	await page.goto('/morphism-property/isomorphism')
+	await expect(
+		page.getByText(
+			'There are 0 morphisms for which the database has no information on whether they satisfy this property'
+		)
+	).toBeVisible()
+})
+
+test("user can navigate to properties tagged with 'types of epimorphism' from the property list page", async ({
+	page
+}) => {
+	await page.goto('/morphism-properties', { waitUntil: 'networkidle' })
+
+	await page
+		.getByRole('button', {
+			name: 'types of epimorphisms',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: "Properties of morphisms tagged with 'types of epimorphisms'",
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'regular epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test("user can navigate to properties tagged with 'types of monomorphisms' from the property detail page", async ({
+	page
+}) => {
+	await page.goto('/morphism-property/regular_monomorphism', {
+		waitUntil: 'networkidle'
+	})
+
+	await page
+		.getByRole('button', {
+			name: 'types of monomorphisms',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: "Properties of morphisms tagged with 'types of monomorphisms'",
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'split monomorphism',
+			exact: true
+		})
+	).toBeVisible()
+})

--- a/tests/morphism-search.spec.ts
+++ b/tests/morphism-search.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect } from '@playwright/test'
+
+const encoded_delimiter = '%7E'
+
+test('user can navigate to the search page', async ({ page }) => {
+	await page.goto('/morphism-list')
+
+	const nav = page.getByRole('navigation')
+	await expect(nav).toBeVisible()
+
+	await nav
+		.getByRole('link', {
+			name: 'Search',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Property combo search',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism-search')
+})
+
+test('user can enter properties', async ({ page }) => {
+	await page.goto('/morphism-search')
+
+	const satisfied_input_field = page.getByRole('textbox', {
+		name: 'Satisfied property',
+		exact: true
+	})
+
+	for (const p of ['monomorphism', 'epimorphism']) {
+		await expect(satisfied_input_field).toHaveValue('')
+
+		await satisfied_input_field.fill(p)
+		await satisfied_input_field.focus()
+		await page.waitForTimeout(500)
+		await satisfied_input_field.press('Enter')
+
+		await expect(page.getByRole('button', { name: p, exact: true })).toBeVisible()
+
+		await expect(satisfied_input_field).toHaveValue('')
+	}
+
+	const unsatisfied_input_field = page.getByRole('textbox', {
+		name: 'Unsatisfied property',
+		exact: true
+	})
+
+	for (const q of ['isomorphism']) {
+		await expect(unsatisfied_input_field).toHaveValue('')
+
+		await unsatisfied_input_field.fill(q)
+		await unsatisfied_input_field.focus()
+		await page.waitForTimeout(500)
+		await unsatisfied_input_field.press('Enter')
+
+		await expect(page.getByRole('button', { name: q, exact: true })).toBeVisible()
+
+		await expect(unsatisfied_input_field).toHaveValue('')
+	}
+
+	await page
+		.getByRole('button', {
+			name: 'Search',
+			exact: true
+		})
+		.click()
+
+	await expect(page).toHaveURL(
+		`/morphism-search/results?satisfied=monomorphism${encoded_delimiter}epimorphism&unsatisfied=isomorphism`
+	)
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Search results',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test('user can view search results', async ({ page }) => {
+	await page.goto(
+		`/morphism-search/results?satisfied=monomorphism${encoded_delimiter}epimorphism&unsatisfied=isomorphism`
+	)
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Search results',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'monomorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'isomorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'embedding of integer into rational numbers',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test('user can dualize search', async ({ page }) => {
+	const url =
+		'/morphism-search/results?satisfied=regular_epimorphism&unsatisfied=monomorphism'
+	const dual_url =
+		'/morphism-search/results?satisfied=regular_monomorphism&unsatisfied=epimorphism'
+
+	await page.goto(url, { waitUntil: 'networkidle' })
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Search results',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'regular epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'reduction modulo p',
+			exact: true
+		})
+	).toBeVisible()
+
+	const dualize_link = page.getByRole('link', {
+		name: 'Dualize search',
+		exact: true
+	})
+
+	await expect(dualize_link).toBeVisible()
+	expect(await dualize_link.getAttribute('href')).toContain(dual_url)
+
+	await dualize_link.click()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'regular monomorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'map from the empty set',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test('contradictions are detected', async ({ page }) => {
+	await page.goto(
+		'/morphism-search/results?satisfied=regular_epimorphism~monomorphism&unsatisfied=split_epimorphism'
+	)
+
+	await expect(page.getByText('the requirements are inconsistent')).toBeVisible()
+
+	await expect(page.getByText('isomorphism ⟹ split epimorphism')).toBeVisible()
+})

--- a/tests/morphisms.spec.ts
+++ b/tests/morphisms.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from '@playwright/test'
+
+test('user can navigate to a morphism', async ({ page }) => {
+	await page.goto('/morphism-list')
+
+	await page
+		.getByRole('link', {
+			name: 'universal split epimorphism',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'universal split epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism/universal-split-epi')
+})
+
+test("user can navigate to morphisms tagged with 'algebra' from the morphism list page", async ({
+	page
+}) => {
+	await page.goto('/morphism-list', { waitUntil: 'networkidle' })
+
+	await page
+		.getByRole('button', {
+			name: 'algebra',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: "Morphisms tagged with 'algebra'",
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'embedding of integer into rational numbers',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test("user can navigate to morphisms tagged with 'set theory' from the morphism detail page", async ({
+	page
+}) => {
+	await page.goto('/morphism/id_X', { waitUntil: 'networkidle' })
+
+	await page
+		.getByRole('button', {
+			name: 'set theory',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: "Morphisms tagged with 'set theory'",
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(
+		page.getByRole('link', {
+			name: 'map into the singleton set',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test('user can view morphism details', async ({ page }) => {
+	await page.goto('/morphism/universal-split-epi')
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'universal split epimorphism',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page.getByText('basic example of a split epimorphism')).toBeVisible()
+	await expect(page.getByText('is a split epimorphism')).toBeVisible()
+	await expect(page.getByText('is a regular epimorphism')).toBeVisible()
+	await expect(page.getByText('is not an effective epimorphism')).toBeVisible()
+	await expect(page.getByText('is not an isomorphism')).toBeVisible()
+})
+
+test('user sees no unknown properties for a basic map', async ({ page }) => {
+	await page.goto('/morphism/terminal-map')
+
+	const unknown_properties_section = page.locator('section', {
+		hasText: 'Unknown properties'
+	})
+	await expect(unknown_properties_section.locator('li')).toHaveCount(0)
+})
+
+test('user can navigate to a related morphism', async ({ page }) => {
+	await page.goto('/morphism/id_X', { waitUntil: 'networkidle' })
+
+	await page
+		.getByRole('link', {
+			name: 'identity map of a group',
+			exact: true
+		})
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'identity map of a group',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/morphism/id_G')
+})
+
+test('user can navigate to the ambient category', async ({ page }) => {
+	await page.goto('/morphism/fork-handle', { waitUntil: 'networkidle' })
+
+	await page
+		.getByRole('link', {
+			name: 'walking fork',
+			exact: true
+		})
+		.first()
+		.click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'walking fork',
+			exact: true
+		})
+	).toBeVisible()
+
+	await expect(page).toHaveURL('/category/walking_fork')
+})
+
+test('user can open and close a proof for a property of a morphism', async ({ page }) => {
+	await page.goto('/morphism/A3-S3-embedding', { waitUntil: 'networkidle' })
+
+	const claim = page.locator('li', { has: page.getByText('is a normal monomorphism') })
+
+	await expect(claim).toBeVisible()
+
+	await claim.locator('button').click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Proof',
+			exact: true
+		})
+	).toBeVisible()
+
+	const popup = page.locator('.popup').filter({ hasText: 'Proof' })
+
+	const text = (await popup.textContent())?.trim() ?? ''
+
+	const proof_text = text.replace(/^Proof/, '').trim()
+
+	expect(proof_text).toContain('normal subgroup')
+
+	await popup.getByRole('button', { name: 'close' }).click()
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'Proof',
+			exact: true
+		})
+	).not.toBeVisible()
+})
+
+test('user can open a proof for a deduced satisfied property of a morphism', async ({
+	page
+}) => {
+	await page.goto('/morphism/terminal-map', { waitUntil: 'networkidle' })
+
+	const claim = page.locator('li', { has: page.getByText('is a strict epimorphism') })
+
+	await expect(claim).toBeVisible()
+
+	await claim.locator('button').click()
+
+	const popup = page.locator('.popup').filter({ hasText: 'Proof' })
+
+	await expect(
+		popup.getByText('Since it is a regular epimorphism, it is a strict epimorphism')
+	).toBeVisible()
+})
+
+test('user can open a proof for a deduced unsatisfied property of a morphism', async ({
+	page
+}) => {
+	await page.goto('/morphism/multiply-2', { waitUntil: 'networkidle' })
+
+	const claim = page.locator('li', {
+		has: page.getByText('is not a regular monomorphism')
+	})
+
+	await expect(claim).toBeVisible()
+
+	await claim.locator('button').click()
+
+	const popup = page.locator('.popup').filter({ hasText: 'Proof' })
+
+	await expect(
+		popup.getByText('Assume for contradiction that it is a regular monomorphism.')
+	).toBeVisible()
+})

--- a/tests/structure_selector.spec.ts
+++ b/tests/structure_selector.spec.ts
@@ -52,3 +52,42 @@ test('functors are selected on a functor route', async ({ page }) => {
 	await expect(selector).toBeVisible()
 	await expect(selector).toHaveValue('functor')
 })
+
+test('user can switch to morphisms', async ({ page }) => {
+	await page.goto('/', { waitUntil: 'networkidle' })
+
+	const selector = page
+		.getByRole('combobox', {
+			name: 'Structure',
+			exact: true
+		})
+		.first()
+
+	await expect(selector).toBeVisible()
+	await selector.selectOption('morphism')
+
+	await expect(selector).toHaveValue('morphism')
+
+	await expect(page).toHaveURL('/morphism-list')
+
+	await expect(
+		page.getByRole('heading', {
+			name: 'List of morphisms',
+			exact: true
+		})
+	).toBeVisible()
+})
+
+test('morphisms are selected on a morphism route', async ({ page }) => {
+	await page.goto('/morphism-properties')
+
+	const selector = page
+		.getByRole('combobox', {
+			name: 'Structure',
+			exact: true
+		})
+		.first()
+
+	await expect(selector).toBeVisible()
+	await expect(selector).toHaveValue('morphism')
+})


### PR DESCRIPTION
This PR is a continuation of #270 and #265. It adds the same set of end-to-end tests for morphisms that have already been written for categories and functors. There is one exception: I have omitted a test for the compare feature, since currently it does not make much sense for morphisms.