### PR TITLE
Remove authors from content pages

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -226,7 +226,6 @@
 		"morphisms",
 		"Multialgébriques",
 		"naturality",
-		"Nekoma",
 		"Neves",
 		"Niefield",
 		"nilradical",

--- a/content/Meas_not_regular.md
+++ b/content/Meas_not_regular.md
@@ -1,7 +1,6 @@
 ---
 title: The category of measurable spaces is not regular
 description: An example of a quotient measurable map is given whose product with itself is not a quotient map anymore.
-author: Nekoma
 ---
 
 ## $\Meas$ is not regular

--- a/content/Top-embeds-in-LRS.md
+++ b/content/Top-embeds-in-LRS.md
@@ -1,7 +1,6 @@
 ---
 title: An embedding of the category of topological spaces in the category of locally ringed spaces
 description: Describes a functor which makes the category of topological spaces a coreflective and "almost reflective" subcategory of the category of locally ringed spaces. From the properties of this embedding, we can rule out several properties for the category of locally ringed spaces, using the corresponding failures of these properties for the category of topological spaces.
-author: Daniel Schepler
 ---
 
 ## An embedding of the category of topological spaces in the category of locally ringed spaces

--- a/content/aleph1-cofiltered-limits-fg-groups.md
+++ b/content/aleph1-cofiltered-limits-fg-groups.md
@@ -1,7 +1,6 @@
 ---
 title: ℵ₁-cofiltered limits of finitely generated abelian groups
 description: The existence of these limits follows from a couple of reduction arguments.
-author: Martin Brandenburg
 ---
 
 ## ℵ₁-cofiltered limits of finitely generated abelian groups

--- a/content/aleph1-filtered-colimits-in-deloopings.md
+++ b/content/aleph1-filtered-colimits-in-deloopings.md
@@ -1,7 +1,6 @@
 ---
 title: ℵ₁-filtered colimits in deloopings
 description: We give a detailed proof that the delooping of the monoid of natural numbers, and likewise the delooping of the large monoid of ordinal numbers, has colimits indexed by ℵ₁-filtered categories.
-author: Martin Brandenburg
 ---
 
 # $\aleph_1$-filtered colimits in deloopings

--- a/content/cocongruences_of_groups.md
+++ b/content/cocongruences_of_groups.md
@@ -1,7 +1,6 @@
 ---
 title: Cocongruences on groups are effective
 description: This result will be proved more generally for categories in which pushouts and monomorphisms interact in a suitable way.
-author: Martin Brandenburg
 ---
 
 ## Cocongruences on groups are effective

--- a/content/comphaus_copresentable.md
+++ b/content/comphaus_copresentable.md
@@ -1,7 +1,6 @@
 ---
 title: Local ℵ₁-copresentability of the category of compact Hausdorff spaces
 description: We gather several relevant results about the category of compact Hausdorff spaces, and provide accessible proofs of these facts leading up to a proof that it is locally ℵ₁-copresentable.
-author: Daniel Schepler
 ---
 
 ## Local ℵ₁-copresentability of the category of compact Hausdorff spaces

--- a/content/congruences_in_rel.md
+++ b/content/congruences_in_rel.md
@@ -1,7 +1,6 @@
 ---
 title: A classification of congruences in the category of sets and relations
 description: The classification will prove in particular that the category of sets and relations has quotients of congruences and that congruences are effective.
-author: Daniel Schepler
 ---
 
 ## A classification of congruences in the category of sets and relations

--- a/content/coslice-effective-congruences.md
+++ b/content/coslice-effective-congruences.md
@@ -1,7 +1,6 @@
 ---
 title: Inheritance of effective congruences in coslice categories
 description: An extensive category has effective congruences when some of its coslice categories has effective congruences.
-author: Daniel Schepler
 ---
 
 ## Inheritance of effective congruences in coslice categories

--- a/content/effective-congruence-quotients.md
+++ b/content/effective-congruence-quotients.md
@@ -1,7 +1,6 @@
 ---
 title: Quotients of effective congruences are strict quotients
 description: Quotients by effective congruences are characterized via a pullback
-author: Daniel Schepler
 ---
 
 ## Quotients of effective congruences are strict quotients

--- a/content/foundations.md
+++ b/content/foundations.md
@@ -1,7 +1,6 @@
 ---
 title: Foundations
 description: How to make sense of categories in set theory
-author: Martin Brandenburg
 ---
 
 ## Foundations

--- a/content/functors_on_discrete_categories.md
+++ b/content/functors_on_discrete_categories.md
@@ -1,7 +1,6 @@
 ---
 title: Functors on discrete categories
 description: We describe which functors on discrete categories are continuous or cocontinuous.
-author: Martin Brandenburg
 ---
 
 ## Functors on discrete categories

--- a/content/generator_construction.md
+++ b/content/generator_construction.md
@@ -1,9 +1,6 @@
 ---
 title: Construction of Generators
 description: How to construct a generator from a generating set
-authors:
-    - Martin Brandenburg
-    - Daniel Schepler
 ---
 
 ## Construction of Generators

--- a/content/inclusion-functors.md
+++ b/content/inclusion-functors.md
@@ -1,7 +1,6 @@
 ---
 title: Inclusion functors
 description: We gather results about inclusion functors
-author: Martin Brandenburg
 ---
 
 # Inclusion functors

--- a/content/missing_cogenerating_sets.md
+++ b/content/missing_cogenerating_sets.md
@@ -1,7 +1,6 @@
 ---
 title: Missing cogenerating sets
 description: A generalization of the proof that the category of commutative rings has no cogenerating set.
-author: Martin Brandenburg
 ---
 
 ## Missing cogenerating sets

--- a/content/missing_cogenerator.md
+++ b/content/missing_cogenerator.md
@@ -1,7 +1,6 @@
 ---
 title: Missing cogenerator
 description: A generalization of the proof that the category of groups has no cogenerator.
-author: Martin Brandenburg
 ---
 
 ## Missing cogenerator

--- a/content/nno_distributive_criterion.md
+++ b/content/nno_distributive_criterion.md
@@ -1,7 +1,6 @@
 ---
 title: Natural number objects indicate distributivity
 description: A partial converse of the result that countably distributive categories have a NNO.
-author: Martin Brandenburg
 ---
 
 ## Natural number objects indicate distributivity

--- a/content/preadditive_structure_unique.md
+++ b/content/preadditive_structure_unique.md
@@ -1,7 +1,6 @@
 ---
 title: Uniqueness of preadditive structures
 description: In the presence of finite products, a preadditive structure on a given category is uniquely determined.
-author: Martin Brandenburg
 ---
 
 ## Uniqueness of preadditive structures

--- a/content/pushouts-of-monos-via-congruence-quotients.md
+++ b/content/pushouts-of-monos-via-congruence-quotients.md
@@ -1,7 +1,6 @@
 ---
 title: Construction of a pushout of monomorphisms as a quotient of a congruence
 description: An extensive category with quotients of congruences has pushouts of monomorphisms.
-author: Daniel Schepler
 ---
 
 ## Construction of a pushout of monomorphisms as a quotient of a congruence

--- a/content/sifted-colimits-in-groupoids.md
+++ b/content/sifted-colimits-in-groupoids.md
@@ -1,7 +1,6 @@
 ---
 title: Sifted colimits in groupoids
 description: A description of sifted colimits in groupoids, yielding a proof that every essentially small groupoid is a generalized variety.
-author: Martin Brandenburg
 ---
 
 ## Sifted colimits in groupoids

--- a/content/special_sequential_colimits.md
+++ b/content/special_sequential_colimits.md
@@ -1,7 +1,6 @@
 ---
 title: Finite structures usually have no sequential colimits
 description: A generalization of the proof that the category of finite groups has no filtered colimits.
-author: Martin Brandenburg
 ---
 
 ## Finite structures usually have no sequential colimits

--- a/content/subcategories.md
+++ b/content/subcategories.md
@@ -1,9 +1,6 @@
 ---
 title: Results on subcategories
 description: We prove that several properties of categories descend to suitable subcategories.
-authors:
-    - Martin Brandenburg
-    - Daniel Schepler
 ---
 
 ## Results on subcategories

--- a/content/thin_algebraic_categories.md
+++ b/content/thin_algebraic_categories.md
@@ -1,7 +1,6 @@
 ---
 title: Algebraic categories are "never" thin
 description: A proof that the only thin algebraic categories are the terminal and the interval category.
-author: Martin Brandenburg
 ---
 
 ## Algebraic categories are "never" thin

--- a/content/thin_extremal_generator.md
+++ b/content/thin_extremal_generator.md
@@ -1,7 +1,6 @@
 ---
 title: Thin Category with an Extremal Generator
 description: A result restricting which thin categories can have an extremal generator
-author: Daniel Schepler
 ---
 
 # Thin Category with an Extremal Generator

--- a/content/topos-with-generator.md
+++ b/content/topos-with-generator.md
@@ -1,7 +1,6 @@
 ---
 title: Topos with a Generator
 description: An elementary topos with a generator has at most two subterminal objects
-author: Daniel Schepler
 ---
 
 # Topos with a Generator

--- a/src/lib/server/markdown.ts
+++ b/src/lib/server/markdown.ts
@@ -145,8 +145,6 @@ function render_content<T = Record<string, unknown>>(
 type ContentMetaData = {
 	title: string
 	description: string
-	author?: string
-	authors?: string[]
 }
 
 /**

--- a/src/routes/content/[id]/+page.svelte
+++ b/src/routes/content/[id]/+page.svelte
@@ -13,12 +13,6 @@
 	{@html data.html}
 </div>
 
-{#if data.meta_data.author}
-	<p class="hint">Author: {data.meta_data.author}</p>
-{:else if data.meta_data.authors}
-	<p class="hint">Authors: {data.meta_data.authors.join(', ')}</p>
-{/if}
-
 <!-- TODO: make this more systematic -->
 
 {#if data.categories.length > 0 || data.category_properties.length > 0 || data.category_implications.length > 0 || data.functors.length > 0}


### PR DESCRIPTION
The authors have been removed from the content pages, resolving #307. The reasons are:

1. The Git history already shows who contributed which parts*.
2. Pages may be edited by multiple people over time.
3. There is an inconsistency with implications, which have no authors, even though some of them are equally non-trivial as some content pages.

*There is one exception: via the suggestion form, someone called *Nekoma* provided the proof that **Meas** is not regular. I then created a PR that added this proof to CatDat (#216, and https://github.com/ScriptRaccoon/CatDat/commit/74842d7da68904a0094214f2e00a109d31af59e4 converted this to a content page). Thus, *Nekoma* is not automatically visible in the Git history. However, I mentioned *Nekoma* in the commit message, and this should always be done when someone has provided a proof via the submission form or through any other contact channel.