### PR TITLE
The category of measurable spaces is regular, and not coaccessible

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -323,6 +323,7 @@
 		"Vincenzo",
 		"Vite",
 		"Wedderburn",
+		"Wengenroth",
 		"well-copowered",
 		"Yoneda",
 		"Zulip"

--- a/database/data/categories/CMon.yaml
+++ b/database/data/categories/CMon.yaml
@@ -69,4 +69,4 @@ special_objects:
 special_morphisms:
   epimorphisms:
     description: A morphism in $\CMon$ is an epimorphism iff it is an epimorphism in $\Mon$, which in turn can be characterized by <a href="https://en.wikipedia.org/wiki/Isbell's_zigzag_theorem" target="_blank">Isbell's zigzag theorem</a>.
-    proof: 'If $f : M \to N$ is a homomorphism of commutative monoids which is an epimorphism in $\Mon$, then it is trivially also an epimorphism in $\CMon$. The converse requires a proof, which can be found at <a href="https://math.stackexchange.com/a/5133596/1650">MSE/5133488</a>.'
+    proof: 'If $f : M \to N$ is a homomorphism of commutative monoids which is an epimorphism in $\Mon$, then it is trivially also an epimorphism in $\CMon$. The converse requires a proof, which can be found at <a href="https://math.stackexchange.com/a/5133596">MSE/5133488</a>.'

--- a/database/data/categories/Man.yaml
+++ b/database/data/categories/Man.yaml
@@ -85,7 +85,7 @@ unsatisfied_properties:
     proof: If $\Man$ had sequential colimits, then by <a href="/content/special_sequential_colimits">this lemma</a> there would be a manifold $M$ that admits a split epimorphism $M \to \IR^n$ for every $n$. But then $M$ will have an infinite-dimensional tangent space, which is a contradiction.
 
   - property: ℵ₂-small copowers
-    proof: A proof can be found at <a href="https://math.stackexchange.com/a/5083683/1650" target="_blank">MSE/5083641</a> (ignore the arguments regarding equal dimension).
+    proof: A proof can be found at <a href="https://math.stackexchange.com/a/5083683" target="_blank">MSE/5083641</a> (ignore the arguments regarding equal dimension).
 
   - property: ℵ₁-cofiltered limits
     proof: >-

--- a/database/data/categories/Meas.yaml
+++ b/database/data/categories/Meas.yaml
@@ -94,6 +94,9 @@ unsatisfied_properties:
 
       Next, consider the collection of all subsets $E \subseteq X \times X$ with the property that, whenever $x \sim y$, we have $(x,y) \in E \iff (x,x) \in E$. It is easily seen that this collection is a $\sigma$-algebra on $X \times X$. Moreover, it contains each rectangle $A_n \times B_n$. Therefore, it also contains the diagonal $\Delta$. But this means that $x \sim y$ implies $x=y$, i.e. that $\sim$ is trivial. This contradiction proves that the diagonal is not measurable.
 
+  - property: coaccessible
+    proof: 'The proof is very similar to the proof for <a href="/category/Top">$\Top$</a>. Assume $\Meas$ is coaccessible. Let $p : D \to I$ be the identity map from the two-element discrete space to the two-element indiscrete space. Then, a measurable space is discrete if and only if it is projective to the morphism $p$. This implies that the full subcategory spanned by all discrete measurable spaces, which is equivalent to $\Set$, is coaccessible by Prop. 4.7 in <a href="https://ncatlab.org/nlab/show/Locally+Presentable+and+Accessible+Categories" target="_blank">Adamek-Rosicky</a>. However, since <a href="/category/Set">$\Set$</a> is not coaccessible, this is a contradiction.'
+
 special_objects:
   initial object:
     description: empty set with the unique $\sigma$-algebra

--- a/database/data/categories/Meas.yaml
+++ b/database/data/categories/Meas.yaml
@@ -14,6 +14,7 @@ related:
 
 comments:
   - The thread <a href="https://math.stackexchange.com/questions/5024471/">MSE/5024471</a> asks for the finitely presentable objects of this category.
+  - Will Sawin has sketched a proof for the co-Malcev property in <a href="https://mathoverflow.net/questions/509552/is-the-category-mathbfring-mathrmop-a-malcev-category#comment1328251_509555">MO/509552</a>.
 
 satisfied_properties:
   - property: locally small
@@ -36,6 +37,14 @@ satisfied_properties:
 
   - property: cocomplete
     proof: Take the colimit of the underlying sets and take the largest $\sigma$-algebra making all inclusions measurable. That is, a set is measurable iff its preimage under each inclusion is measurable.
+
+  - property: coregular
+    proof: >-
+      The proof is similar to the proof for <a href="/category/Top">$\Top$</a>. We already know that (finite) colimits and equalizers exist, and that they are preserved by the forgetful functor to $\Set$. It remains to show that regular monomorphisms, i.e. embeddings, are stable under pushouts. Thus, let $i : A \to X$ be an embedding and let $f : A \to Y$ be any measurable map. We claim that the induced measurable map
+      $$j : Y \to Y \sqcup_A X$$
+      is again an embedding. It is certainly injective, since <a href="/category/Set">$\Set$</a> is coregular. More precisely, the underlying set of $Y \sqcup_A X$ can be identified with $Y \sqcup (X \setminus \im(i))$. Now let $T \subseteq Y$ be a measurable subset. Then its preimage $f^*(T) \subseteq A$ is measurable. Since $i$ is an embedding, there exists a measurable subset $S \subseteq X$ such that $i^*(S) = f^*(T)$. Let $u : X \to Y \sqcup_A X$ denote the canonical map, so that $u \circ i = j \circ f$, and consider the subset
+      $$M := j_*(T) \cup u_*(S \setminus \im(i))$$
+      of the pushout. It is straightforward to verify that $j^*(M) = T$ and $u^*(M) = S$. Since both $T$ and $S$ are measurable, it follows that $M$ is measurable. Finally, the equality $j^*(M) = T$ shows that every measurable subset of $Y$ is the preimage of a measurable subset of the pushout. Hence $j$ is an embedding, as claimed.
 
   - property: countably extensive
     proof: >-

--- a/database/data/categories/Meas.yaml
+++ b/database/data/categories/Meas.yaml
@@ -63,9 +63,6 @@ unsatisfied_properties:
   - property: skeletal
     proof: This is trivial.
 
-  - property: cartesian filtered colimits
-    proof: See <a href="https://math.stackexchange.com/questions/5027218" target="_blank">MSE/5027218</a>.
-
   - property: cofiltered-limit-stable epimorphisms
     proof: We already know that <a href="/category/Set">$\Set$</a> does not have this property. Now apply the contrapositive of the dual of Lemma 2 <a href="/content/subcategories">here</a> to the functor $\Set \to \Meas$ which equips a set with the trivial $\sigma$-algebra.
 
@@ -89,7 +86,7 @@ unsatisfied_properties:
     proof: >-
       Let $X$ be a set of cardinality $> 2^{\aleph_0}$. We equip $X$ with the discrete $\sigma$-algebra. If $1$ denotes the singleton space, we therefore have $X \cong \coprod_{x \in X} 1$ in $\Meas$. However, we claim that the canonical bijective measurable map
       $$\textstyle\coprod_{x,y \in X} 1 \to X \times X$$
-      is not an isomorphism, i.e. that $X \times X$ does not carry the discrete $\sigma$-algebra. More precisely, we will show that the diagonal $\Delta \subseteq X \times X$ is not measurable. (This is probably standard, but we include the proof here for lack of a reference.)
+      is not an isomorphism, i.e. that $X \times X$ does not carry the discrete $\sigma$-algebra. More precisely, we will show that the diagonal $\Delta \subseteq X \times X$ is not measurable. (This is well-known and is remarked for example at the end of chapter 1 in Wengenroth's book <a href="https://doi.org/10.1515/9783110203592" target="_blank">Wahrscheinlichkeitstheorie</a>, but we include the proof nevertheless.)
 
       Assume that $\Delta \subseteq X \times X$ is measurable. Then (cf. <a href="https://math.stackexchange.com/questions/61617" target="_blank">MSE/61617</a>) there is a countable family of rectangles $(A_n \times B_n)_{n \in \IN}$ such that $\Delta \in \sigma(\{A_n \times B_n : n \in \IN\})$. Consider the product of the characteristic functions
       $$((\chi_{A_n})_n,(\chi_{B_n})_n) : X \to \{0,1\}^{\IN} \times \{0,1\}^{\IN}.$$

--- a/database/data/categories/Rel.yaml
+++ b/database/data/categories/Rel.yaml
@@ -56,7 +56,7 @@ unsatisfied_properties:
     proof: This is trivial.
 
   - property: Cauchy complete
-    proof: See <a href="https://math.stackexchange.com/a/5030380/1650" target="_blank">MSE/1931577</a>.
+    proof: See <a href="https://math.stackexchange.com/a/5030380" target="_blank">MSE/1931577</a>.
 
   - property: normal
     proof: The construction of equalizers in $\Rel$ shows that they are injective functions, but <a href="https://math.stackexchange.com/questions/350716" target="_blank">MSE/350716</a> shows that monomorphisms in $\Rel$ don't have to be functions.

--- a/database/data/categories/Top.yaml
+++ b/database/data/categories/Top.yaml
@@ -46,7 +46,7 @@ satisfied_properties:
     proof: The indiscrete two-point space $\{0,1\}$ is a regular subobject classifier since continuous maps $X \to \{0,1\}$ correspond to subsets of $X$.
 
   - property: coregular
-    proof: The category has all limits and colimits, and the regular monomorphisms are the subspace inclusions. Thus, it suffices to prove that subspace inclusions are stable under pushouts. For a proof see e.g. Lemma 3.6 at the <a href="https://ncatlab.org/nlab/show/subspace+topology#pushout" target="_blank">nLab</a>.
+    proof: The category has all limits and colimits, and the regular monomorphisms are the subspace inclusions. Thus, it suffices to prove that subspace inclusions are stable under pushouts. For a proof see e.g. Lemma 3.6 at the <a href="https://ncatlab.org/nlab/show/subspace+topology#pushout" target="_blank">nLab</a>. Another proof can be found in <a href="https://math.stackexchange.com/a/2044509">MSE/2016945</a>.
 
   - property: filtered-colimit-stable monomorphisms
     proof: This follows from Lemma 2 <a href="/content/subcategories">here</a> applied to the forgetful functor to $\Set$.

--- a/database/data/category-implications/Malcev.yaml
+++ b/database/data/category-implications/Malcev.yaml
@@ -32,7 +32,7 @@
     - pointed
   conclusions:
     - unital
-  proof: This follows from Corollary 2.2.10 in <a href="https://ncatlab.org/nlab/show/Malcev,+protomodular,+homological+and+semi-abelian+categories" target="_blank">Malcev, protomodular, homological and semi-abelian categories</a>. The proof is also written down in <a href="https://math.stackexchange.com/a/5034834/1650" target="_blank">MSE/5033161</a>.
+  proof: This follows from Corollary 2.2.10 in <a href="https://ncatlab.org/nlab/show/Malcev,+protomodular,+homological+and+semi-abelian+categories" target="_blank">Malcev, protomodular, homological and semi-abelian categories</a>. The proof is also written down in <a href="https://math.stackexchange.com/a/5034834" target="_blank">MSE/5033161</a>.
   is_equivalence: false
 
 - id: biproducts_unital

--- a/database/data/category-implications/disjoint coproducts.yaml
+++ b/database/data/category-implications/disjoint coproducts.yaml
@@ -41,7 +41,7 @@
     - strongly connected
   conclusions:
     - disjoint finite products
-  proof: See <a href="https://math.stackexchange.com/a/5132300/1650" target="_blank">MSE/5130190</a> for a proof.
+  proof: See <a href="https://math.stackexchange.com/a/5132300" target="_blank">MSE/5130190</a> for a proof.
   is_equivalence: false
 
 - id: disjoint_coproduct_cogenerator

--- a/database/data/category-implications/subobject classifiers.yaml
+++ b/database/data/category-implications/subobject classifiers.yaml
@@ -33,7 +33,7 @@
     - regular subobject classifier
   conclusions:
     - trivial
-  proof: See <a href="https://math.stackexchange.com/a/5132767/1650" target="_blank">MSE/4086192</a>.
+  proof: See <a href="https://math.stackexchange.com/a/5132767" target="_blank">MSE/4086192</a>.
   is_equivalence: false
 
 - id: regular_subobjects_trivial


### PR DESCRIPTION
This PR

- removes a redundant assignment that has been introduced recently in the PR #313 
- adds the proof that **Meas** is not coaccessible (which is very similar to the proof for **Top**)
- adds the proof that **Meas** is coregular (again, very similar to **Top**)

Only one property of **Meas** remains undecided: co-Malcev. Will Sawin has sketched a proof [here](https://mathoverflow.net/questions/509552/is-the-category-mathbfring-mathrmop-a-malcev-category#comment1328251_509555), but this can be expanded and checked in another PR.
