### PR TITLE
Add button to expand popups to full height

### DIFF
--- a/src/components/Popup.svelte
+++ b/src/components/Popup.svelte
@@ -4,20 +4,23 @@
 		open: boolean
 		heading: string
 		text: string
+		expanded: boolean
 	}
 
 	export const popup_state = $state<PopupState>({
 		id: '',
 		open: false,
 		heading: '',
-		text: ''
+		text: '',
+		expanded: false
 	})
 
-	export function show_popup(data: Omit<PopupState, 'open'>) {
+	export function show_popup(data: Omit<PopupState, 'open' | 'expanded'>) {
 		popup_state.open = true
 		popup_state.id = data.id
 		popup_state.heading = data.heading
 		popup_state.text = data.text
+		popup_state.expanded = false
 	}
 
 	export function close_popup() {
@@ -29,7 +32,7 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation'
 
-	import { faXmark } from '@fortawesome/free-solid-svg-icons'
+	import { faExpand, faXmark } from '@fortawesome/free-solid-svg-icons'
 	import Fa from 'svelte-fa'
 
 	afterNavigate(() => {
@@ -50,6 +53,10 @@
 	}
 
 	let popup = $state<HTMLElement | null>(null)
+
+	function toggle_expanded() {
+		popup_state.expanded = !popup_state.expanded
+	}
 </script>
 
 <svelte:document onkeydown={handle_keydown} />
@@ -60,10 +67,23 @@ In theory, it is better to use a <dialog> here, but Safari makes many
 problems, Firefox does not display the native animation, and there is
 an issue when clicking two proofs in a row. So it's a <div> then.
 -->
-<div class="popup" class:open={popup_state.open} bind:this={popup}>
+<div
+	class="popup"
+	class:open={popup_state.open}
+	class:expanded={popup_state.expanded}
+	bind:this={popup}
+>
 	<div class="content">
 		<header>
 			<h3>{popup_state.heading}</h3>
+
+			<button
+				onclick={toggle_expanded}
+				aria-label={popup_state.expanded ? 'collapse' : 'expand'}
+			>
+				<Fa icon={faExpand} />
+			</button>
+
 			<button onclick={close_popup} aria-label="close popup">
 				<Fa icon={faXmark} />
 			</button>
@@ -111,7 +131,12 @@ an issue when clicking two proofs in a row. So it's a <div> then.
 			visibility 0s;
 	}
 
-	.content {
+	.popup.expanded {
+		max-height: unset;
+		height: 100dvh;
+	}
+
+	.popup .content {
 		max-width: 800px;
 		margin: 0 auto;
 
@@ -121,7 +146,7 @@ an issue when clicking two proofs in a row. So it's a <div> then.
 		}
 	}
 
-	header {
+	.popup header {
 		margin-block: 0rem 1rem;
 		display: flex;
 		justify-content: space-between;
@@ -129,6 +154,7 @@ an issue when clicking two proofs in a row. So it's a <div> then.
 
 		h3 {
 			margin: 0;
+			margin-right: auto;
 		}
 
 		button {


### PR DESCRIPTION
This PR adds a button to the popups that expands them to the full page height. By default, they only occupy up to 50% of the page height. This is particularly useful when reading long proofs. Although scrolling is possible and may still be necessary for some very long proofs, expanding the popup often eliminates the need for it and makes the proof easier to see as a whole.

## Minimized State

<img width="500" src="https://github.com/user-attachments/assets/6bd62ef8-b8ed-4c8f-9a70-3808fa53430c" /><br />

## Expanded State


<img width="500" src="https://github.com/user-attachments/assets/1a855aa4-1344-47ad-923d-1bdd24a0d1d0" /><br />

## Thoughts

- The popups are not expanded by default (which would also make this new feature redundant), since many proofs are short and should not distract too much from the rest of the page.
- The expand button does not make much sense for short proofs, and one could argue that it should not be displayed in those cases. However, it is simpler and more consistent to always show it. Any calculation that determines when the button should be displayed would be brittle and probably not worth the effort.
- This change goes in the opposite direction from #238 and #221. Perhaps long proofs outside of content pages are fine after all. In contrast, creating a content page whose sole purpose is to present a single proof introduces an unnecessary indirection for the user. For example, the proof that the [Brauer group functor](https://catdat.app/functor/brauer_group) Br : **Fld** &rarr; **Ab** is finitary is somewhat long, but it is not worth adding a separate page for it.

