### PR TITLE
Make description of a structure mandatory

### DIFF
--- a/database/schema/001_structures.sql
+++ b/database/schema/001_structures.sql
@@ -12,7 +12,7 @@ CREATE TABLE structures (
     type TEXT NOT NULL,
     name TEXT NOT NULL UNIQUE,
     notation TEXT NOT NULL,
-    description TEXT,
+    description TEXT NOT NULL,
     nlab_link TEXT CHECK (nlab_link IS NULL OR nlab_link like 'https://%'),
     dual_structure_id TEXT,
     parent TEXT,

--- a/database/scripts/utils/seed.types.ts
+++ b/database/scripts/utils/seed.types.ts
@@ -49,7 +49,7 @@ export type StructureYaml = {
 	id: string
 	name: string
 	notation: string
-	description: string | null
+	description: string
 	nlab_link: string | null
 	tags: string[]
 	related: string[]

--- a/src/lib/commons/types.ts
+++ b/src/lib/commons/types.ts
@@ -15,7 +15,7 @@ export type StructureDisplay = {
 	id: string
 	name: string
 	notation: string
-	description: string | null
+	description: string
 	nlab_link: string | null
 	dual_structure_id: string | null
 	dual_structure_name: string | null
@@ -77,6 +77,7 @@ export type SpecialObject = {
 
 export type SpecialMorphism = {
 	type: string
+	// null when the morphisms of this type have not been determined
 	description: string | null
 	proof: string
 }

--- a/src/pages/CategoryDetailPage.svelte
+++ b/src/pages/CategoryDetailPage.svelte
@@ -43,13 +43,13 @@
 			<h3>Special morphisms</h3>
 
 			<ul class="with-margins no-bullets">
-				{#each data.special_morphisms as obj}
+				{#each data.special_morphisms as morph}
 					<li>
-						<TextWithProof proof={obj.proof}>
-							{#if obj.description}
-								{obj.type}: {@html obj.description}
+						<TextWithProof proof={morph.proof}>
+							{#if morph.description}
+								{morph.type}: {@html morph.description}
 							{:else}
-								{obj.type}: <Fa icon={faQuestion} scale={0.825} />
+								{morph.type}: <Fa icon={faQuestion} scale={0.825} />
 							{/if}
 						</TextWithProof>
 					</li>

--- a/src/pages/StructureDetailPage.svelte
+++ b/src/pages/StructureDetailPage.svelte
@@ -121,9 +121,7 @@
 		{/if}
 	</ul>
 
-	{#if structure.description}
-		<p>{@html structure.description}</p>
-	{/if}
+	<p>{@html structure.description}</p>
 </section>
 
 <PropertyAssignmentList


### PR DESCRIPTION
In #323, every category received a description. Functors and morphisms already had descriptions. This means we can now make the description mandatory for every structure. This requires a small schema change.