### PR TITLE
Add the categories of graded modules and cochain complexes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -60,6 +60,7 @@
 		"Clowder",
 		"coaccessible",
 		"cocartesian",
+		"cochain",
 		"coclosed",
 		"cocomplete",
 		"cocompleteness",

--- a/database/data/categories/Ab.yaml
+++ b/database/data/categories/Ab.yaml
@@ -19,6 +19,7 @@ related:
   - TorsAb
   - TorsFreeAb
   - grAb
+  - SeqAb
 
 satisfied_properties: []
 

--- a/database/data/categories/Ab.yaml
+++ b/database/data/categories/Ab.yaml
@@ -18,6 +18,7 @@ related:
   - Grp
   - TorsAb
   - TorsFreeAb
+  - grAb
 
 satisfied_properties: []
 

--- a/database/data/categories/Ch(Ab).yaml
+++ b/database/data/categories/Ch(Ab).yaml
@@ -1,0 +1,35 @@
+id: Ch(Ab)
+name: category of cochain complexes of abelian groups
+notation: $\Ch(\Ab)$
+objects: sequences of abelian groups $\cdots \xrightarrow{d} A_0 \xrightarrow{d} A_1 \xrightarrow{d} A_2 \xrightarrow{d} \cdots$ such that $d^2 = 0$
+morphisms: commutative diagrams
+description: For every category $\A$ with zero morphisms, we can construct the category $\Ch(\A)$ of cochain complexes in $\A$. In this entry, $\A$ is the <a href="/category/Ab">category of abelian groups</a>. The category $\Ch(\Ab)$ is isomorphic to the <a href="/category/grMod_G(R)">category of $\IZ$-graded modules</a> over the $\IZ$-graded ring $\IZ[T]/\langle T^2 \rangle$, with the grading concentrated in degrees $0$ and $1$.
+nlab_link: https://ncatlab.org/nlab/show/cochain+complex
+parent: grMod_G(R)
+
+tags:
+  - algebra
+
+related:
+  - Ab
+  - grAb
+  - SeqAb
+
+satisfied_properties: []
+
+unsatisfied_properties:
+  - property: split abelian
+    proof: 'This follows directly from the fact that <a href="/category/Ab">$\Ab$</a> is not split abelian: it identifies with the full subcategory of $\Ch(\Ab)$ consisting of complexes concentrated in degree $0$.'
+
+  - property: finitary algebraic
+    proof: The proof is very similar to the one for <a href="/category/grAb">$\grAb$</a>, which is the special case in which all differentials are zero. Every finitely presentable complex is concentrated in finitely many degrees and therefore cannot be a generator.
+    references:
+      - grAb_not_finitary_algebraic
+
+special_objects:
+  initial object:
+    description: the zero complex
+  terminal object:
+    description: the zero complex
+
+special_morphisms: {}

--- a/database/data/categories/FiltVect.yaml
+++ b/database/data/categories/FiltVect.yaml
@@ -13,6 +13,8 @@ tags:
 
 related:
   - Vect
+  - grMod_G(R)
+  - SeqAb
 
 comments:
   - 'The forgetful functor $U : \FiltVect \to \Vect$ has a left adjoint that equips a vector space with the trivial filtration. It also has a right adjoint that equips a vector space with the maximal filtration. In particular, it follows that $U$ preserves limits and colimits.'

--- a/database/data/categories/R-Mod.yaml
+++ b/database/data/categories/R-Mod.yaml
@@ -13,6 +13,7 @@ related:
   - M-Set
   - Ab
   - Vect
+  - grMod_G(R)
 
 satisfied_properties:
   - property: locally small

--- a/database/data/categories/SeqAb.yaml
+++ b/database/data/categories/SeqAb.yaml
@@ -1,0 +1,46 @@
+id: SeqAb
+name: category of sequences of abelian groups
+notation: $\Ab^{(\IN,\leq)}$
+objects: sequences of abelian groups $A_0 \to A_1 \to A_2 \to \cdots$
+morphisms: commutative diagrams
+description: This is the special case of the <a href="/category/grMod_G(R)">category of $\IN$-graded modules</a> over the $\IN$-graded ring $\IZ[T]$ with $\deg(T)=1$. It can also be viewed as the category of functors from the <a href="/category/N">category of natural numbers $(\IN,\leq)$</a> to $\Ab$. Thus, most (but not all) properties are inherited from <a href="/category/Ab">$\Ab$</a>. A notable difference is that $\Ab^{(\IN,\leq)}$ is not finitary algebraic.
+nlab_link: null
+parent: grMod_G(R)
+
+tags:
+  - algebra
+
+related:
+  - Ab
+  - grAb
+  - FiltVect
+
+satisfied_properties: []
+
+unsatisfied_properties:
+  - property: split abelian
+    proof: 'This follows directly from the fact that <a href="/category/Ab">$\Ab$</a> is not split abelian: it identifies with the full subcategory of $\Ab^{(\IN,\leq)}$ consisting of sequences concentrated in degree $0$.'
+
+  - property: finitary algebraic
+    proof: >-
+      The proof is similar to the one for <a href="/category/grAb">$\grAb$</a>, which is the special case in which all transition maps are zero. We will show that there is no finitely presentable generator.
+
+      First, notice that $\Ab^{(\IN,\leq)}$ is the category of algebras for the multi-sorted algebraic theory with one sort $S_n$ for each $n \in \IN$, one unary operation $T : S_n \to S_{n+1}$ for each $n \in \IN$, and the theory of an abelian group on each $S_n$. The free algebra on one generator of sort $S_n$ is the object $P[n]$ defined by
+      $$0 \to \cdots \to 0 \to \IZ \xrightarrow{\id} \IZ \xrightarrow{\id} \cdots,$$
+      which starts in degree $n$ and remains constant in all degrees $\geq n$. By Theorem 3.12 in <a href="https://ncatlab.org/nlab/show/Locally+Presentable+and+Accessible+Categories" target="_blank">Adamek-Rosicky</a>, every finitely presentable object $A$ is a quotient of a finite direct sum of objects $P[n]$. It follows that there is some $N \in \IN$ such that the map $A_n \to A_{n+1}$ is surjective for every $n \geq N$ (in fact, much more is true, but this is sufficient here). But then every homomorphism $A \to P[N+1]$ is zero, as can be seen from a diagram chase in
+      $$\begin{CD}
+      \cdots @>>> A_N @>{\text{epi}}>> A_{N+1} @>{\text{epi}}>> A_{N+2} @>{\text{epi}}>> \cdots \\
+      @. @VVV @VVV @VVV @. \\
+      \cdots @>>> 0 @>>> \IZ @>{\id}>> \IZ @>{\id}>> \cdots
+      \end{CD}$$
+      Since $P[N+1] \neq 0$, it follows that $A$ is not a generator.
+    references:
+      - grAb_not_finitary_algebraic
+
+special_objects:
+  initial object:
+    description: the zero sequence $0 \to 0 \to \cdots$
+  terminal object:
+    description: the zero sequence $0 \to 0 \to \cdots$
+
+special_morphisms: {}

--- a/database/data/categories/SeqAb.yaml
+++ b/database/data/categories/SeqAb.yaml
@@ -14,6 +14,7 @@ related:
   - Ab
   - grAb
   - FiltVect
+  - Ch(Ab)
 
 satisfied_properties: []
 

--- a/database/data/categories/grAb.yaml
+++ b/database/data/categories/grAb.yaml
@@ -11,6 +11,7 @@ tags:
 
 related:
   - Ab
+  - SeqAb
 
 satisfied_properties: []
 

--- a/database/data/categories/grAb.yaml
+++ b/database/data/categories/grAb.yaml
@@ -12,6 +12,7 @@ tags:
 related:
   - Ab
   - SeqAb
+  - Ch(Ab)
 
 satisfied_properties: []
 

--- a/database/data/categories/grAb.yaml
+++ b/database/data/categories/grAb.yaml
@@ -1,0 +1,27 @@
+id: grAb
+name: category of graded abelian groups
+notation: $\grAb$
+objects: $\IZ$-graded abelian groups
+morphisms: graded linear maps
+description: This is the special case of the <a href="/category/grMod_G(R)">category of $\IZ$-graded modules</a> over the $\IZ$-graded ring $\IZ$ concentrated in degree $0$. It can also be viewed as the product category $\Ab^{\IZ}$. It provides an example of a category that is locally strongly finitely presentable and Grothendieck abelian but, unlike $\Ab$, is not finitary algebraic.
+nlab_link: https://ncatlab.org/nlab/show/graded+abelian+group
+parent: grMod_G(R)
+tags:
+  - algebra
+
+related:
+  - Ab
+
+satisfied_properties: []
+
+unsatisfied_properties:
+  - property: split abelian
+    proof: 'This follows directly from the fact that <a href="/category/Ab">$\Ab$</a> is not split abelian: it identifies with the full subcategory of $\grAb$ consisting of graded abelian groups concentrated in degree $0$.'
+
+  - property: finitary algebraic
+    proof: From the description of $\grAb$ using a $\IZ$-sorted algebraic theory and Theorem 3.12 in <a href="https://ncatlab.org/nlab/show/Locally+Presentable+and+Accessible+Categories" target="_blank">Adamek-Rosicky</a>, we see that a finitely presentable object of $\grAb \cong \Ab^{\IZ}$ is a graded abelian group $(A_n)_{n \in \IZ}$ such that each $A_n$ is finitely presentable and $A_n = 0$ for all but finitely many degrees $n$. Thus, it cannot be a generator, since it cannot distinguish homomorphisms concentrated in degrees outside the finite set of degrees. However, every finitary algebraic category has a finitely presentable generator, namely the free algebra on one generator.
+    label: grAb_not_finitary_algebraic
+
+special_objects: {}
+
+special_morphisms: {}

--- a/database/data/categories/grMod_G(R).yaml
+++ b/database/data/categories/grMod_G(R).yaml
@@ -10,6 +10,7 @@ tags:
 
 related:
   - R-Mod
+  - FiltVect
 
 satisfied_properties:
   - property: locally small

--- a/database/data/categories/grMod_G(R).yaml
+++ b/database/data/categories/grMod_G(R).yaml
@@ -1,0 +1,65 @@
+id: grMod_G(R)
+name: category of graded modules over a graded ring
+notation: $\grMod_G(R)$
+objects: $G$-graded modules over a $G$-graded ring $R$
+morphisms: $R$-linear $G$-graded maps
+description: Here, $G$ is a monoid (written additively), $R = (R_n)_{n \in G}$ is a non-trivial $G$-graded ring, and we consider $G$-graded $R$-modules, consisting of abelian groups $(M_n)_{n \in G}$ and bilinear maps $R_n \times M_m \to M_{n+m}$ satisfying the module axioms. Typical examples are $G = \IN$ and $G = \IZ$, both with respect to addition.
+nlab_link: https://ncatlab.org/nlab/show/grMod
+tags:
+  - algebra
+
+related:
+  - R-Mod
+
+satisfied_properties:
+  - property: locally small
+    proof: There is a forgetful functor $\grMod_G(R) \to \Ab^{G}$, and $\Ab^{G}$ is locally small since $\Ab$ is locally small.
+
+  - property: complete
+    proof: 'This follows formally since <a href="/category/Ab">$\Ab$</a> is complete and limits are computed degree-wise. In more detail, if $D : \I \to \grMod_G(R)$ is a small diagram and we write $D(i) = (D_n(i))_{n \in G}$, then each $D_n : \I \to \Ab$ is a diagram and therefore has a limit $L_n \in \Ab$. The multiplication maps $R_n \times D_m(i) \to D_{n+m}(i)$ induce a multiplication map $R_n \times L_m \to L_{n+m}$ on the limits. These maps make $(L_n)_{n \in G}$ into a graded module, and one can check that it satisfies the universal property of a limit of $D$.'
+    check_redundancy: false
+
+  - property: cocomplete
+    proof: 'This follows formally since <a href="/category/Ab">$\Ab$</a> is cocomplete and colimits are computed degree-wise. In more detail, if $D : \I \to \grMod_G(R)$ is a small diagram and we write $D(i) = (D_n(i))_{n \in G}$, then each $D_n : \I \to \Ab$ is a diagram and therefore has a colimit $L_n \in \Ab$. The linear multiplication maps $R_n \otimes D_m(i) \to D_{n+m}(i)$ induce a linear multiplication map $R_n \otimes L_m \to L_{n+m}$ on the colimits; here we use that $R_n \otimes -$ preserves colimits. These maps make $(L_n)_{n \in G}$ into a graded module, and one can check that it satisfies the universal property of a colimit of $D$.'
+    check_redundancy: false
+
+  - property: abelian
+    proof: 'The sum of two graded linear maps is defined degree-wise. Since we already know that limits and colimits exist and are computed degree-wise, kernels and cokernels exist in particular, and they are computed degree-wise. If $f : M \to N$ is a graded linear map, then the canonical morphism $\coim(f) \to \im(f)$ is an isomorphism since this is true in every degree.'
+
+  - property: locally strongly finitely presentable
+    proof: 'We can model graded modules using a multi-sorted finitary algebraic theory with sorts $(S_n)_{n \in G}$, unary operations $r : S_m \to S_{n+m}$ for $r \in R_n$, the algebraic theory of an abelian group on each $S_n$, and the obvious equations.'
+
+unsatisfied_properties:
+  - property: skeletal
+    proof: This is trivial.
+
+  - property: CSP
+    proof: By using the multiplication in $R$, we regard $R$ as a graded $R$-module. Then the canonical graded linear map $\bigoplus_{n \geq 0} R \to \prod_{n \geq 0} R$ is not an epimorphism in $\grMod_G(R)$. In fact, if it were an epimorphism, it would be surjective in every degree, and in particular the group homomorphism $\bigoplus_{n \geq 0} R_0 \to \prod_{n \geq 0} R_0$ would be surjective. But this is only possible when $R_0 = 0$, which would imply $R = 0$.
+
+undecidable_properties:
+  - property: split abelian
+    proof: This depends on the choice of the graded ring $R$ and the monoid $G$. For a trivial example, when $G = 0$, $R$ is just a ring and $\grMod_G(R) = \Mod(R)$ is split abelian if and only if $R$ is semisimple. For a slightly more interesting example, let $G = \IZ$, let $k$ be a ring, and consider the $\IZ$-graded ring $R := (k)_{n \in \IZ}$ with multiplication induced by the multiplication on $k$ (that is, the associated ring is the Laurent polynomial ring $k[T,T^{-1}]$). Then $\grMod_G(R) \simeq \Mod(k)$ is split abelian if and only if $k$ is semisimple.
+
+  - property: finitary algebraic
+    proof: This depends on the choice of the graded ring $R$ and the monoid $G$. For example, if $k$ is a ring and we take the $\IZ$-graded ring $R := (k)_{n \in \IZ}$ with multiplication induced by the multiplication on $k$ (that is, the associated ring is the Laurent polynomial ring $k[T,T^{-1}]$), then $\grMod_{\IZ}(R) \simeq \Mod(k)$ is finitary algebraic. On the other hand, when $R$ has the trivial $\IZ$-grading, with $R_n = 0$ for $n \neq 0$ and $k := R_0$, we have $\grMod_{\IZ}(R) \simeq \prod_{n \in \IZ} \Mod(k)$, which is not finitary algebraic when $k \neq 0$. To see this, note that every finitary algebraic category has a finitely presentable (regular-projective) generator, namely the free algebra on one generator. A finitely presentable object in $\prod_{n \in \IZ} \Mod(k)$ is concentrated in finitely many degrees and therefore cannot be a generator.
+
+special_objects:
+  initial object:
+    description: the zero graded module with $0_n := 0$
+  terminal object:
+    description: the zero graded module with $0_n := 0$
+  coproducts:
+    description: degree-wise defined direct sums
+  products:
+    description: degree-wise defined direct products
+
+special_morphisms:
+  isomorphisms:
+    description: morphisms that are bijective in each degree
+    proof: This is straightforward to check.
+  monomorphisms:
+    description: morphisms that are injective in each degree
+    proof: 'A graded linear map that is injective in each degree is clearly a monomorphism. Conversely, a monomorphism $f : M \to N$ has trivial kernel. Since limits are computed degree-wise, the kernel is computed degree-wise as well. It follows that each component $f_n : M_n \to N_n$ has trivial kernel, i.e. is injective.'
+  epimorphisms:
+    description: morphisms that are surjective in each degree
+    proof: 'A graded linear map that is surjective in each degree is clearly an epimorphism. Conversely, an epimorphism $f : M \to N$ has trivial cokernel. Since colimits are computed degree-wise, the cokernel is computed degree-wise as well. It follows that each component $f_n : M_n \to N_n$ has trivial cokernel, i.e. is surjective.'

--- a/database/data/macros.yaml
+++ b/database/data/macros.yaml
@@ -76,6 +76,7 @@
 \Rel: \mathbf{Rel}
 \Ab: \mathbf{Ab}
 \grAb: \mathbf{grAb}
+\Ch: \mathbf{Ch}
 \Grp: \mathbf{Grp}
 \Vect: \mathbf{Vect}
 \FinVect: \mathbf{FinVect}

--- a/database/data/macros.yaml
+++ b/database/data/macros.yaml
@@ -75,6 +75,7 @@
 \Setne: \mathbf{Set}_{\neq \varnothing}
 \Rel: \mathbf{Rel}
 \Ab: \mathbf{Ab}
+\grAb: \mathbf{grAb}
 \Grp: \mathbf{Grp}
 \Vect: \mathbf{Vect}
 \FinVect: \mathbf{FinVect}

--- a/database/data/macros.yaml
+++ b/database/data/macros.yaml
@@ -49,6 +49,7 @@
 \card: \operatorname{card}
 \colim: \operatorname{colim}
 \im: \operatorname{im}
+\coim: \operatorname{coim}
 \lcm: \operatorname{lcm}
 \Spec: \operatorname{Spec}
 \ord: \operatorname{ord}
@@ -86,6 +87,7 @@
 \Mon: \mathbf{Mon}
 \CMon: \mathbf{CMon}
 \Mod: \mathbf{Mod}
+\grMod: \mathbf{grMod}
 \Fld: \mathbf{Fld}
 \FinAb: \mathbf{FinAb}
 \FinGrp: \mathbf{FinGrp}


### PR DESCRIPTION
This PR adds the category $\mathbf{grMod}_G(R)$ of $G$-graded modules over a $G$-graded ring $R$, where $G$ is any monoid and $R$ is only assumed to be non-trivial. In this generality, two properties cannot be decided: (one-sorted) finitary algebraic and split abelian. However, they can be decided for three special cases, which are also added as separate entries to the database:

- the category $\mathbf{Ab}^{(\mathbb{N},\leq)}$ of sequences of abelian groups,
- the category $\mathbf{Ab}^{\mathbb{Z}}$ of $\mathbb{Z}$-graded abelian groups,
- the category $\mathbf{Ch}(\mathbf{Ab})$ of cochain complexes of abelian groups.

Two of these have been mentioned in the issue #14.

All three have the category of graded modules as a parent (a feature only recently introduced in #323), so all properties except for the two mentioned above are inherited directly. Each of the three child categories is neither (one-sorted) finitary algebraic nor split abelian.

Currently, the three categories are indistinguishable. But this is just because some properties are missing from the database. For example, I think that $\mathbf{Ab}^{\mathbb{Z}}$ is hereditary, but $\mathbf{Ab}^{(\mathbb{N},\leq)}$ is not.