### PR TITLE
Rename tables with special objects and special morphisms

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -109,6 +109,6 @@ to check for redundant assignments of properties to categorical structures.
 
 ## Diagram
 
-This is the database schema as of 20.07.2026; changes may occur.
+This is the database schema as of 12.08.2026; changes may occur.
 
-<img alt="database diagram" src="https://github.com/user-attachments/assets/45e8704a-34d6-43e1-a08e-d9bc3908dc28" />
+<img alt="database diagram" src="https://github.com/user-attachments/assets/e1a11ea8-6c00-4624-aeaf-6700b1a484cf" />

--- a/database/schema/005_special_objects.sql
+++ b/database/schema/005_special_objects.sql
@@ -5,7 +5,7 @@ CREATE TABLE special_object_types (
     FOREIGN KEY (dual) REFERENCES special_object_types (type) ON DELETE SET NULL
 );
 
-CREATE TABLE special_objects (
+CREATE TABLE special_object_assignments (
     category_id TEXT NOT NULL,
     type TEXT NOT NULL,
     description TEXT NOT NULL,
@@ -16,4 +16,4 @@ CREATE TABLE special_objects (
     FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_special_objects_by_category ON special_objects (category_id);
+CREATE INDEX idx_special_objects_by_category ON special_object_assignments (category_id);

--- a/database/schema/006_special-morphisms.sql
+++ b/database/schema/006_special-morphisms.sql
@@ -5,7 +5,7 @@ CREATE TABLE special_morphism_types (
     FOREIGN KEY (dual) REFERENCES special_morphism_types (type) ON DELETE SET NULL
 );
 
-CREATE TABLE special_morphisms (
+CREATE TABLE special_morphism_assignments (
     category_id TEXT NOT NULL,
     type TEXT NOT NULL,
     description TEXT NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE special_morphisms (
     FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_special_morphisms_by_category ON special_morphisms (category_id);
+CREATE INDEX idx_special_morphisms_by_category ON special_morphism_assignments (category_id);
 
 CREATE TABLE special_morphism_rules (
     id INTEGER PRIMARY KEY,

--- a/database/scripts/deduce-special-morphisms.ts
+++ b/database/scripts/deduce-special-morphisms.ts
@@ -16,7 +16,10 @@ export function deduce_special_morphisms() {
  * Clears deduced special morphisms
  */
 function clear_deduced_special_morphisms() {
-	db.prepare(`DELETE FROM special_morphisms WHERE is_deduced = TRUE`).run()
+	db.prepare(
+		`DELETE FROM special_morphism_assignments
+		WHERE is_deduced = TRUE`
+	).run()
 }
 
 /**
@@ -28,13 +31,15 @@ function inherit_special_morphisms_from_parents() {
 	const parent_map = get_structure_parent_map(db, 'category')
 
 	const get_parent_special_morphisms = db.prepare<[string], SpecialMorphism>(
-		`SELECT type, description, proof FROM special_morphisms
+		`SELECT type, description, proof
+		FROM special_morphism_assignments
 		WHERE category_id = ? AND is_deduced = FALSE`
 	)
 
 	const insert_special_morphism = db.prepare(
-		`INSERT INTO special_morphisms (category_id, type, description, proof, is_deduced)
-		VALUES (?, ?, ?, ?, TRUE)
+		`INSERT INTO special_morphism_assignments (
+			category_id, type, description, proof, is_deduced
+		) VALUES (?, ?, ?, ?, TRUE)
 		ON CONFLICT (category_id, type) DO NOTHING`
 	)
 
@@ -95,7 +100,7 @@ function deduce_special_morphisms_by_rules() {
 	for (const { property_id, type, description, proof } of rules) {
 		const res = db
 			.prepare(
-				`INSERT INTO special_morphisms (
+				`INSERT INTO special_morphism_assignments (
                     category_id,
                     type,
                     description,
@@ -131,7 +136,7 @@ function deduce_special_morphisms_by_rules() {
 function deduce_special_morphisms_of_dual_categories() {
 	const res = db
 		.prepare(
-			`INSERT INTO special_morphisms (
+			`INSERT INTO special_morphism_assignments (
                 category_id,
                 type,
                 description,
@@ -145,7 +150,7 @@ function deduce_special_morphisms_of_dual_categories() {
                 'This is deduced from its dual category.',
                 TRUE
             FROM structures c
-            INNER JOIN special_morphisms m ON m.category_id = c.id
+            INNER JOIN special_morphism_assignments m ON m.category_id = c.id
             INNER JOIN special_morphism_types t ON t.type = m.type
             WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL
             ON CONFLICT (category_id, type) DO NOTHING`

--- a/database/scripts/deduce-special-objects.ts
+++ b/database/scripts/deduce-special-objects.ts
@@ -15,7 +15,7 @@ export function deduce_special_objects() {
  * Clears deduced special objects
  */
 function clear_deduced_special_objects() {
-	db.prepare(`DELETE FROM special_objects WHERE is_deduced = TRUE`).run()
+	db.prepare(`DELETE FROM special_object_assignments WHERE is_deduced = TRUE`).run()
 }
 
 /**
@@ -27,13 +27,14 @@ function inherit_special_objects_from_parents() {
 	const parent_map = get_structure_parent_map(db, 'category')
 
 	const get_parent_special_objects = db.prepare<[string], SpecialObject>(
-		`SELECT type, description FROM special_objects
+		`SELECT type, description FROM special_object_assignments
 		WHERE category_id = ? AND is_deduced = FALSE`
 	)
 
 	const insert_special_object = db.prepare(
-		`INSERT INTO special_objects (category_id, type, description, is_deduced)
-		VALUES (?, ?, ?, TRUE)
+		`INSERT INTO special_object_assignments (
+			category_id, type, description, is_deduced
+		) VALUES (?, ?, ?, TRUE)
 		ON CONFLICT (category_id, type) DO NOTHING`
 	)
 
@@ -71,7 +72,7 @@ function inherit_special_objects_from_parents() {
 function deduce_special_objects_of_dual_categories() {
 	const res = db
 		.prepare(
-			`INSERT INTO special_objects (
+			`INSERT INTO special_object_assignments (
                 category_id,
                 type,
                 description,
@@ -83,7 +84,7 @@ function deduce_special_objects_of_dual_categories() {
                 o.description,
                 TRUE
             FROM structures c
-            INNER JOIN special_objects o ON o.category_id = c.id
+            INNER JOIN special_object_assignments o ON o.category_id = c.id
             INNER JOIN special_object_types t ON t.type = o.type
             WHERE c.type = 'category' AND c.dual_structure_id IS NOT NULL`
 		)

--- a/database/scripts/seed.ts
+++ b/database/scripts/seed.ts
@@ -70,9 +70,9 @@ function clear_all_tables() {
 		db.pragma('defer_foreign_keys = ON')
 
 		db.prepare(`DELETE FROM special_morphism_rules`).run()
-		db.prepare(`DELETE FROM special_morphisms`).run()
+		db.prepare(`DELETE FROM special_morphism_assignments`).run()
 		db.prepare(`DELETE FROM special_morphism_types`).run()
-		db.prepare(`DELETE FROM special_objects`).run()
+		db.prepare(`DELETE FROM special_object_assignments`).run()
 		db.prepare(`DELETE FROM special_object_types`).run()
 
 		db.prepare(`DELETE FROM mapped_assumptions`).run()
@@ -309,12 +309,15 @@ function insert_category(category: CategoryYaml) {
 	)
 
 	const special_object_insert = db.prepare(
-		`INSERT INTO special_objects (category_id, type, description) VALUES (?, ?, ?)`
+		`INSERT INTO special_object_assignments (
+			category_id, type, description
+		) VALUES (?, ?, ?)`
 	)
 
 	const special_morphism_insert = db.prepare(
-		`INSERT INTO special_morphisms (category_id, type, description, proof)
-		VALUES (?, ?, ?, ?)`
+		`INSERT INTO special_morphism_assignments (
+			category_id, type, description, proof
+		) VALUES (?, ?, ?, ?)`
 	)
 
 	category_insert.run(category.id, category.objects, category.morphisms)

--- a/src/lib/server/fetchers/category.ts
+++ b/src/lib/server/fetchers/category.ts
@@ -21,7 +21,7 @@ export function fetch_category(id: string) {
 	const special_objects = db
 		.prepare<[string], SpecialObject>(
 			`SELECT s.type, s.description
-			FROM special_objects s
+			FROM special_object_assignments s
 			INNER JOIN special_object_types t
 			ON t.type = s.type
 			WHERE s.category_id = ?
@@ -33,7 +33,7 @@ export function fetch_category(id: string) {
 		.prepare<[string], SpecialMorphism>(
 			`SELECT t.type, s.description, s.proof
 			FROM special_morphism_types t
-			LEFT JOIN special_morphisms s
+			LEFT JOIN special_morphism_assignments s
 			ON s.type = t.type AND s.category_id = ?
 			ORDER BY t.id`
 		)
@@ -78,7 +78,7 @@ export function fetch_categories_with_missing_morphisms() {
 				COUNT(*) AS count
 			FROM structures s
 			JOIN special_morphism_types t
-			LEFT JOIN special_morphisms m
+			LEFT JOIN special_morphism_assignments m
 			ON m.category_id = s.id AND m.type = t.type
 			WHERE s.type = 'category' AND m.type IS NULL
 			GROUP BY s.id


### PR DESCRIPTION
The table `special_objects` is renamed to `special_object_assignments`. Likewise, the table `special_morphisms` is renamed to `special_morphism_assignments`. This name is more clear and is also consistent with the existing tables `property_assignments`, `property_tag_assignments`, and `structure_tag_assignments`.

## Updated diagram

This PR also updates the database diagram in the documentation (which also includes changes from other PRs such as #323).

<img width="700" src="https://github.com/user-attachments/assets/e1a11ea8-6c00-4624-aeaf-6700b1a484cf" /><br />

Click for a larger image.