### PR TITLE
Justify mathematical texts

### DIFF
--- a/content/constant_morphisms.md
+++ b/content/constant_morphisms.md
@@ -30,7 +30,7 @@ If $X$ is a subterminal object, then any morphism $X \to Y$ is constant. If $Y$ 
 _Proof._ This is immediate from the definitions. <span class="qed">$\square$</span>
 
 ::: Lemma 5
-If $f : X \to Y$ is a monomorphism that is constant, then $X$ is subterminal.
+If $f : X \to Y$ is a monomorphism that is constant, then $X$ is sub&shy;terminal.
 :::
 
 _Proof._ If $x_1,x_2 : T \rightrightarrows X$ are morphisms, then $f \circ x_1 = f \circ x_2$ since $f$ is constant. Since $f$ is also a monomorphism, we infer that $x_1 = x_2$. <span class="qed">$\square$</span>

--- a/content/contribute.md
+++ b/content/contribute.md
@@ -5,7 +5,7 @@ description: CatDat welcomes contributions from the community, including filling
 
 ## How to contribute
 
-_CatDat_ is developed in an open-source [GitHub repository](https://github.com/ScriptRaccoon/catdat) owned by [Martin Brandenburg](https://ncatlab.org/nlab/show/Martin+Brandenburg). It welcomes contributions from the community, including filling in missing information or discovering new combinations of properties.
+_CatDat_ is developed in an open-source [GitHub repository](https://github.com/ScriptRaccoon/catdat) by [Martin Brandenburg](https://ncatlab.org/nlab/show/Martin+Brandenburg). It welcomes contributions from the community, including filling in missing information or discovering new combinations of properties.
 
 [**Video tutorial**](https://www.youtube.com/watch?v=NoZWdMFfQfg)
 

--- a/content/sifted-colimits-in-groupoids.md
+++ b/content/sifted-colimits-in-groupoids.md
@@ -55,7 +55,7 @@ $$h u_i = v_{i_0} D(b)^{-1} D(a) = v_k D(a) = v_i.$$
 Moreover, $h$ is uniquely determined: if $v_i = h u_i$ for all $i \in \I$, then for $i = i_0$ we obtain $v_{i_0} = h$. <span class="qed">$\square$</span>
 
 ::: Corollary 2
-Let $\C$ be a category with the property that every sifted diagram is eventually constant (for example, a groupoid). Then every object $X \in \C$ is strongly finitely presentable, i.e. the functor $\Hom(X,-) : \C \to \Set$ preserves sifted colimits.
+Let $\C$ be a category with the property that every sifted diagram is eventually constant (for example, a groupoid). Then every object $X \in \C$ is strongly finitely presentable, i.e. the functor $\Hom(X,-) : \C \to \Set$ preserves sifted co&shy;limits.
 :::
 
 _Proof._

--- a/src/components/Popup.svelte
+++ b/src/components/Popup.svelte
@@ -88,7 +88,9 @@ an issue when clicking two proofs in a row. So it's a <div> then.
 				<Fa icon={faXmark} />
 			</button>
 		</header>
-		{@html popup_state.text}
+		<div class="justified">
+			{@html popup_state.text}
+		</div>
 	</div>
 </div>
 

--- a/src/pages/ImplicationPage.svelte
+++ b/src/pages/ImplicationPage.svelte
@@ -37,7 +37,7 @@
 
 <h2>Implication Details</h2>
 
-<p>
+<p class="justified">
 	<strong>Claim:</strong>
 	{#if has_associated_assumptions}
 		Given a {remove_underscores(type)}
@@ -88,7 +88,7 @@
 	{/each}
 </p>
 
-<p>
+<p class="justified">
 	<strong>Proof:</strong>
 	{@html implication.proof}
 </p>

--- a/src/pages/PropertyPage.svelte
+++ b/src/pages/PropertyPage.svelte
@@ -48,7 +48,7 @@
 
 <TagList {tags} {type} sort="property" />
 
-<p>
+<p class="justified">
 	{@html property.description}
 
 	{#if property.invariant_under_equivalences === false}

--- a/src/pages/StructureDetailPage.svelte
+++ b/src/pages/StructureDetailPage.svelte
@@ -134,7 +134,7 @@
 		{/if}
 	</ul>
 
-	<p>{@html structure.description}</p>
+	<p class="justified">{@html structure.description}</p>
 </section>
 
 <PropertyAssignmentList

--- a/src/routes/app.css
+++ b/src/routes/app.css
@@ -61,6 +61,7 @@ body {
 	background-color: var(--bg-color);
 	color: var(--text-color);
 	line-height: 1.5;
+	hyphens: auto;
 }
 
 body:has(#nav_dialog[open]) {
@@ -83,6 +84,8 @@ h3 {
 	font-weight: 500;
 	color: var(--heading-color);
 	font-family: 'DM Mono', monospace;
+	text-align: left;
+	hyphens: none;
 }
 
 h2 {
@@ -294,6 +297,10 @@ label {
 
 .error {
 	color: var(--error-color);
+}
+
+.justified {
+	text-align: justify;
 }
 
 /* container class for youtube videos */

--- a/src/routes/content/[id]/+page.svelte
+++ b/src/routes/content/[id]/+page.svelte
@@ -18,7 +18,7 @@
 
 <MetaData title={data.meta_data.title} description={data.meta_data.description} />
 
-<div class="content">
+<div class="content justified">
 	{@html data.html}
 </div>
 


### PR DESCRIPTION
This PR implements justified text in property proofs (in popups), implication pages, descriptions, and content pages by using the CSS declaration `text-align: justify`. Justified text is generally not recommended on the web for accessibility reasons ([article on this matter](https://theadminbar.com/accessibility-weekly/text-alignment-left-center-justified/)), but it is more consistent with the usual layout of mathematical writing, such as in journals, on the arXiv, and on the nLab, and the negative effect of excessive spacing between words is mitigated by enabling hyphenation throughout the body. Headings are excluded from justification and hyphenation.

## Proofs in Minimized Popups

### Before

<img width="500" alt="1-before" src="https://github.com/user-attachments/assets/52b5f42e-297b-4146-acc1-cc75cbfee287" />

### After

<img width="500" alt="1-after" src="https://github.com/user-attachments/assets/475a3dd4-d179-4956-86e6-7379432c34a2" />

## Proofs in Expanded Popups

### Before

<img width="500" alt="2-before" src="https://github.com/user-attachments/assets/c5f0afe2-a69a-4487-868e-2388195874bc" />

### After

<img width="500" alt="2-after" src="https://github.com/user-attachments/assets/002c2bb6-cd17-4886-a6a2-485a348b2548" />

## Implications

### Before

<img width="500" alt="3-before" src="https://github.com/user-attachments/assets/a7ba608c-1fa3-43d5-a6d3-b6bc42f2e297" />

### After

<img width="500" alt="3-after" src="https://github.com/user-attachments/assets/6984a57a-2b6a-4e28-b71f-c58c58bf22e7" />

## Content Pages

### Before

<img width="500" alt="4-before" src="https://github.com/user-attachments/assets/932b1f16-c965-42e0-9f2a-c79643292898" />

### After

<img width="500" alt="4-after" src="https://github.com/user-attachments/assets/3ea3116c-3cb9-4106-8c05-e029856d8142" />

## Issues

Despite the hyphenation, some sentences still have excessively large spaces between words.

<img width="500" alt="spaces" src="https://github.com/user-attachments/assets/a2e0f680-c228-4da3-80ba-bc914576ebeb" /><br />

This seems to happen when the browser does not know how to hyphenate a technical term. In this case, one can use a soft hyphen: replacing `subterminal` with `sub&shy;terminal` fixes the issue. However, this is not really scalable.

We also still have the non-trivial issue of formulas being broken across lines (#135).

<img width="500" alt="break" src="https://github.com/user-attachments/assets/20b20faf-c831-4329-93c7-b0edc78deef8" /><br />

More generally, the text needs to remain readable at every viewport width. This is a significant difference from the layout of a classical paper.
