### PR TITLE
Add an example of a cocomplete category without equalizers

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -216,6 +216,7 @@
 		"Kerodon",
 		"Kolmogorov",
 		"Kunen",
+		"Kuratowski",
 		"Lawvere",
 		"libsql",
 		"Lindelöf",

--- a/.cspell.json
+++ b/.cspell.json
@@ -65,6 +65,7 @@
 		"cocomplete",
 		"cocompleteness",
 		"cocompletion",
+		"cocompletions",
 		"cocone",
 		"cocones",
 		"cocongruence",

--- a/.cspell.json
+++ b/.cspell.json
@@ -106,6 +106,7 @@
 		"comonadicity",
 		"compactification",
 		"compactifications",
+		"concretizability",
 		"concretizable",
 		"conormal",
 		"copower",

--- a/content/free-cocompletion.md
+++ b/content/free-cocompletion.md
@@ -1,0 +1,191 @@
+---
+title: The free cocompletion of a locally small category
+description: We investigate the properties of the free cocompletion of a locally small category.
+---
+
+# The free cocompletion of a locally small category
+
+Let $\C$ be a locally small category. All results here can easily be adapted to the case that $\C$ is locally essentially small, and we do not assume that $\C$ is small. Then $\widehat{\C}$ denotes its _free cocompletion_ (often called $P\C$ in the literature when $\C$ is not assumed to be small), which is the full subcategory of $[\C^{\op},\Set]$ consisting presheaves
+$$F : \C^{\op} \to \Set$$
+that are _small_. This condition can be described in many equivalent ways:
+
+1. $F$ is a small colimit of representable functors.
+2. There is a small category $\I$ such that $F$ is the left Kan extension of a presheaf on $\I$ along a functor $\I \to \C$.
+3. There is small subcategory $\I \subseteq \C$ such that $F$ is the left Kan extension of its restriction to $\I$.
+4. The category of elements $\int F$ is [finally small](https://ncatlab.org/nlab/show/finally+small).
+
+Here, the objects of $\int F$ are pairs $(X,a)$, where $X \in \C$ and $a \in F(X)$, and a morphism $(X,a) \to (Y,b)$ is a morphism $f : X \to Y$ with $F(f)(b) = a$. The equivalence of the conditions (1), (2), (3) is proven as Proposition 4.83 in Kelly's book [Basic Concepts of Enriched Category Theory](http://www.tac.mta.ca/tac/reprints/articles/10/tr10.html). The implication (1) $\implies$ (4) is proven as Proposition 3.7 in <a href="https://doi.org/10.1007/s10485-021-09671-9">Kan Extensions are Partial Colimits</a> by Perrone-Tholen (but there must be earlier references). The implication (4) $\implies$ (1) follows from the [co-Yoneda Lemma](https://ncatlab.org/nlab/show/co-Yoneda+lemma)
+$$F \cong \colim_{(X,a) \in \int F} \Hom(-,X)$$
+and the fact that final functors do not "change" colimits; see Proposition 2.5.2 in <a href="https://ncatlab.org/nlab/show/Categories+and+Sheaves" target="_blank">Kashiwara-Schapira</a>.
+
+In contrast to the full presheaf category $[\C^{\op},\Set]$, its subcategory $\widehat{\C}$ of small presheaves is always locally essentially small:
+
+::: Lemma 1
+If $\C$ is a locally small category, then $\widehat{\C}$ is locally essentially small.
+:::
+
+::: Proof
+Let $F : \C^{\op} \to \Set$ be a small presheaf, so that $F \cong \colim_i \Hom(-,X_i)$ for a small diagram $X : \I \to \C$. For every other (small) presheaf $G : \C^{\op} \to \Set$ we compute, using the Yoneda Lemma,
+$$\textstyle \Hom(F,G) \cong \lim_i \Hom(\Hom(-,X_i),G) \cong \lim_i G(X_i),$$
+and the latter is a set.
+:::
+
+But it is usually not locally small:
+
+::: Lemma 2
+If $\widehat{\C}$ is locally small, then $\C$ is small.
+:::
+
+Disclaimer: This result and its proof are not relevant for category theory and are also depending on implementation details of set theory. That $\widehat{\C}$ is locally essentially small is only what matters.
+
+::: Proof
+If $\C$ is empty, there is nothing to prove. Otherwise, choose an object $X \in \C$. Consider the collection of morphisms $\Hom(-,X) \to \Hom(-,X)$, which is surely isomorphic to the set $\Hom(X,X)$. By assumption, it actually _is_ a set. It follows that $\{\id_{\Hom(-,X)}\}$ is a set, and therefore also that $\id_{\Hom(-,X)}$ is a set. This natural transformation is a map that associates to every object $Y \in \Ob(\C)$ the map $\id_{\Hom(Y,X)}$. If we model a map as a set of ordered pairs and ordered pairs as Kuratowski pairs, we get
+
+$$
+\begin{align*}
+\id_{\Hom(-,X)} & = \bigl\{(Y,\id_{\Hom(Y,X)}) : Y \in \Ob(\C)\bigr\} \\
+& = \bigl\{\{\{Y\},\{Y,\id_{\Hom(Y,X)}\}\} : Y \in \Ob(\C)\bigr\}
+\end{align*}
+$$
+
+This construction shows $\Ob(\C) \subseteq \bigcup \bigcup \id_{\Hom(-,X)}$, so that $\Ob(\C)$ is indeed a set.
+:::
+
+::: Lemma 3
+If $\C$ is a locally small category, then $\widehat{\C}$ is cocomplete. Colimits can be constructed objectwise.
+:::
+
+::: Proof
+This follows from cocompleteness of $[\C^{\op},\Set]$ with objectwise constructed colimits and the third characterization of small presheaves above. Details can be found as Proposition 5.34 in Kelly's book.
+:::
+
+The existence of limits in $\widehat{\C}$ is a much more complicated issue, see the paper [_Limits of small functors_](https://arxiv.org/pdf/math/0610439) by Day-Lack. The following result is useful in this regard. Namely, it shows that $\widehat{\C}$ has limits of a given type if and only if small functors are closed under these limits taken in the category of all presheaves.
+
+::: Lemma 4
+For every $X \in \C$ the evaluation functor $\ev_X : \widehat{\C} \to \Set$, $F \mapsto F(X)$ is continuous. In particular, the inclusion functor $\widehat{\C} \hookrightarrow [\C^{\op},\Set]$ is continuous, and every limit that exists in $\widehat{\C}$ is an objectwise limit.
+:::
+
+::: Proof
+By the Yoneda Lemma, the evaluation functor is represented by $\Hom(-,X)$. Thus, it is continuous.
+:::
+
+::: Lemma 5
+A morphism $\alpha : F \to G$ in $\widehat{\C}$ is a monomorphism (resp. epimorphism) if and only if for every $X \in \C$ the map $\alpha(X) : F(X) \to G(X)$ injective (resp. surjective).
+:::
+
+::: Proof
+The direction $\impliedby$ is trivial in each case. For the direction $\implies$, the evaluation functor $\ev_X : \widehat{\C} \to \Set$ is continuous by Lemma 4 and therefore preserves monomorphisms. Furthermore, it is also cocontinuous by Lemma 3 and therefore preserves epimorphisms.
+:::
+
+::: Lemma 6
+If $\C$ is a locally small category, then $\widehat{\C}$ is mono-regular. Actually, every monomorphism is an effective monomorphism. Moreover, monomorphisms are stable under filtered colimits.
+:::
+
+::: Proof
+The first statement is a formal consequence of the fact that every monomorphism in $\Set$ is effective and the already established facts that monomorphisms and pushouts can be understood objectwise. For similar reasons, the second statement is a formal consequence of the corresponding fact for $\Set$.
+:::
+
+::: Lemma 7
+If $\C$ is a locally small category, then $\widehat{\C}$ is infinitary extensive.
+:::
+
+::: Proof
+We need to prove that for a family of small presheaves $(P_i)_{i \in I}$ the coproduct functor
+$$\textstyle \prod_{i \in I} \widehat{\C} / P_i \to \widehat{\C}/\coprod_{i \in I} P_i$$
+is an equivalence of categories. Since $\Set$ is infinitary extensive, also $[\C^{\op},\Set]$ is infinitary extensive, so that the coproduct functor
+$$\textstyle \prod_{i \in I} [\C^{\op},\Set] / P_i \to [\C^{\op},\Set]/\coprod_{i \in I} P_i$$
+is an equivalence of categories. Since $\widehat{\C}$ is a full subcategory of $[\C^{\op},\Set]$ that is closed under coproducts, it remains to prove that if a coproduct of presheaves $\coprod_{i \in I} F_i$ is small, then each $F_i$ is small. For this, it suffices to prove for two presheaves $F,G$ for which $F+G$ is small, that $F$ is small. The category of elements $\int (F+G)$ identifies with $\int F + \int G$. Thus, the claim follows from the next lemma.
+:::
+
+::: Lemma 8
+Let $\C,\D$ be two categories. Assume that the coproduct $\C + \D$ is finally small. Then $\C$ is finally small.
+:::
+
+::: Proof
+Assume that $\I \to \C + \D$ is a final functor, where $\I$ is small. Since $\Cat$ is extensive, we get a decomposition $\I = \I_\C + \I_\D$ with two functors $\I_\C \to \C$ and $\I_\D \to \D$. For every $X \in \C$ the comma category $X \downarrow I_\C$ identifies with the comma category $X \downarrow I$, which is connected. Therefore, $I_\C \to \C$ is final.
+:::
+
+::: Lemma 9
+Let $\C$ be a locally small category. Then $\widehat{\C}$ is co-Malcev.
+:::
+
+::: Proof
+This follows since $\Set$ is co-Malcev and since finite colimits are objectwise.
+:::
+
+::: Proposition 10
+Let $\C$ be a locally small category. Then $\widehat{\C}$ is epi-regular.
+:::
+
+Notice that this would be easy if $\widehat{\C}$ has pullbacks. In that case, every epimorphism would even be effective since this is the case for $\Set$. But in general, $\widehat{\C}$ may fail to have pullbacks. This is why the proof is more complicated.
+
+::: Proof
+First, notice that the Yoneda Lemma and the description of epimorphisms (see Lemma 5) implies that representable functors are [projective objects](https://ncatlab.org/nlab/show/projective+object). Therefore, also coproducts of representable functors are projective.
+
+Now let $\eta : F \to G$ be an epimorphism of small presheaves. Since $F$ is small, there is an epimorphism
+$$F_0 \xrightarrow{~ \pi ~} F,$$
+where $F_0$ is a coproduct of representable functors. Since $G$ is small, there is a coequalizer diagram
+
+$$
+G_1
+\begin{array}{c}
+\xrightarrow{~ \alpha ~ }\\[-1.25ex] \xrightarrow[~ \beta ~ ]{}
+\end{array}
+G_0 \xrightarrow{~ \psi ~} G,
+$$
+
+where $G_0$ and $G_1$ are coproducts of representable functors. Since $G_0$ is projective, there is a morphism $\lambda : G_0 \to F$ such that $\eta \circ \lambda = \psi$. Since $F_0$ is projective, there is a morphism $\mu : F_0 \to G_0$ such that $\psi \circ \mu = \eta \circ \pi$. We get the following diagram, where the outer square and the lower triangle commutes, but not necessarily the upper triangle.
+
+$$
+\begin{CD}
+F_0 @>{\pi}>> F \\
+@V{\mu}VV \,  \, \nearrow{\scriptsize \, \lambda}  @VV{\eta}V \\
+G_0 @>>{\psi}> G
+\end{CD}
+$$
+
+Define the morphisms $\gamma,\delta : G_1 \sqcup F_0 \rightrightarrows F$ by
+$$\gamma|_{G_1} = \lambda \circ \alpha, \quad \delta|_{G_1} = \lambda \circ \beta,$$
+$$\gamma|_{F_0} = \lambda \circ \mu, \quad \delta|_{F_0} = \pi.$$
+We will prove that $\eta : F \to G$ is a coequalizer of $\gamma$ and $\delta$. First, $\eta$ coequalizes these because
+$$\eta \circ \gamma|_{G_1} = \eta \circ \lambda \circ \alpha = \psi \circ \alpha = \psi \circ \beta = \eta \circ \lambda \circ \beta = \eta \circ \delta|_{G_1}$$
+and
+$$\eta \circ \gamma|_{F_0} = \eta \circ \lambda \circ \mu = \psi \circ \mu = \eta \circ \pi = \eta \circ \delta|_{F_0}.$$
+Conversely, suppose that $\vartheta : F \to H$ is a morphism that coequalizes these morphisms, meaning that $\vartheta \circ \lambda \circ \alpha = \vartheta \circ \lambda \circ \beta$ and $\vartheta \circ \lambda \circ \mu = \vartheta \circ \pi$. The first equation means that there is a morphism $\vartheta' : G \to H$ such that $\vartheta' \circ \psi = \vartheta \circ \lambda$. The second equation then becomes
+$$\vartheta \circ \pi = \vartheta' \circ \psi \circ \mu = \vartheta' \circ \eta \circ \pi,$$
+which is equivalent to $\vartheta = \vartheta' \circ \eta$. We have thus shown that every morphism that coequalizes $\alpha$ and $\beta$ factors through $\eta$, and uniqueness is clear since $\eta$ is an epimorphism.
+:::
+
+::: Lemma 11
+Let $\C$ be a locally small category. Then $\widehat{\C}$ has effective congruences.
+:::
+
+::: Proof
+Let $f,g : F \rightrightarrows G$ be a congruence in $\widehat{\C}$. Let $p : G \twoheadrightarrow Q$ be its quotient (i.e. coequalizer) in $\widehat{\C}$, which is constructed objectwise. Applying the functorial definition of a congruence to representable functors in $\widehat{\C}$, we see that for every object $X \in \C$ that $f(X),g(X) : F(X) \rightrightarrows G(X)$ is a congruence in $\Set$. Since congruences in $\Set$ are effective, $f(X),g(X)$ is the kernel pair of $p(X)$; we are also using [this result](/content/effective-congruence-quotients). Therefore, $f,g$ is the kernel pair of $p$ in the category of all presheaves, _a fortiori_ in the category of small presheaves.
+:::
+
+::: Proposition 12
+Let $\C$ be a locally small category. Then $\widehat{\C}$ has effective cocongruences.
+:::
+
+::: Proof
+Let $F \rightrightarrows G$ be a cocongruence in $\widehat{\C}$. Since the inclusion functor $\widehat{\C} \hookrightarrow [\C^{\op},\Set]$ preserves finite colimits by Lemma 3, this is the same as a cocongruence of presheaves where $F,G$ happen to be small. Since cocongruences in $\Set$ are effective (by [this result](/category-implication/regular_epi-regular_extensive_consequences)), and in fact cokernel pairs of their equalizer (see [here](/content/effective-congruence-quotients)), the cocongruence is isomorphic to
+$$F \rightrightarrows F \sqcup_E F,$$
+where $E \coloneqq \eq(F \rightrightarrows G)$ is the objectwise defined equalizer in $[\C^{\op},\Set]$. We would be done if $E$ were small, which however is not the case in general. But we can prove that $E$ is a quotient of a small presheaf, or equivalently, a quotient of a coproduct of representable presheaves, which is sufficient, since any epimorphism $E' \to E$ satisfies $F \sqcup_E F = F \sqcup_{E'} F$. (Such presheaves are also called _petty_ in the literature.)
+
+We view the pushout $P := F \sqcup_E F$ as the union of two copies $F_1,F_2$ of $F$ with $F_1 \cap F_2 = E$. In particular, we regard $E,F_1,F_2$ as sub-presheaves of $P$. For a morphism $f$ in $\C$, we write $f^*$ instead of $P(f)$.
+
+Since $P \cong G$ is small, its category of elements $\int P$ has a finally small subcategory $\K$. Let $K \subseteq \Ob(\C)$ be the set of objects that appear in $\K$. We claim that
+$$\{(A,a) : A \in K, \, a \in E(A)\}$$
+is a weakly terminal set in $\int E$, which is equivalent to saying that the canonical morphism
+$$\textstyle \coprod_{A \in K,\, a \in E(A)} \Hom(-,A) \to E$$
+is an epimorphism of presheaves, as required.
+
+Let $(X,x)$ be an object of $\int E$, i.e. $X \in \Ob(\C)$ and $x \in E(X)$. In particular, $x \in P(X)$. Thus the comma category $(X,x) \downarrow \K$ is connected, and therefore non-empty. Choose an object $f : (X,x) \to (A,a)$. Thus, $A \in K$, $a \in P(A)$, and $f : X \to A$ satisfies $f^*(a)=x$. If $a \in E(A)$, we are done. Assume otherwise and, without loss of generality, $a \in F_1(A)$. Let $b \in F_2(A) \subseteq P(A)$ be the corresponding element in the other copy of $F$. Using the flip automorphism of $P$ that fixes $E$ and exchanges $F_1$ and $F_2$, we see that $f^*(b)=x$. Thus, we also have a morphism $f' : (X,x) \to (A,b)$ with the same underlying morphism $f : X \to A$.
+
+Since $(X,x) \downarrow \K$ is connected, the two morphisms $f$ and $f'$ are connected to each other. Thus, there are morphisms $(X,x) \to (A_i,a_i)$ with $A_i \in K$, $a_i \in P(A_i)$, starting with $f$ and ending with $f'$, such that for each pair of adjacent indices $i,i+1$, there is a morphism $(A_i,a_i) \to (A_{i+1},a_{i+1})$ or a morphism $(A_{i+1},a_{i+1}) \to (A_i,a_i)$. If any $a_i$ is contained in $E(A_i)$, we would be done. Assume, for a contradiction, that this is not the case.
+
+In this case, we can prove inductively that $a_i \in F_1(A_i)$ as follows. The base case follows from $a \in F_1(A)$. If $a_i \in F_1(A_i)$ and there is a morphism $(A_{i+1},a_{i+1}) \to (A_i,a_i)$, we immediately get $a_{i+1} \in F_1(A_{i+1})$ since $F_1$ is a sub-presheaf of $P$. If, on the other hand, there is a morphism $(A_i,a_i) \to (A_{i+1},a_{i+1})$ and $a_{i+1} \notin F_1(A_{i+1})$, we would get $a_{i+1} \in F_2(A_{i+1})$, hence $a_i \in F_1(A_i) \cap F_2(A_i) = E(A_i)$, contradicting our assumption.
+
+Therefore, every $a_i$ lies in $F_1(A_i)$. But the last element in this chain is $b \in F_2(A)$, so we would have $b \in E(A)$, contradicting our assumption.
+:::

--- a/content/isbell_concreteness.md
+++ b/content/isbell_concreteness.md
@@ -1,0 +1,47 @@
+---
+title: Isbell's condition for concretizability
+description: We present a direct proof that concretizable categories satisfy the Isbell condition, which restricts the size of certain spans.
+---
+
+# Isbell's condition for concretizability
+
+Here we reproduce a sufficient condition for [concretizability](/category-property/concretizable) due to Isbell [[I63]](#references). It was further investigated by Freyd [[F73]](#references).
+
+Let $A,B$ be fixed objects of a category. We say that a span $A \leftarrow X \rightarrow B$ over $(A,B)$ _commutes_ with a cospan $A \rightarrow Y \leftarrow B$ if the diagram
+
+$$
+\begin{CD}
+X @>>> A \\
+@VVV @VVV \\
+B @>>> Y
+\end{CD}
+$$
+
+commutes. We say that two spans over $(A,B)$ are _equivalent_ if they commute with exactly the same cospans.
+
+The _Isbell condition_ says that, for each pair of objects $A,B$, the collection of equivalence classes of spans over $(A,B)$ is isomorphic to a set. Equivalently, there must be a set of selected spans over $(A,B)$ such that every span over $(A,B)$ is equivalent to one of the selected spans.
+
+::: Lemma
+Every concretizable category satisfies the Isbell condition.
+:::
+
+::: Proof
+Let $U : \C \to \Set$ be a faithful functor. A span
+$$A \xleftarrow{a} X \xrightarrow{b} B$$
+commutes with a cospan
+$$A \xrightarrow{a'} Y \xleftarrow{b'} B$$
+if and only if $a' \circ a = b' \circ b$. Since $U$ is faithful, this is equivalent to
+$$U(a') \circ U(a) = U(b') \circ U(b).$$
+Define $P_{a,b} \subseteq U(A) \times U(B)$ to be the set of pairs
+$$(U(a)(x),U(b)(x))$$
+for $x \in U(X)$. Then the span commutes with the cospan if and only if
+$$U(a')(u) = U(b')(v)$$
+for every $(u,v) \in P_{a,b}$. Thus, whether a span commutes with a given cospan depends only on the subset $P_{a,b}$.
+
+Call a subset of $U(A) \times U(B)$ _realizable_ if it is of the form $P_{a,b}$ for some span $(a,b)$. Since $U(A) \times U(B)$ is a set, there is a set of realizable subsets. As we have just seen, the map that sends a realizable subset $P_{a,b}$ to the equivalence class of $(a,b)$ is well-defined, and it is clearly surjective. Hence, the collection of equivalence classes of spans over $(A,B)$ is isomorphic to a set.
+:::
+
+## References
+
+[F73] P. J. Freyd, _Concreteness_, J. Pure Appl. Algebra **3** (1973), 171–191  
+[I63] J. Isbell, _Two set-theoretical theorems in categories_, Fund. Math. **53** (1963), 43–49

--- a/content/nice-and-small-presheaves.md
+++ b/content/nice-and-small-presheaves.md
@@ -1,0 +1,88 @@
+---
+title: Nice and small presheaves
+description: We give a concrete description of small presheaves on a specific locally small category.
+---
+
+# Nice and small presheaves
+
+Let $\C$ be the locally small category defined in [this entry](/category/cocompletion-discrete-pair-join). Its objects are $A$, $B$, and every set $X$. The non-identity morphisms are $f,g : A \rightrightarrows B$, $u_X : X \to A$ and $v_X : X \to B$ for every set $X$, and they satisfy the relation $f \circ u_X = g \circ u_X = v_X$. We will give a concrete description of the [small presheaves](https://ncatlab.org/nlab/show/small+presheaf) on $\C$.
+
+Let $F$ be a presheaf on $\C$. Concretely, this means that we are given sets $F(A)$, $F(B)$, and $F(X)$ for every set $X$, two maps $f^*,g^* : F(B) \rightrightarrows F(A)$ and, for every set $X$, a map $u_X^* : F(A) \to F(X)$ satisfying
+$$u_X^* \circ f^* = u_X^* \circ g^* = v_X^*,$$
+where $v_X^* : F(B) \to F(X)$. Thus, we have a commutative diagram
+$$F(B) ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ F(A) \xrightarrow{u_X^*} F(X).$$
+If this is a coequalizer diagram, we say that $F$ is _nice at_ $X$. In particular, $u_X^*$ must be surjective. We say that $F$ is _nice_ if there is a set $S_F$ of sets such that $F$ is nice at every set $X \notin S_F$. We then call $S_F$ an _exceptional set_ for $F$. Intuitively, this means that $F$ is nice "almost everywhere".
+
+Let us check that representable presheaves are nice.
+
+1. When $F = \Hom(-,A)$, the diagram evaluates to
+   $$\varnothing ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ \{\id_A\} \xrightarrow{u_X^*} \{u_X\},$$
+   which is clearly a coequalizer diagram. Thus, this presheaf is nice everywhere.
+
+2. When $F = \Hom(-,B)$, the diagram evaluates to
+   $$\{\id_B\} ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ \{f,g\} \xrightarrow{u_X^*} \{v_X\},$$
+   which is again clearly a coequalizer diagram. Thus, this presheaf is nice everywhere.
+
+3. When $F = \Hom(-,X)$ for a set $X$, the diagram at $X$ evaluates to
+   $$\varnothing ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ \varnothing \xrightarrow{u_X^*} \{\id_X\},$$
+   which is not a coequalizer diagram. At $Y \neq X$, however, the diagram evaluates to
+   $$\varnothing ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ \varnothing \xrightarrow{u_Y^*} \varnothing,$$
+   which is a coequalizer diagram. Hence, the set $\{X\}$ is an exceptional set for $\Hom(-,X)$.
+
+::: Lemma 1
+A presheaf $F$ on $\C$ is small if and only if it is nice.
+:::
+
+::: Proof
+The collection of nice presheaves is clearly closed under small colimits of presheaves, since colimits commute with colimits and colimits of presheaves are computed objectwise. Furthermore, we have seen above that representable presheaves are nice. It follows that every small presheaf is nice.
+
+Conversely, assume that $F$ is a nice presheaf and choose an exceptional set $S_F$. To show that $F$ is small, we will show that its category of elements $\int F$ has a small final subcategory. Let $\D$ be the full subcategory of $\int F$ consisting of the objects
+
+- $(A,a)$ for $a \in F(A)$,
+- $(B,b)$ for $b \in F(B)$,
+- $(X,x)$ for $x \in F(X)$ and $X \in S_F$.
+
+This is a small category since $S_F$ is a set.
+
+We need to show that, for every object $T \in \int F$, the comma category $T \downarrow \D$ is connected. This is trivial for objects $T$ of $\D$. It remains to check this for $T = (X,x)$, where $x \in F(X)$ and $X \notin S_F$. By the definition of $S_F$, the diagram
+$$F(B) ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ F(A) \xrightarrow{u_X^*} F(X) \tag{1}$$
+is a coequalizer diagram. In particular, $u_X^*$ is surjective, so there is some $a \in F(A)$ with $u_X^*(a) = x$. Then $u_X : (X,x) \to (A,a)$ is a morphism in $\int F$, showing that $(X,x) \downarrow \D$ is non-empty.
+
+There are two types of objects in $(X,x) \downarrow \D$. The first type consists of morphisms
+$$u_X : (X,x) \to (A,a),$$
+where $a \in F(A)$ satisfies $u_X^*(a)=x$. The second type consists of morphisms
+$$v_X : (X,x) \to (B,b),$$
+where $b \in F(B)$ satisfies $v_X^*(b)=x$. Every object of the second type is connected to an object of the first type, since $f : (A,f^*(b)) \to (B,b)$ is a morphism with $f \circ u_X = v_X$.
+
+It remains to show that every two objects
+$$(X,x) \to (A,a), \quad (X,x) \to (A,a')$$
+are connected, where $a,a' \in F(A)$ satisfy $u_X^*(a)=u_X^*(a')=x$. Since the diagram $(1)$ is a coequalizer diagram, there is a finite sequence of elements $a_0,\dotsc,a_n$ in $F(A)$, where $a_0=a$ and $a_n=a'$, and a finite sequence of elements $b_0,\dotsc,b_{n-1} \in F(B)$ such that, for every $0 \leq i < n$, either
+$$a_i=f^*(b_i), \quad a_{i+1}=g^*(b_i),$$
+or
+$$a_i=g^*(b_i), \quad a_{i+1}=f^*(b_i).$$
+It suffices to show that $(X,x) \to (A,a_i)$ and $(X,x) \to (A,a_{i+1})$ are connected. We may assume without loss of generality that
+$$a_i=f^*(b_i), \quad a_{i+1}=g^*(b_i).$$
+But then both are connected to $(X,x) \to (B,b_i)$ via the morphisms
+
+$$f : (A,a_i) \to (B,b_i), \quad g : (A,a_{i+1}) \to (B,b_i),$$
+
+respectively.
+:::
+
+We can also characterize the presheaves $G$ that are quotients of small presheaves (called _petty presheaves_ in the literature). By Lemma 1, a necessary condition is that $u_X^* : G(A) \to G(X)$ is surjective for "almost all" sets $X$. It turns out that this condition is sufficient as well.
+
+::: Lemma 2
+Let $G$ be a presheaf on $\C$ such that there is a set of sets $S$ with the property that $u_X^* : G(A) \to G(X)$ is surjective for all sets $X \notin S$. Then there is a small presheaf $F$ with an epimorphism of presheaves $F \to G$.
+:::
+
+::: Proof
+We define the presheaf
+$$F \coloneqq \coprod_{a \in G(A)} \Hom(-,A) \sqcup \coprod_{b \in G(B)} \Hom(-,B) \sqcup \coprod_{X \in S, \, x \in G(X)} \Hom(-,X).$$
+As a coproduct of representable functors, $F$ is a small presheaf. By the Yoneda Lemma, there is a morphism $\alpha : F \to G$ characterized by
+
+- $\alpha_A(i_a(\id_A)) = a$ for $a \in G(A)$
+- $\alpha_B(i_b(\id_B)) = b$ for $b \in G(B)$
+- $\alpha_X(i_x(\id_X)) = x$ for $X \in S$, $x \in G(X)$
+
+In particular, by construction, $\alpha$ hits all elements of $G$ except possibly those $x \in G(X)$ where $X \notin S$. But in this case, $u_X^* : G(A) \to G(X)$ is surjective, and since $\alpha$ hits all elements of $G(A)$, it also hits $x$. Thus, $\alpha$ is an epimorphism.
+:::

--- a/database/data/categories/Sp.yaml
+++ b/database/data/categories/Sp.yaml
@@ -40,7 +40,7 @@ unsatisfied_properties:
     proof: If $1$ denotes the terminal species, there are infinitely many morphisms $1 \to 1 \sqcup 1$ since they correspond to functions $\IN \to \{1,2\}$.
 
   - property: locally small
-    proof: 'Disclaimer: This result and its proof are not relevant for category theory and are also depending on the concrete model of set theory. That this category is locally essentially small is only what matters. Now, consider the terminal species $F=G=1$. Then $\Hom(F,G)$ has just a single element, namely the natural transformation $\alpha$ that sends every finite set $X$ to the unique map $\alpha_X : 1 \to 1$. Formally, $\alpha$ is a map, modelled as a set of ordered pairs $(X,\id_1)$, where $X$ is a finite set. Hence, $\alpha$ is not a set (since finite sets do not form a set), and therefore $\Hom(F,G) = \{\alpha\}$ is also not a set.'
+    proof: Since $\FinSet$ is not small, this follows exactly like Lemma 2 <a href="/content/free-cocompletion">here</a>; but this result is not really relevant and what only matters is that $\Sp$ is locally essentially small.
 
   - property: essentially countable
     proof: 'Any function $f : \IN \to \IN$ can be regarded as a combinatorial species with trivial actions, and distinct functions yield non-isomorphic species.'

--- a/database/data/categories/cocompletion-discrete-pair-join.yaml
+++ b/database/data/categories/cocompletion-discrete-pair-join.yaml
@@ -1,0 +1,186 @@
+id: cocompletion-discrete-pair-join
+name: cocompletion of a discrete–pair join
+notation: $\widehat{\C}$
+objects: small presheaves on the join of a large discrete category with the walking parallel pair
+morphisms: natural transformations
+description: >-
+  This rather technical category has been added as an example of a cocomplete category that does not have equalizers, but it also satisfies many other interesting property combinations.
+
+  To construct it, we start with the category $\C$ that has two objects $A,B$ and every set $X$ as an object. (Instead of the collection of sets, we can take any other large collection.) Apart from the identities, there two morphisms $f,g : A \rightrightarrows B$ and, for every set $X$, a unique morphism $u_X : X \to A$ and a unique morphism $v_X : X \to B$. The composition is defined by $f \circ u_X = g \circ u_X = v_X$. There are no morphisms between distinct sets.
+  $$\begin{array}{c}
+  X \\[0.25ex]
+  {\raisebox{1ex}{$\scriptstyle u_X$}} \!\! \swarrow
+  \qquad
+  \searrow \!\! {\raisebox{1ex}{$\scriptstyle v_X$}} \\
+  A \;\;
+  \begin{array}{c}
+  \xrightarrow{\quad f \quad }\\[-1.25ex]
+  \xrightarrow[\quad g \quad ]{}
+  \end{array}
+  \;\; B
+  \end{array}$$
+  In other words, $\C$ is the <a href="https://ncatlab.org/nlab/show/join+of+categories" target="_blank">join</a> of a large discrete category and the <a href="/category/walking_pair">walking parallel pair</a>.
+  The category in this entry is the free cocompletion $\widehat{\C}$ consisting of <a href="https://ncatlab.org/nlab/show/small+presheaf" target="_blank">small presheaves</a> $\C^{\op} \to \Set$, i.e. those presheaves that can be written as a small colimit of representable functors. See <a href="/content/free-cocompletion">here</a> for a couple of equivalent characterizations that hold for general $\C$, as well as general results on free cocompletions, and see <a href="/content/nice-and-small-presheaves">here</a> for a concrete description of small presheaves in this specific setting.
+nlab_link: null
+tags:
+  - category theory
+
+related:
+  - walking_pair
+  - '2'
+  - Z
+  - Sp
+
+comments:
+  - This category was suggested by Simon Henry in <a href="https://mathoverflow.net/questions/509754" target="_blank">MO/509754</a> and further explained in <a href="https://math.stackexchange.com/questions/5137415" target="_blank">MSE/5137415</a>.
+
+satisfied_properties:
+  - property: locally essentially small
+    proof: This holds for the free cocompletion of every locally small category. See Lemma 1 <a href="/content/free-cocompletion">here</a>.
+
+  - property: cocomplete
+    check_redundancy: false
+    proof: Colimits in every free cocompletion can be constructed objectwise by Lemma 3 <a href="/content/free-cocompletion">here</a>. Alternatively, the claim follows easily from the <a href="/content/nice-and-small-presheaves">description of small presheaves</a>.
+
+  - property: terminal object
+    label: terminal_presheaf_small
+    proof: >-
+      It suffices to check that the terminal presheaf is small. This follows immediately from the <a href="/content/nice-and-small-presheaves">description of small presheaves</a>, since in fact, for every set $X$, the diagram
+      $$1 ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ 1 \xrightarrow{u_X^*} 1$$
+      is a coequalizer diagram. Alternatively, one can easily check that the terminal presheaf is a coequalizer of $f_*,g_* : \Hom(-,A) \rightrightarrows \Hom(-,B)$, which directly implies that it is small.
+
+  - property: epi-regular
+    proof: This holds for the free cocompletion of every locally small category. See Proposition 10 <a href="/content/free-cocompletion">here</a>.
+
+  - property: filtered-colimit-stable monomorphisms
+    proof: This holds for the free cocompletion of every locally small category. See Lemma 6 <a href="/content/free-cocompletion">here</a>.
+
+  - property: infinitary extensive
+    proof: This holds for the free cocompletion of every locally small category. See Lemma 7 <a href="/content/free-cocompletion">here</a>.
+
+  - property: co-Malcev
+    proof: This holds for the free cocompletion of every locally small category. See Lemma 9 <a href="/content/free-cocompletion">here</a>.
+
+  - property: effective congruences
+    proof: This holds for the free cocompletion of every locally small category. See Lemma 11 <a href="/content/free-cocompletion">here</a>.
+
+  - property: effective cocongruences
+    proof: This holds for the free cocompletion of every locally small category. See Proposition 12 <a href="/content/free-cocompletion">here</a>.
+
+unsatisfied_properties:
+  - property: skeletal
+    proof: This is trivial.
+
+  - property: locally small
+    proof: Since $\C$ is not small, this follows from Lemma 2 <a href="/content/free-cocompletion">here</a>; however, this result is not really relevant for category theory, and all that matters is that $\widehat{\C}$ is locally essentially small.
+
+  - property: semi-strongly connected
+    proof: Pick two different sets $X$ and $Y$. There is no morphism $\Hom(-,X) \to \Hom(-,Y)$, since the image of $\id_X$ would be a morphism $X \to Y$, which does not exist. Likewise, there is no morphism in the other direction.
+
+  - property: well-powered
+    references:
+      - terminal_presheaf_small
+    proof: We already know that the terminal presheaf $1$ is small. For every set $X$, the unique morphism $\Hom(-,X) \to 1$ is a monomorphism since $X$ is subterminal in $\C$ (in fact, any morphism with codomain $X$ is the identity). For different sets $X,X'$ we have $\Hom(-,X) \not\cong \Hom(-,X')$ since there is not even a morphism $X \to X'$ in $\C$. This shows that $\Sub(1)$ is not small.
+
+  - property: well-copowered
+    proof: >-
+      For every set $X$, we use $u_X : X \to A$ to construct the pushout
+      $$P_X \coloneqq \Hom(-,A) \sqcup_{\Hom(-,X)} \Hom(-,A).$$
+      It is a quotient of $\Hom(-,A) \sqcup \Hom(-,A)$. For $X \neq Y$ we have $P_X \not\cong P_Y$ because $P_X(Y)$ has two elements, the two copies of $u_Y$, whereas $P_Y(Y)$ has exactly one element, the image of $u_Y$.
+
+  - property: equalizers
+    proof: >-
+      By Lemma 4 <a href="/content/free-cocompletion">here</a>, it suffices to find parallel morphisms of small presheaves whose equalizer in the category of all presheaves is not small. For example, consider the morphisms $f_*,g_* : \Hom(-,A) \rightrightarrows \Hom(-,B)$. Their equalizer $E$ satisfies $E(X) = \{u_X\}$ for every set $X$, $E(A) = \varnothing$, and $E(B) = \varnothing$. In particular, $u_X^* : E(A) \to E(X)$ is never surjective. Therefore, the <a href="/content/nice-and-small-presheaves">description of small presheaves</a> shows that $E$ is not small.
+    label: free_cocompletion_no_equalizers
+    check_redundancy: false # because the counterexample for equalizers of cokernel pairs below is more complicated
+
+  - property: binary powers
+    proof: >-
+      By Lemma 4 <a href="/content/free-cocompletion">here</a>, it suffices to find a small presheaf $F$ whose square $F^2$ in the category of all presheaves is not small. Specifically, we will show that the square $\Hom(-,B)^2$ is not small. By the <a href="/content/nice-and-small-presheaves">description of small presheaves</a>, it is sufficient to show that for every set $X$ the diagram
+      $$\Hom(B,B)^2 ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ \Hom(A,B)^2 \xrightarrow{u_X^*} \Hom(X,B)^2$$
+      is not a coequalizer diagram. It identifies with
+      $$\{(\id_B,\id_B)\} ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ \{f,g\}^2 \xrightarrow{u_X^*} \{(v_X,v_X)\}.$$
+      But the coequalizer of $f^*,g^*$ has three elements, so it cannot be isomorphic to $\{(v_X,v_X)\}$, which has just one element.
+
+  - property: sequential limits
+    proof: >-
+      By Lemma 4 <a href="/content/free-cocompletion">here</a>, it suffices to find a sequence of small presheaves on $\C$ whose limit in the category of all presheaves is not small.
+
+      For $n \in \IN$ define the presheaf $F_n$ on objects by
+      $$F_n(A) = F_n(B) = \IN_{\geq n}, \quad F_n(X)=\{\ast\}$$
+      for every set $X$. The maps $u_X^* : F_n(A) \to F_n(X)$ and $v_X^* : F_n(B) \to F_n(X)$ are uniquely determined. The map $f^* : F_n(B) \to F_n(A)$ is the identity map, while the map $g^* : F_n(B) \to F_n(A)$ is defined by $k \mapsto k + 1$. This is indeed a presheaf since $F_n(X)$ is a singleton. That $F_n$ is small follows from the <a href="/content/nice-and-small-presheaves">description of small presheaves</a>, since for every set $X$
+      $$\IN_{\geq n} ~\overset{k \mapsto k}{\underset{k \mapsto k+1}{\rightrightarrows}}~ \IN_{\geq n} \xrightarrow{!} \{\ast\}$$
+      is a coequalizer diagram; there is exactly one equivalence class under $k \sim k+1$ on $\IN_{\geq n}$.
+
+      Define the morphism $F_{n+1} \to F_n$ as the inclusion at $A$ and $B$ and as the identity at $X$. Naturality is easy to check. Let $F_\infty$ denote the limit presheaf of this sequence. We compute $F_\infty(A) = \bigcap_{n \in \IN} \IN_{\geq n} = \varnothing$. Likewise, we have $F_\infty(B) = \varnothing$. But we have $F_\infty(X) = \{\ast\}$. Thus, for every set $X$, the map $u_X^* : F_\infty(A) \to F_\infty(X)$ is not surjective, so the <a href="/content/nice-and-small-presheaves">description of small presheaves</a> shows that $F_\infty$ is not small.
+
+  - property: ℵ₁-cofiltered limits
+    references:
+      - free_cocompletion_no_equalizers
+    proof: >-
+      More generally, for every regular cardinal $\kappa$, $\kappa$-sequential and hence also $\kappa$-cofiltered limits do not exist. By Lemma 4 <a href="/content/free-cocompletion">here</a>, it suffices to find a $\kappa$-sequence in $\widehat{\C}$ whose presheaf limit is not small.
+
+      For an ordinal $\alpha < \kappa$, let $T_\alpha \coloneqq [\alpha,\kappa)$ be the set of ordinals greater than or equal to $\alpha$ and less than $\kappa$. For $\beta \leq \alpha$, there is an inclusion map $T_\alpha \to T_\beta$. Notice that
+      $$\textstyle \lim_\alpha T_\alpha = \bigcap_{\alpha < \kappa} T_\alpha = \varnothing,$$
+      whereas each $T_\alpha$ is non-empty. These are the only properties of the sets $T_\alpha$ used below.
+
+      For $\alpha < \kappa$, define the presheaf $F_\alpha$ on $\C$ on objects by
+      $$F_\alpha(A) \coloneqq T_\alpha, \quad F_\alpha(B) \coloneqq T_\alpha \times T_\alpha, \quad F_\alpha(X) \coloneqq \{\ast\}.$$
+      The maps $u_X^* : F_\alpha(A) \to F_\alpha(X)$ and $v_X^* : F_\alpha(B) \to F_\alpha(X)$ are uniquely determined. The map $f^* : F_\alpha(B) \to F_\alpha(A)$ is the projection $(x,y) \mapsto x$ onto the first coordinate, while the map $g^* : F_\alpha(B) \to F_\alpha(A)$ is the projection $(x,y) \mapsto y$ onto the second coordinate. Since $F_\alpha(X)$ is a singleton, $F_\alpha$ is clearly a presheaf.
+
+      In fact, it is a small presheaf: By the <a href="/content/nice-and-small-presheaves">description of small presheaves</a>, it suffices to prove that the diagram
+      $$T_\alpha \times T_\alpha ~\overset{(x,y) \mapsto x}{\underset{(x,y) \mapsto y}{\rightrightarrows}}~ T_\alpha \xrightarrow{!} \{\ast\}.$$
+      is a coequalizer diagram. This is clear since $T_\alpha$ is non-empty.
+
+      For $\beta \leq \alpha$, define the morphism $F_\alpha \to F_\beta$ using the inclusion $T_\alpha \to T_\beta$ at $A$, its product with itself at $B$, and the unique map at $X$. Naturality is immediate.
+
+      The presheaf limit $L \coloneqq \lim_\alpha F_\alpha$ takes $A$ and $B$ to $\varnothing$, since $\lim_\alpha T_\alpha = \varnothing$, while it takes each set $X$ to $\{\ast\}$. As we have seen in previous proofs, $L$ is not small, since for every set $X$ the map $u_X^* : L(A) \to L(X)$ is not surjective.
+
+  - property: equalizers of cokernel pairs
+    proof: >-
+      Consider the morphism of small presheaves
+      $$(f_*;g_*) : \Hom(-,A) \sqcup \Hom(-,A) \to \Hom(-,B).$$
+      We claim that its cokernel pair has no equalizer. By Lemma 4 <a href="/content/free-cocompletion">here</a>, this equalizer must be the objectwise defined equalizer $E$ in the category of presheaves. Since the equalizer of the cokernel pair of a map of sets is equal to its image, we see that, for every object $O \in \C$, the set $E(O)$ is the image of the map
+      $$(f_*;g_*) : \Hom(O,A) \sqcup \Hom(O,A) \to \Hom(O,B).$$
+      Therefore, $E(B) = \varnothing$, $E(A) = \{f,g\}$, and $E(X) = \{v_X\}$ for every set $X$.
+
+      We now use the <a href="/content/nice-and-small-presheaves">description of small presheaves</a> to prove that $E$ is not small. It suffices to prove that for every set $X$ the diagram
+      $$\varnothing ~\overset{f^*}{\underset{g^*}{\rightrightarrows}}~ \{f,g\} \xrightarrow{u_X^*} \{v_X\}.$$
+      is not a coequalizer diagram. This is clear since $f^*=g^*$, so the coequalizer of $f^*,g^*$ is just $\{f,g\}$.
+
+  # We can keep this proof here because at some point we will drop
+  # the assumption of cofiltered limits for this property to hold,
+  # and then this proof will not be redundant anymore.
+  # - property: cofiltered-limit-stable epimorphisms
+  #   references:
+  #     - terminal_presheaf_small
+  #   proof: We already know that the terminal presheaf $1$ is small. Now consider for $n \in \IN$ the copower $\IN_{\geq n} \otimes 1$ and for $n < m$ the morphism $\IN_{\geq m} \otimes 1 \to \IN_{\geq n} \otimes 1$ induced by the inclusion $\IN_{\geq m} \subseteq \IN_{\geq n}$. This sequence has a limit, the empty presheaf; this can easily be deduced from $\bigcap_{n \in \IN} \IN_{\geq n} = \varnothing$ in $\IN$. Therefore, the unique morphisms $\IN_{\geq n} \otimes 1 \to 1$ are epimorphisms, but their limit $0 \to 1$ is not.
+
+  - property: concretizable
+    proof: >-
+      It suffices to show that <a href="/content/isbell_concreteness">Isbell's condition for concretizability</a> fails. For each set $X$, consider the span
+      $$\Hom(-,A) \xleftarrow{(u_X)_*} \Hom(-,X) \xrightarrow{(u_X)_*} \Hom(-,A).$$
+      We claim that these spans are pairwise non-equivalent. Thus, for $X \neq Y$, there must be a cospan that commutes with the span associated with $X$ but not with the span associated with $Y$.
+
+      By the Yoneda Lemma, such a cospan is equivalently a small presheaf $F$ together with elements $a,b \in F(A)$ such that $u_X^*(a) = u_X^*(b)$ in $F(X)$, but $u_Y^*(a) \neq u_Y^*(b)$ in $F(Y)$. For the first condition, take the pushout
+      $$F \coloneqq \Hom(-,A) \sqcup_{\Hom(-,X)} \Hom(-,A).$$
+      This is a small presheaf, since it is a pushout of representable presheaves. Let $a,b \in F(A)$ be the images of $\id_A$ under the two canonical maps $\Hom(-,A) \to F$. Since the two copies of $\Hom(-,X)$ are identified in the pushout, we have $u_X^*(a) = u_X^*(b)$ in $F(X)$. On the other hand, $F(Y) = \Hom(Y,A) \sqcup \Hom(Y,A)$ shows that the two copies of $\id_A$ remain distinct, so $u_Y^*(a) \neq u_Y^*(b)$.
+
+special_objects:
+  initial object:
+    description: constant presheaf with value $0$
+  terminal object:
+    description: constant presheaf with value $1$
+  coproducts:
+    description: objectwise defined disjoint union of presheaves
+
+special_morphisms:
+  isomorphisms:
+    description: natural isomorphisms
+    proof: This is trivial.
+  monomorphisms:
+    description: natural transformations that are injective at every object
+    proof: See Lemma 5 <a href="/content/free-cocompletion">here</a>.
+  epimorphisms:
+    description: natural transformations that are surjective at every object
+    proof: See Lemma 5 <a href="/content/free-cocompletion">here</a>.

--- a/database/data/macros.yaml
+++ b/database/data/macros.yaml
@@ -20,6 +20,7 @@
 \F: \mathcal{F}
 \I: \mathcal{I}
 \J: \mathcal{J}
+\K: \mathcal{K}
 \L: \mathcal{L}
 \M: \mathcal{M}
 \O: \mathcal{O}
@@ -48,6 +49,7 @@
 \Bilin: \operatorname{Bilin}
 \Ob: \operatorname{Ob}
 \id: \operatorname{id}
+\ev: \operatorname{ev}
 \card: \operatorname{card}
 \colim: \operatorname{colim}
 \im: \operatorname{im}


### PR DESCRIPTION
This PR adds an example of a cocomplete category without equalizers, namely the "artificial" example presented in my question [MSE/5137415](https://math.stackexchange.com/questions/5137415). It is the free cocompletion of a suitably defined locally small but non-small category, namely the join of a large discrete category with the walking parallel pair. I have been waiting for answers with other, more natural examples for a while now, but apparently, they simply do not exist.

**All properties of this category have now been decided.**

Quite a bit of work was necessary to achieve this. Some proofs can be carried out for free cocompletions in general and have therefore been extracted to a separate content page. To show that the category is not concretizable, Isbell's condition for concretizability has been added. Most of the other proofs, however, depend on a concrete description of the small presheaves in this particular situation.

The new category is not just a witness to "cocomplete &and; &not;equalizers", but also to several other property combinations. More precisely, the combinations script (cf. #347) allows us to list **78** new combinations (see below) witnessed by this new category. If we also take the duals into account, the number is even **153**. The number of consistent combinations of the form p &and; &not;q without witnesses has decreased from 886 to 733. This is still a large number, but the reduction is remarkable. It contributes to [this milestone](https://github.com/ScriptRaccoon/CatDat/milestone/1).

- locally essentially small ∧ ¬concretizable
- cocomplete ∧ ¬binary powers
- cocomplete ∧ ¬binary products
- cocomplete ∧ ¬coequalizers of kernel pairs
- cocomplete ∧ ¬cofiltered limits
- cocomplete ∧ ¬connected limits
- cocomplete ∧ ¬coquotients of cocongruences
- cocomplete ∧ ¬coreflexive equalizers
- cocomplete ∧ ¬cosifted limits
- cocomplete ∧ ¬directed limits
- cocomplete ∧ ¬equalizers
- cocomplete ∧ ¬equalizers of cokernel pairs
- cocomplete ∧ ¬kernel pairs
- cocomplete ∧ ¬pullbacks
- cocomplete ∧ ¬sequential limits
- cocomplete ∧ ¬wide pullbacks
- cocomplete ∧ ¬ℵ₁-cofiltered limits
- filtered-colimit-stable monomorphisms ∧ ¬generating set
- infinitary extensive ∧ ¬binary powers
- infinitary extensive ∧ ¬binary products
- infinitary extensive ∧ ¬coquotients of cocongruences
- infinitary extensive ∧ ¬coreflexive equalizers
- infinitary extensive ∧ ¬countably distributive
- infinitary extensive ∧ ¬distributive
- infinitary extensive ∧ ¬equalizers
- infinitary extensive ∧ ¬finite powers
- infinitary extensive ∧ ¬finite products
- infinitary extensive ∧ ¬finitely complete
- infinitary extensive ∧ ¬infinitary distributive
- infinitary extensive ∧ ¬kernel pairs
- infinitary extensive ∧ ¬parametrized natural numbers object
- infinitary extensive ∧ ¬pullbacks
- co-Malcev ∧ ¬equalizers of cokernel pairs
- effective cocongruences ∧ ¬coquotients of cocongruences
- coproducts ∧ ¬binary powers
- coproducts ∧ ¬binary products
- coproducts ∧ ¬coquotients of cocongruences
- countably extensive ∧ ¬binary powers
- countably extensive ∧ ¬binary products
- countably extensive ∧ ¬coquotients of cocongruences
- countably extensive ∧ ¬countably distributive
- countably extensive ∧ ¬distributive
- countably extensive ∧ ¬finite powers
- countably extensive ∧ ¬finite products
- countably extensive ∧ ¬parametrized natural numbers object
- connected colimits ∧ ¬equalizers of cokernel pairs
- multi-cocomplete ∧ ¬coequalizers of kernel pairs
- multi-cocomplete ∧ ¬cofiltered limits
- multi-cocomplete ∧ ¬connected limits
- multi-cocomplete ∧ ¬coquotients of cocongruences
- multi-cocomplete ∧ ¬coreflexive equalizers
- multi-cocomplete ∧ ¬cosifted limits
- multi-cocomplete ∧ ¬directed limits
- multi-cocomplete ∧ ¬equalizers
- multi-cocomplete ∧ ¬kernel pairs
- multi-cocomplete ∧ ¬pullbacks
- multi-cocomplete ∧ ¬sequential limits
- multi-cocomplete ∧ ¬wide pullbacks
- multi-cocomplete ∧ ¬ℵ₁-cofiltered limits
- countable coproducts ∧ ¬binary powers
- countable coproducts ∧ ¬binary products
- extensive ∧ ¬coquotients of cocongruences
- copowers ∧ ¬binary powers
- copowers ∧ ¬binary products
- copowers ∧ ¬coquotients of cocongruences
- ℵ₂-small coproducts ∧ ¬binary powers
- ℵ₂-small coproducts ∧ ¬binary products
- ℵ₂-small coproducts ∧ ¬coquotients of cocongruences
- wide pushouts ∧ ¬equalizers of cokernel pairs
- strict initial object ∧ ¬coquotients of cocongruences
- ℵ₂-small copowers ∧ ¬binary powers
- ℵ₂-small copowers ∧ ¬binary products
- ℵ₂-small copowers ∧ ¬coquotients of cocongruences
- countable copowers ∧ ¬binary powers
- countable copowers ∧ ¬binary products
- disjoint coproducts ∧ ¬binary powers
- disjoint coproducts ∧ ¬binary products
- disjoint coproducts ∧ ¬coquotients of cocongruences