### PR TITLE
Combinations script

### DIFF
--- a/database/scripts/combinations.ts
+++ b/database/scripts/combinations.ts
@@ -1,0 +1,102 @@
+import { get_client } from '$shared/db'
+import { is_structure_type, type StructureType } from '$shared/config'
+import { remove_underscores } from '$shared/utils'
+
+/**
+ * This script prints the combinations of the form p ∧ ¬q
+ * that are witnessed by a given structure but by no other
+ * structure in the database. In particular, it can be used
+ * when adding new structures to the database to detect which
+ * combinations are newly witnessed.
+ */
+
+const db = get_client({ readonly: true })
+
+const args = process.argv.slice(2)
+
+const [structure_id, type] = args
+
+if (args.length !== 2 || !structure_id || !type) {
+	console.error('Expected exactly 2 arguments: <structure-id> <structure-type>.')
+	process.exit(1)
+}
+
+if (!is_structure_type(type)) {
+	console.error(`Unknown structure type: ${type}`)
+	process.exit(1)
+}
+
+const structure = db
+	.prepare<
+		[string, StructureType],
+		{ id: string }
+	>(`SELECT id FROM structures WHERE id = ? AND type = ?`)
+	.get(structure_id, type)
+
+if (!structure) {
+	console.error(
+		`No ${remove_underscores(type)} with ID "${structure_id}" exists in the database.`
+	)
+	process.exit(1)
+}
+
+const property_duals = db
+	.prepare<
+		[StructureType],
+		{ id: string; dual_property_id: string | null }
+	>(`SELECT id, dual_property_id FROM properties WHERE type = ?`)
+	.all(type)
+
+const dual_property_ids = new Map(
+	property_duals.map(({ id, dual_property_id }) => [id, dual_property_id])
+)
+
+const combinations = db
+	.prepare<[StructureType], { structure_id: string; p: string; q: string }>(
+		`SELECT
+			a.structure_id,
+			a.property_id AS p,
+			an.property_id AS q
+		FROM property_assignments a
+		JOIN property_assignments an
+			ON an.structure_id = a.structure_id AND an.type = a.type
+		WHERE a.type = ?
+			AND a.is_satisfied = TRUE
+			AND an.is_satisfied = FALSE`
+	)
+	.all(type)
+
+const other_combinations = new Set(
+	combinations
+		.filter((comb) => comb.structure_id !== structure_id)
+		.flatMap(({ p, q }) => combination_keys(p, q))
+)
+
+const unique_combinations = combinations
+	.filter(
+		(comb) =>
+			comb.structure_id === structure_id &&
+			combination_keys(comb.p, comb.q).every((key) => !other_combinations.has(key))
+	)
+	.map(({ p, q }) => ({ p, q }))
+
+console.info(
+	`Unique witnessed combinations for ${remove_underscores(type)} with ID "${structure_id}":`
+)
+
+if (unique_combinations.length === 0) {
+	console.info('None')
+	process.exit(0)
+}
+
+for (const { p, q } of unique_combinations) {
+	console.info(`- ${p} ∧ ¬${q}`)
+}
+
+function combination_keys(p: string, q: string): string[] {
+	const keys = new Set<string>([`${p}|${q}`])
+	const dual_p = dual_property_ids.get(p) ?? null
+	const dual_q = dual_property_ids.get(q) ?? null
+	if (dual_p && dual_q) keys.add(`${dual_p}|${dual_q}`)
+	return [...keys]
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"db:update": "pnpm db:seed && pnpm db:deduce && pnpm db:test && pnpm db:snapshot",
 		"db:watch": "tsx --tsconfig database/tsconfig.json database/scripts/watch.ts",
 		"db:redundancies": "tsx --tsconfig database/tsconfig.json database/scripts/redundancies.ts",
+		"db:combinations": "tsx --tsconfig database/tsconfig.json database/scripts/combinations.ts",
 		"e2e": "PUBLIC_PLAYWRIGHT=true pnpm exec playwright test",
 		"e2e:debug": "PUBLIC_PLAYWRIGHT=true pnpm exec playwright test --debug",
 		"e2e:ui": "PUBLIC_PLAYWRIGHT=true pnpm exec playwright test --ui"


### PR DESCRIPTION
When adding a new category (or a new functor, etc.) to the database, it is useful to see which combinations of properties are witnessed by the new structure but have not been witnessed before. Although the `/missing` page lists all consistent combinations that are not yet witnessed, it is cumbersome to manually check which combinations disappear after adding a new structure.

Therefore, this PR adds a new command-line script that lists all combinations of properties of the form $p \land \neg q$ that are witnessed by a given structure (or its dual), but by no other structure of the same type.

Of course, the results may change when other structures are added in the future. For example, currently the Stone-Cech-compactification functor is the only functor in the database that is a reflector but does not preserve binary products, but [there are other examples too](https://math.stackexchange.com/questions/5144819/examples-of-reflectors-that-dont-preserve-binary-products).

This script has been developed while working on #340, which adds a category witnessing many new combinations. The idea came already while working on #305 and #306, which added several functors to witness all consistent functor property combinations.

## Usage

```text
pnpm db:combinations <structure-id> <structure-type>
```

## Examples

### The category of groups

```text
pnpm db:combinations Grp category
```

prints:

```text  
Unique witnessed combinations for category with ID "Grp":
- conormal ∧ ¬cogenerating set
- conormal ∧ ¬extremal cogenerating set
```

### The dual category of topological spaces

In this case, the ID needs to be written in quotes.

```text
pnpm db:combinations 'Top_*' category
```

prints:

```text
Unique witnessed combinations for category with ID "Top_*":
- counital ∧ ¬ℵ₁-accessible
- CIP ∧ ¬extremal generating set
- CIP ∧ ¬extremal generator
```

### The functor Q x - on topological spaces

```text
pnpm db:combinations rational_product functor
```

prints:

```
Unique witnessed combinations for functor with ID "rational_product":
- preserves epimorphisms ∧ ¬preserves regular epimorphisms
```

### The Stone-Cech-compactification functor

```text
pnpm db:combinations stone-cech-compactification functor
```

prints:

```text
Unique witnessed combinations for functor with ID "stone-cech-compactification":
- reflector ∧ ¬preserves binary products
- reflector ∧ ¬preserves finite products
```

### The category of non-empty sets

This example shows that "weird" categories tend to witness many combinations.

```text
pnpm db:combinations Setne category
```

prints:

```text
Unique witnessed combinations for category with ID "Setne":
- products ∧ ¬cofiltered
- products ∧ ¬ℵ₁-cofiltered
- cartesian closed ∧ ¬cofiltered
- cartesian closed ∧ ¬coquotients of cocongruences
- cartesian closed ∧ ¬coreflexive equalizers
- cartesian closed ∧ ¬equalizers
- cartesian closed ∧ ¬finitely complete
- cartesian closed ∧ ¬pullbacks
- cartesian closed ∧ ¬ℵ₁-cofiltered limits
- mono-regular ∧ ¬coquotients of cocongruences
- mono-regular ∧ ¬effective cocongruences
- epi-regular ∧ ¬coquotients of cocongruences
- epi-regular ∧ ¬effective cocongruences
- finitely accessible ∧ ¬coquotients of cocongruences
- finitely accessible ∧ ¬ℵ₁-cofiltered limits
- generalized variety ∧ ¬coquotients of cocongruences
- generalized variety ∧ ¬ℵ₁-cofiltered limits
- parametrized natural numbers object ∧ ¬cofiltered
- parametrized natural numbers object ∧ ¬coquotients of cocongruences
- parametrized natural numbers object ∧ ¬countable copowers
- parametrized natural numbers object ∧ ¬countable coproducts
- parametrized natural numbers object ∧ ¬distributive
- parametrized natural numbers object ∧ ¬finite copowers
- parametrized natural numbers object ∧ ¬finite coproducts
- parametrized natural numbers object ∧ ¬initial object
- parametrized natural numbers object ∧ ¬multi-initial object
- parametrized natural numbers object ∧ ¬strict initial object
- parametrized natural numbers object ∧ ¬ℵ₁-cofiltered
- multi-complete ∧ ¬coquotients of cocongruences
- multi-complete ∧ ¬coreflexive equalizers
- multi-complete ∧ ¬ℵ₁-cofiltered limits
- natural numbers object ∧ ¬cofiltered
- natural numbers object ∧ ¬coquotients of cocongruences
- natural numbers object ∧ ¬initial object
- natural numbers object ∧ ¬multi-initial object
- natural numbers object ∧ ¬ℵ₁-cofiltered
- filtered-colimit-stable monomorphisms ∧ ¬coquotients of cocongruences
- filtered-colimit-stable monomorphisms ∧ ¬ℵ₁-cofiltered limits
- ℵ₁-accessible ∧ ¬coquotients of cocongruences
- ℵ₁-accessible ∧ ¬ℵ₁-cofiltered limits
- filtered colimits ∧ ¬coquotients of cocongruences
- filtered colimits ∧ ¬ℵ₁-cofiltered limits
- sifted colimits ∧ ¬coquotients of cocongruences
- sifted colimits ∧ ¬ℵ₁-cofiltered limits
- balanced ∧ ¬coquotients of cocongruences
- balanced ∧ ¬effective cocongruences
- ℵ₂-small products ∧ ¬cofiltered
- ℵ₂-small products ∧ ¬ℵ₁-cofiltered
- ℵ₁-filtered colimits ∧ ¬coquotients of cocongruences
- ℵ₁-filtered colimits ∧ ¬ℵ₁-cofiltered limits
- cartesian filtered colimits ∧ ¬cofiltered
- cartesian filtered colimits ∧ ¬coquotients of cocongruences
- cartesian filtered colimits ∧ ¬coreflexive equalizers
- cartesian filtered colimits ∧ ¬equalizers
- cartesian filtered colimits ∧ ¬finitely complete
- cartesian filtered colimits ∧ ¬pullbacks
- cartesian filtered colimits ∧ ¬ℵ₁-cofiltered limits
- directed colimits ∧ ¬coquotients of cocongruences
- directed colimits ∧ ¬ℵ₁-cofiltered limits
- countable products ∧ ¬cofiltered
- countable products ∧ ¬ℵ₁-cofiltered
- disjoint products ∧ ¬cofiltered
- disjoint products ∧ ¬finite copowers
- disjoint products ∧ ¬finite coproducts
- disjoint products ∧ ¬initial object
- disjoint products ∧ ¬multi-initial object
- disjoint products ∧ ¬ℵ₁-cofiltered
- wide pushouts ∧ ¬coquotients of cocongruences
- wide pushouts ∧ ¬coreflexive equalizers
- wide pushouts ∧ ¬ℵ₁-cofiltered limits
- connected colimits ∧ ¬coquotients of cocongruences
- connected colimits ∧ ¬coreflexive equalizers
- connected colimits ∧ ¬ℵ₁-cofiltered limits
```

### The delooping of the ordinals

This is another example that shows that "weird" categories tend to witness many combinations.

```text
pnpm db:combinations BOn category
```

prints:

```text
Unique witnessed combinations for category with ID "BOn":
- cogenerating set ∧ ¬concretizable
- cogenerating set ∧ ¬locally essentially small
- cogenerator ∧ ¬concretizable
- cogenerator ∧ ¬locally essentially small
- core-connected ∧ ¬concretizable
- core-connected ∧ ¬essentially small
- core-connected ∧ ¬locally essentially small
- core-connected ∧ ¬locally small
- core-connected ∧ ¬regular-subobject-trivial
- core-connected ∧ ¬self-dual
- core-connected ∧ ¬small
- core-connected ∧ ¬well-powered
- core-thin ∧ ¬concretizable
- core-thin ∧ ¬locally essentially small
- core-thin ∧ ¬locally small
- extremal cogenerating set ∧ ¬concretizable
- extremal cogenerating set ∧ ¬locally essentially small
- extremal cogenerating set ∧ ¬well-powered
- extremal cogenerator ∧ ¬concretizable
- extremal cogenerator ∧ ¬locally essentially small
- extremal cogenerator ∧ ¬well-powered
- extremal generating set ∧ ¬concretizable
- extremal generating set ∧ ¬locally essentially small
- extremal generating set ∧ ¬well-powered
- extremal generator ∧ ¬concretizable
- extremal generator ∧ ¬locally essentially small
- extremal generator ∧ ¬well-powered
- gaunt ∧ ¬concretizable
- gaunt ∧ ¬locally essentially small
- gaunt ∧ ¬locally small
- generating set ∧ ¬concretizable
- generating set ∧ ¬locally essentially small
- generator ∧ ¬concretizable
- generator ∧ ¬locally essentially small
- left cancellative ∧ ¬concretizable
- left cancellative ∧ ¬locally essentially small
- left cancellative ∧ ¬locally small
- locally cartesian closed ∧ ¬concretizable
- locally cartesian closed ∧ ¬locally essentially small
- regular-quotient-trivial ∧ ¬concretizable
- regular-quotient-trivial ∧ ¬locally essentially small
- regular-quotient-trivial ∧ ¬locally small
- semi-strongly connected ∧ ¬concretizable
- semi-strongly connected ∧ ¬locally essentially small
- semi-strongly connected ∧ ¬locally small
- skeletal ∧ ¬concretizable
- skeletal ∧ ¬locally essentially small
- skeletal ∧ ¬locally small
- strongly connected ∧ ¬concretizable
- strongly connected ∧ ¬locally essentially small
- strongly connected ∧ ¬locally small
- strongly connected ∧ ¬well-powered
- well-copowered ∧ ¬concretizable
- well-copowered ∧ ¬locally essentially small
```

### The category of topological spaces

Actually, most structures have no unique combinations. In this case, `None` is printed.

```text
Unique witnessed combinations for category with ID "Top":
None
```