### PR TITLE
Three results on Cauchy complete categories

### DIFF
--- a/database/data/categories/FinSet_even.yaml
+++ b/database/data/categories/FinSet_even.yaml
@@ -59,9 +59,7 @@ satisfied_properties:
     proof: In fact, every small diagram has a cocone in $\FinSet_{\even}$. We take the colimit in $\Set$ and then map it to $\{0,1\}$ via a constant map.
 
   - property: effective congruences
-    proof: Let $E \rightrightarrows X$ be a congruence in $\FinSet_{\even}$. This means that the induced map of sets $E \to X \times X$ is a monomorphism, i.e. injective, and that for every test object $T$ of $\FinSet_{\even}$, the induced injective map $\Hom(T,E) \to \Hom(T,X) \times \Hom(T,X)$ is an equivalence relation in $\Set$. By applying this to $T = \{0,1\}$ and constant maps, it is easy to check that $E \rightrightarrows X$ is a congruence in $\Set$. It is therefore the kernel pair of the projection $X \twoheadrightarrow X/E$ in $\Set$, and hence also in $\FinSet$. If $X/E$ has even cardinality, this remains true in $\FinSet_{\even}$, and we are done. If not, we simply compose the projection with the inclusion $X/E \hookrightarrow X/E + \{\ast\}$. The resulting map $X \to X/E + \{\ast\}$ is a morphism in $\FinSet_{\even}$ with kernel pair $E \rightrightarrows X$. (The last step is also an indication that quotients of congruences do not exist in general, which we will prove later.)
-    references:
-      - FinSet_even_no_kernel_pair_quotients
+    proof: Let $E \rightrightarrows X$ be a congruence in $\FinSet_{\even}$. This means that the induced map of sets $E \to X \times X$ is a monomorphism, i.e. injective, and that for every test object $T$ of $\FinSet_{\even}$, the induced injective map $\Hom(T,E) \to \Hom(T,X) \times \Hom(T,X)$ is an equivalence relation in $\Set$. By applying this to $T = \{0,1\}$ and constant maps, it is easy to check that $E \rightrightarrows X$ is a congruence in $\Set$. It is therefore the kernel pair of the projection $X \twoheadrightarrow X/E$ in $\Set$, and hence also in $\FinSet$. If $X/E$ has even cardinality, this remains true in $\FinSet_{\even}$, and we are done. If not, we simply compose the projection with the inclusion $X/E \hookrightarrow X/E + \{\ast\}$. The resulting map $X \to X/E + \{\ast\}$ is a morphism in $\FinSet_{\even}$ with kernel pair $E \rightrightarrows X$. (The last step is also an indication that quotients of congruences do not exist in general, which we will see later.)
 
   - property: effective cocongruences
     proof: Let $X \rightrightarrows Q$ be a cocongruence in $\FinSet_{\even}$. In particular, it is a coreflexive corelation. Then $X+X \to Q$ is an epimorphism, hence surjective. It follows that $X \rightrightarrows Q$ is also a coreflexive corelation in $\Set$. Since <a href="/category/Set">$\Set$</a> is co-Malcev and has effective cocongruences (by <a href="/category-implication/regular_epi-regular_extensive_consequences">this result</a>), there is a subset $Y \subseteq X$ such that $Q \cong X \sqcup_Y X$ in $\Set$, with $X \rightrightarrows Q$ corresponding to the two pushout inclusions. We have $\card(Q) = 2 \card(X) - \card(Y)$, so $\card(Y)$ is even. Hence, $Q \cong X \sqcup_Y X$ remains true in $\FinSet_{\even}$.
@@ -93,22 +91,9 @@ unsatisfied_properties:
 
   - property: extensive
     proof: >-
-      We will show that pullbacks along coproduct inclusions do not exist in general. First, we observe that the inclusion functor $\FinSet_{\even} \hookrightarrow \Set$ is continuous. This follows from the dual of Lemma 1 <a href="/content/inclusion-functors">here</a> since $\FinSet_{\even}$ contains the extremal generator $\{0,1\}$ of $\Set$.
+      We will show that pullbacks along coproduct inclusions do not exist in general. First, we observe that the inclusion functor $\FinSet_{\even} \hookrightarrow \Set$ is continuous. This follows from the dual of Lemma 1 <a href="/content/inclusion-functors">here</a> since $\FinSet_{\even}$ contains the extremal generator $\{0,1\}$ of $\Set$. (For a similar reason the inclusion functor is cocontinuous since $\{0,1\}$ is also an extremal cogenerator of $\Set$.)
+
       Now consider the inclusion map $\{0,2\} \to \{0,1,2,3\} = \{0,1\} \sqcup \{2,3\}$. Assume that the pullback of this map along the coproduct inclusion from $\{0,1\}$ exists in $\FinSet_{\even}$. Since the inclusion functor to $\Set$ preserves pullbacks, we can compute it as the pullback in $\Set$, which is simply the intersection $\{0,2\} \cap \{0,1\} = \{0\}$. But this is not an object of $\FinSet_{\even}$.
-    label: FinSet_even_inclusion_continuous
-
-  - property: cokernel pairs
-    proof: >-
-      First, the inclusion functor $\FinSet_{\even} \hookrightarrow \Set$ is cocontinuous. This follows from Lemma 1 <a href="/content/inclusion-functors">here</a> since $\FinSet_{\even}$ contains the extremal cogenerator $\{0,1\}$ of $\Set$.
-      Now consider the constant map $e : \{0,1\} \to \{0,1\}$, $x \mapsto 0$. If it has a cokernel pair in $\FinSet_{\even}$, this must be the cokernel pair in $\Set$, i.e. $\{0,1\} \sqcup_{\{0\}} \{0,1\} \cong \{0,1,1'\}$, whose cardinality, however, is odd.
-    label: FinSet_even_inclusion_cocontinuous
-
-  - property: coequalizers of kernel pairs
-    proof: 'We already know that the inclusion functor $\FinSet_{\even} \hookrightarrow \Set$ is continuous and cocontinuous. Moreover, the coequalizer of the kernel pair of a map of sets is simply its image. Thus, it suffices to note that the image of, say, $e : \{0,1\} \to \{0,1\}$, $x \mapsto 0$, does not have even cardinality.'
-    label: FinSet_even_no_kernel_pair_quotients
-    references:
-      - FinSet_even_inclusion_continuous
-      - FinSet_even_inclusion_cocontinuous
 
 special_objects:
   initial object:

--- a/database/data/categories/FinSet_odd.yaml
+++ b/database/data/categories/FinSet_odd.yaml
@@ -83,22 +83,7 @@ unsatisfied_properties:
     proof: 'The maps $0,1 : \{\ast\} \rightrightarrows \{0,1,2\}$ are not equalized by any morphism, since this would amount to a set $X$ in $\FinSet_{\odd}$ such that $! : X \to \{*\}$ factors through $\varnothing$, i.e. $X = \varnothing$, which is not a valid object of $\FinSet_{\odd}$.'
 
   - property: binary copowers
-    proof: A direct proof is possible, but (also for the remaining proofs) it is best to first establish that the inclusion functor $\FinSet_{\odd} \hookrightarrow \Set$ is cocontinuous. This follows from Lemma 1 <a href="/content/inclusion-functors">here</a> since $\FinSet_{\odd}$ contains the extremal cogenerator $\{0,1,2\}$ of $\Set$. Therefore, binary copowers exist only if $\FinSet_{\odd}$ is closed under binary copowers in $\Set$. But $\{0\} \sqcup \{0\}$ does not have odd cardinality.
-    label: FinSet_odd_inclusion_cocontinuous
-
-  - property: cokernel pairs
-    proof: >-
-      We already know that the inclusion functor $\FinSet_{\odd} \hookrightarrow \Set$ is cocontinuous. Now consider any map $e : \{0,1,2\} \to \{0,1,2\}$ with image $\{0,1\}$. It is a morphism in $\FinSet_{\odd}$. If it has a cokernel pair in $\FinSet_{\odd}$, this must be the cokernel pair in $\Set$, i.e. $\{0,1,2\} \sqcup_{\{0,1\}} \{0,1,2\} \cong \{0,1,2,2'\}$, whose cardinality, however, is even.
-    references:
-      - FinSet_odd_inclusion_cocontinuous
-
-  - property: quotients of congruences
-    proof: >-
-      Partition a finite set $X$ of cardinality $3$ into sets of cardinalities $1,2$. This yields an equivalence relation $E \subseteq X \times X$ with
-      $$\card(E) = 1^2 + 2^2 = 5.$$
-      Thus, $E \rightrightarrows X$ is a congruence in $\FinSet_{\odd}$. We already know that the inclusion functor $\FinSet_{\odd} \hookrightarrow \Set$ is cocontinuous, so a quotient in $\FinSet_{\odd}$ must be the quotient taken in $\Set$. However, since there are $2$ equivalence classes, the set $X/E$ has cardinality $2$. Thus, the quotient does not exist in $\FinSet_{\odd}$.
-    references:
-      - FinSet_odd_inclusion_cocontinuous
+    proof: A direct proof is possible, but it is best to first establish that the inclusion functor $\FinSet_{\odd} \hookrightarrow \Set$ is cocontinuous. This follows from Lemma 1 <a href="/content/inclusion-functors">here</a> since $\FinSet_{\odd}$ contains the extremal cogenerator $\{0,1,2\}$ of $\Set$. Therefore, binary copowers exist only if $\FinSet_{\odd}$ is closed under binary copowers in $\Set$. But $\{0\} \sqcup \{0\}$ does not have odd cardinality.
 
   - property: natural numbers object
     proof: By Lemma 2 <a href="/content/natural_numbers_objects">here</a>, if $(N,z,s)$ is a natural numbers object, then $N \cong 1 \sqcup N$. But there is no finite set with this property.

--- a/database/data/categories/FinSet_power_3.yaml
+++ b/database/data/categories/FinSet_power_3.yaml
@@ -80,11 +80,6 @@ unsatisfied_properties:
       Remark: If we instead consider finite sets of cardinality a power of $2$, then binary copowers do exist, but binary coproducts still do not exist, since $2^0+2^1=3$ is not a power of $2$.
     label: FinSet_power_3_inclusion_cocontinuous
 
-  - property: cokernel pairs
-    proof: We already know that the inclusion functor $\FinSet_{3^\bullet} \hookrightarrow \Set$ is cocontinuous, so it suffices to find an example of a map in $\FinSet_{3^\bullet}$ whose cokernel pair in $\Set$ is not contained in $\FinSet_{3^\bullet}$. Take the inclusion map $\{0\} \to \{0,1,2\}$. Then in $\Set$ we compute $\{0,1,2\} \sqcup_{\{0\}} \{0,1,2\} \cong \{0,1,2,1',2'\}$, which has $5$ elements, which is not a power of $3$.
-    references:
-      - FinSet_power_3_inclusion_cocontinuous
-
   - property: kernel pairs
     proof: >-
       First, notice that the inclusion functor $\FinSet_{3^\bullet} \hookrightarrow \Set$ is continuous since it is representable. Therefore, if a map $f : X \to Y$ has a kernel pair in $\FinSet_{3^\bullet}$, it must be the set $\{(x,x') \in X \times X : f(x)=f(x')\}$.

--- a/database/data/categories/Pos_noiso.yaml
+++ b/database/data/categories/Pos_noiso.yaml
@@ -71,12 +71,6 @@ unsatisfied_properties:
       It is easy to check that the element $(1,1')$ is isolated.
     references:
       - pos_extremal_generator
-    label: Pos_noiso_inclusion_continuous
-
-  - property: equalizers of cokernel pairs
-    proof: Consider the constant order-preserving map $\{0 < 1\} \to \{0 < 1\}$, $x \mapsto 0$. Its cokernel pair is $\{0 < 1, 0 < 1'\}$ with the two obvious maps from $\{0 < 1\}$. Since we have seen above that the inclusion functor $\Pos_{\noiso} \hookrightarrow \Pos$ is continuous, the equalizer of $\{0 < 1\} \rightrightarrows \{0 < 1, 0 < 1'\}$ must be the poset $\{0\}$, which, however, has an isolated point.
-    references:
-      - Pos_noiso_inclusion_continuous
 
   - property: quotients of congruences
     proof: The inclusion functor $\Pos_{\noiso} \hookrightarrow \Pos$ is cocontinuous by Lemma 1 <a href="/content/inclusion-functors">here</a>, since $\Pos_{\noiso}$ contains the extremal cogenerator $\{0 < 1\}$ of $\Pos$. Therefore, it suffices to find a congruence whose quotient in $\Pos$ has an isolated point. Take any non-empty poset $X$ without isolated points, such as $\{0 < 1\}$, and consider the maximal congruence $X \times X \rightrightarrows X$. Its quotient in $\Pos$ is just $\{\ast\}$, which therefore has an isolated point.

--- a/database/data/categories/Rel.yaml
+++ b/database/data/categories/Rel.yaml
@@ -61,9 +61,6 @@ unsatisfied_properties:
   - property: normal
     proof: The construction of equalizers in $\Rel$ shows that they are injective functions, but <a href="https://math.stackexchange.com/questions/350716" target="_blank">MSE/350716</a> shows that monomorphisms in $\Rel$ don't have to be functions.
 
-  - property: kernel pairs
-    proof: 'Let $X$ be a finite set with $n$ elements. Consider the relation $R : X \to \{*\}$ corresponding to the set $\{(x,*) : x \in X\}$ (which is even a map). Assume that it has a kernel pair $E \rightrightarrows X$. Then, in particular, the set $P(E) \cong \Hom(\{*\},E)$ is isomorphic to the set of pairs $(S_1,S_2) \in \Hom(\{*\},X)^2$ such that $R \circ S_1 = R \circ S_2$. A relation $\{*\} \to X$ corresponds to a subset of $X$, and its composition with $R$ corresponds to the image of that subset under $R$, which is either $\varnothing$ or $\{*\}$, depending on whether the subset is empty or not. Therefore, the set of pairs $(S_1,S_2)$ with $R \circ S_1 = R \circ S_2$ has exactly $1 + (2^n - 1) (2^n - 1)$ elements. For $n=2$, for example, this is equal to $10$, and therefore not a power of $2$. Thus, the set cannot be isomorphic to $P(E)$ for any set $E$.'
-
 special_objects:
   initial object:
     description: empty set

--- a/database/data/categories/walking_idempotent.yaml
+++ b/database/data/categories/walking_idempotent.yaml
@@ -44,9 +44,6 @@ unsatisfied_properties:
   - property: Cauchy complete
     proof: The idempotent $e$ does not split.
 
-  - property: kernel pairs
-    proof: Assume that $e$ has a kernel pair. Its underlying object must be $0$. Thus, there is a bijection between the morphisms $0 \to 0$ and the pairs of morphisms $0 \rightrightarrows 0$ that $e$ equalizes. But this holds for all pairs of morphisms. Counting these sets gives the contradiction $2 = 4$.
-
 special_objects: {}
 
 special_morphisms:

--- a/database/data/category-implications/pullbacks.yaml
+++ b/database/data/category-implications/pullbacks.yaml
@@ -97,3 +97,16 @@
   conclusions:
     - kernel pairs
   proof: This holds by definition.
+
+- id: kernel_pairs_coequalizers_implies_Cauchy-complete
+  assumptions:
+    - coequalizers of kernel pairs
+  conclusions:
+    - Cauchy complete
+  proof: >-
+    Let $e : X \to X$ be an idempotent morphism. By assumption, the kernel pair $p_1,p_2 : E \rightrightarrows X$ of $e$ exists, i.e. the universal pair satisfying $e \circ p_1 = e \circ p_2$, and it has a coequalizer $q : X \to Q$. The morphism $e : X \to X$ coequalizes $p_1,p_2$, so there is a morphism $i : Q \to X$ satisfying $e = i \circ q$.
+    It remains to prove that $q \circ i = \id_Q$. Since $q$ is an epimorphism, it suffices to prove that $q \circ i \circ q = q$, i.e. that $q \circ e = q$.
+
+    Because $e \circ e = e \circ \id_X$, the universal property of the kernel pair yields a (unique) morphism $f : X \to E$ with $p_1 \circ f = e$ and $p_2 \circ f = \id_X$. Since $q \circ p_1 = q \circ p_2$, we obtain
+    $$q \circ e = q \circ p_1 \circ f = q \circ p_2 \circ f = q,$$
+    finishing the proof.

--- a/database/data/category-implications/pullbacks.yaml
+++ b/database/data/category-implications/pullbacks.yaml
@@ -34,6 +34,13 @@
     - wide pullbacks
   proof: Each slice category has finite products and is essentially finite, hence has all products by <a href="/category-implication/freyd_finite">this result</a> followed by <a href="/category-implication/thin_finite_product_reduction">this result</a>.
 
+- id: pullback_implies_Cauchy_complete
+  assumptions:
+    - pullbacks
+  conclusions:
+    - Cauchy complete
+  proof: 'A direct proof is possible, but we give a more conceptual one. Suppose that $e : X \to X$ is an idempotent morphism in a category $\C$. It can be regarded as an idempotent morphism $e \to e$ in $\C / X$. If $\C$ has pullbacks, then the slice category $\C / X$ has pullbacks; in fact, the forgetful functor creates all connected limits. The slice category also has a terminal object, and hence is finitely complete. In particular, it has equalizers and is <a href="/category-implication/equalizers_consequence">therefore Cauchy complete</a>. Applying the forgetful functor $\C / X \to \C$ to a splitting of $e$ in $\C / X$ yields a splitting of $e$ in $\C$.'
+
 - id: kernel_pair_is_pullback
   assumptions:
     - pullbacks

--- a/database/data/category-implications/thin.yaml
+++ b/database/data/category-implications/thin.yaml
@@ -79,11 +79,12 @@
     - direct
   proof: See the <a href="https://ncatlab.org/nlab/show/direct+category#direct_versus_oneway_categories" target="_blank">nLab</a> for a proof.
 
-- id: one-way_implies_core-thin
+- id: one-way_consequences
   assumptions:
     - one-way
   conclusions:
     - core-thin
+    - Cauchy complete
   proof: This is trivial.
 
 - id: freyd_small


### PR DESCRIPTION
This PR adds three results on Cauchy complete categories.

- one-way ===> Cauchy complete
- pullbacks ===> Cauchy complete
- coequalizers of kernel pairs ===> Cauchy complete

These make it possible to remove some previous proofs for categories. They also imply that the **7** combinations from the page `/missing`

- one-way ∧ ¬Cauchy complete
- pullbacks ∧ ¬Cauchy complete
- locally cartesian closed ∧ ¬Cauchy complete
- pushouts ∧ ¬Cauchy complete
- locally cocartesian coclosed ∧ ¬Cauchy complete
- coequalizers of kernel pairs ∧ ¬Cauchy complete
- equalizers of cokernel pairs ∧ ¬Cauchy complete

are inconsistent, and therefore do not need any witnesses. They are removed from the list.

The number of consistent combinations without witnesses went down from **668** to **661**.