### PR TITLE
Add the discrete category of sets

### DIFF
--- a/database/data/categories/2.yaml
+++ b/database/data/categories/2.yaml
@@ -11,6 +11,7 @@ tags:
 
 related:
   - '1'
+  - Set_disc
 
 satisfied_properties:
   - property: discrete

--- a/database/data/categories/Set.yaml
+++ b/database/data/categories/Set.yaml
@@ -18,6 +18,7 @@ related:
   - SetxSet
   - Setne
   - Set_arrow
+  - Set_disc
 
 satisfied_properties:
   - property: locally small

--- a/database/data/categories/Set_disc.yaml
+++ b/database/data/categories/Set_disc.yaml
@@ -1,0 +1,30 @@
+id: Set_disc
+name: discrete category of sets
+notation: $\Set_{\disc}$
+objects: sets
+morphisms: only the identity morphisms
+description: This category provides an example of a large discrete category.
+nlab_link: null
+
+tags:
+  - set theory
+  - category theory
+
+related:
+  - '2'
+  - Set
+
+satisfied_properties:
+  - property: discrete
+    proof: This is trivial.
+
+  - property: inhabited
+    proof: This is trivial.
+
+unsatisfied_properties:
+  - property: essentially small
+    proof: This is obvious.
+
+special_objects: {}
+
+special_morphisms: {}

--- a/database/data/category-implications/discrete.yaml
+++ b/database/data/category-implications/discrete.yaml
@@ -46,3 +46,19 @@
   conclusions:
     - trivial
   proof: This is trivial.
+
+- id: discrete_multi_initial
+  assumptions:
+    - essentially discrete
+    - multi-initial object
+  conclusions:
+    - essentially small
+  proof: This is trivial.
+
+- id: discrete_accessible
+  assumptions:
+    - essentially discrete
+    - accessible
+  conclusions:
+    - essentially small
+  proof: This is trivial.

--- a/database/data/macros.yaml
+++ b/database/data/macros.yaml
@@ -63,6 +63,7 @@
 \Spec: \operatorname{Spec}
 \ord: \operatorname{ord}
 \diag: \operatorname{diag}
+\disc: \operatorname{disc}
 \Sub: \operatorname{Sub}
 \Quot: \operatorname{Quot}
 \supp: \operatorname{supp}


### PR DESCRIPTION
This PR adds the discrete category of sets. To decide its properties, two obvious results on discrete categories are added.

This category witnesses **48**  new combinations, bringing the number of missing combinations down from **643**  to **595**.

```
Found 48 unique witnessed combinations by the supplied structures (Set_disc):

Directly witnessed:
- discrete ∧ ¬accessible
- discrete ∧ ¬coaccessible
- discrete ∧ ¬countable
- discrete ∧ ¬essentially countable
- discrete ∧ ¬essentially finite
- discrete ∧ ¬essentially small
- discrete ∧ ¬finite
- discrete ∧ ¬finitely accessible
- discrete ∧ ¬generalized variety
- discrete ∧ ¬locally finitely multi-presentable
- discrete ∧ ¬locally multi-presentable
- discrete ∧ ¬locally poly-presentable
- discrete ∧ ¬multi-algebraic
- discrete ∧ ¬multi-cocomplete
- discrete ∧ ¬multi-complete
- discrete ∧ ¬multi-initial object
- discrete ∧ ¬multi-terminal object
- discrete ∧ ¬small
- discrete ∧ ¬ℵ₁-accessible
- essentially discrete ∧ ¬accessible
- essentially discrete ∧ ¬coaccessible
- essentially discrete ∧ ¬countable
- essentially discrete ∧ ¬essentially countable
- essentially discrete ∧ ¬essentially finite
- essentially discrete ∧ ¬essentially small
- essentially discrete ∧ ¬finite
- essentially discrete ∧ ¬finitely accessible
- essentially discrete ∧ ¬generalized variety
- essentially discrete ∧ ¬locally finitely multi-presentable
- essentially discrete ∧ ¬locally multi-presentable
- essentially discrete ∧ ¬locally poly-presentable
- essentially discrete ∧ ¬multi-algebraic
- essentially discrete ∧ ¬multi-cocomplete
- essentially discrete ∧ ¬multi-complete
- essentially discrete ∧ ¬multi-initial object
- essentially discrete ∧ ¬multi-terminal object
- essentially discrete ∧ ¬small
- essentially discrete ∧ ¬ℵ₁-accessible
- groupoid ∧ ¬accessible
- groupoid ∧ ¬coaccessible
- groupoid ∧ ¬essentially small
- groupoid ∧ ¬finitely accessible
- groupoid ∧ ¬generalized variety
- groupoid ∧ ¬locally poly-presentable
- groupoid ∧ ¬ℵ₁-accessible
- inverse ∧ ¬finitely accessible
- inverse ∧ ¬generalized variety
- inverse ∧ ¬ℵ₁-accessible
```