### PR TITLE
Preadditive categories are not assumed to be locally small

### DIFF
--- a/content/infinite-products-coproducts-additive-categories.md
+++ b/content/infinite-products-coproducts-additive-categories.md
@@ -1,0 +1,72 @@
+---
+title: Infinite products and coproducts in additive categories
+description: We prove that in an additive category, an infinite coproduct of copies of a non-zero object cannot be isomorphic to the corresponding infinite product.
+---
+
+# Infinite products and coproducts in additive categories
+
+In a category with zero morphisms, there is a canonical morphism $\bigoplus_{i \in I} X_i \to \prod_{i \in I} X_i$ whenever the coproduct and product exist. In most categories, if $I$ is infinite and the objects $X_i$ are non-zero, this morphism is not an isomorphism. The following result generalizes this observation.
+
+::: Proposition
+Let $\C$ be an additive category with countable powers and countable copowers. Let $A \in \C$ be an object such that the canonical morphism
+$$\textstyle \alpha : \bigoplus_{n \geq 1} A \to \prod_{n \geq 1} A$$
+is an isomorphism. Then $A = 0$.
+:::
+
+::: Proof
+Define the diagonal morphism
+$$\textstyle \Delta : A \to \prod_{n \geq 1} A$$
+by $p_n \circ \Delta = \id_A$, and the codiagonal morphism
+$$\textstyle \nabla : \bigoplus_{n \geq 1} A \to A$$
+by $\nabla \circ i_n = \id_A$ for all $n \geq 1$. Define the endomorphism $x \in \End(A)$ by
+$$x \coloneqq \nabla \circ \alpha^{-1} \circ \Delta.$$
+
+Using the decompositions
+$$\textstyle \bigoplus_{n \geq 1} A \cong A \oplus \bigoplus_{n \geq 2} A,$$
+$$\textstyle \prod_{n \geq 1} A \cong A \oplus \prod_{n \geq 2} A,$$
+the morphisms $\alpha$, $\Delta$, and $\nabla$ have the following block matrix forms:
+
+- $\alpha = \begin{pmatrix} \id_A & 0 \\ 0 & \alpha' \end{pmatrix}$, where $\alpha' : \bigoplus_{n \geq 2} A \to \prod_{n \geq 2} A$ is the canonical morphism.
+- $\Delta = \begin{pmatrix} \id_A \\ \Delta' \end{pmatrix}$, where $\Delta' : A \to \prod_{n \geq 2} A$ is the diagonal morphism.
+- $\nabla = \begin{pmatrix} \id_A & \nabla' \end{pmatrix}$, where $\nabla' : \bigoplus_{n \geq 2} A \to A$ is the codiagonal morphism.
+
+Since $\alpha$ is an isomorphism, $\alpha'$ is an isomorphism as well. We compute:
+
+$$
+\begin{align*}
+x & = \nabla \circ \alpha^{-1} \circ \Delta \\
+& = \begin{pmatrix} \id_A & \nabla' \end{pmatrix} \circ \begin{pmatrix} \id_A & 0 \\ 0 & \alpha'^{-1} \end{pmatrix} \circ \begin{pmatrix} \id_A \\ \Delta' \end{pmatrix} \\
+& = \begin{pmatrix} \id_A & \nabla' \end{pmatrix} \circ \begin{pmatrix} \id_A \\ \alpha'^{-1} \circ \Delta' \end{pmatrix} \\
+& = {\id_A} \,+\, \nabla' \circ \alpha'^{-1} \circ \Delta'.
+\end{align*}
+$$
+
+Now define the isomorphism
+$$\textstyle \sigma : \bigoplus_{n \geq 1} A \to \bigoplus_{n \geq 2} A$$
+by $\sigma \circ i_n = i_{n+1}$ for $n \geq 1$. Likewise, define the isomorphism
+$$\textstyle \tau : \prod_{n \geq 1} A \to \prod_{n \geq 2} A$$
+by $p_n \circ \tau = p_{n-1}$ for $n \geq 2$.
+
+By the definitions of $\alpha'$, $\Delta'$, and $\nabla'$, we have
+
+$$
+\begin{align*}
+\alpha' & = \tau \circ \alpha \circ \sigma^{-1}, \\
+\Delta' & = \tau \circ \Delta, \\
+\nabla' & = \nabla \circ \sigma^{-1}.
+\end{align*}
+$$
+
+Therefore,
+
+$$
+\begin{align*}
+\nabla' \circ \alpha'^{-1} \circ \Delta' & = \nabla \circ \sigma^{-1} \circ (\tau \circ \alpha \circ \sigma^{-1})^{-1} \circ \tau \circ \Delta \\
+& = \nabla \circ \sigma^{-1} \circ \sigma \circ \alpha^{-1} \circ \tau^{-1} \circ \tau \circ \Delta \\
+& = \nabla \circ \alpha^{-1} \circ \Delta \\
+& = x.
+\end{align*}
+$$
+
+Thus $x = \id_A + x$, and hence $\id_A = 0$. Therefore $A = 0$.
+:::

--- a/database/data/categories/Sh(X,Ab).yaml
+++ b/database/data/categories/Sh(X,Ab).yaml
@@ -16,7 +16,7 @@ related:
 
 comments:
   # TODO: maybe create separate entries for specific spaces X
-  - It is likely that neither of the currently remaining unknown properties (finitary algebraic, locally finitely presentable, CSP, etc.) are satisfied for a <i>generic</i> space $X$, but we need to make this precise by adding additional requirements to $X$. Maybe we need to create separate entries for specific spaces $X$.
+  - It is likely that neither of the currently remaining unknown properties (finitary algebraic, locally finitely presentable, etc.) are satisfied for a <i>generic</i> space $X$, but we need to make this precise by adding additional requirements to $X$. Maybe we need to create separate entries for specific spaces $X$.
 
 satisfied_properties:
   - property: locally small

--- a/database/data/categories/TorsAb.yaml
+++ b/database/data/categories/TorsAb.yaml
@@ -45,9 +45,6 @@ unsatisfied_properties:
   - property: split abelian
     proof: The sequence $0 \to \IZ/2 \to \IZ/4 \to \IZ/2 \to 0$ does not split.
 
-  - property: CSP
-    proof: The canonical homomorphism $\bigoplus_{n \geq 0} \IZ/2 \to T(\prod_{n \geq 0} \IZ/2)$ is not surjective, since the torsion element $(1,1,\dotsc)$ does not lie in the image. Hence, it is no epimorphism.
-
   - property: finitary algebraic
     proof: >-
       Assume that it is the category of models of a many-sorted finitary algebraic theory. For each sort $s$ let $F_s$ be the free algebra on one generator of sort $s$. One of them must be non-trivial, since otherwise the category would be thin. So assume $F_s \neq 0$. It is finitely presentable, hence a finite abelian group, and regular projective. Any direct summand will have the same properties. So we find that some $\IZ/p^k$ (with $k \geq 1$ and $p$ prime) is regular projective. However, the exact sequence in $\TorsAb$

--- a/database/data/category-implications/accessible.yaml
+++ b/database/data/category-implications/accessible.yaml
@@ -105,9 +105,13 @@
 - id: grothendieck_abelian_presentable
   assumptions:
     - Grothendieck abelian
+    - locally essentially small
   conclusions:
     - locally presentable
-  proof: See <a href="https://arxiv.org/abs/1409.7051" target="_blank">Deriving Auslander's formula</a>, Cor. 5.2, or <a href="https://arxiv.org/abs/math/0102087" target="_blank">Sheafifiable homotopy model categories</a>, Prop. 3.10.
+  proof: >-
+    See <a href="https://arxiv.org/abs/1409.7051" target="_blank">Deriving Auslander's formula</a>, Cor. 5.2, or <a href="https://arxiv.org/abs/math/0102087" target="_blank">Sheafifiable homotopy model categories</a>, Prop. 3.10.
+
+    Remark: The assumption that the category is locally essentially small is necessary (and is implicit in most of the literature), as the example $[\Set_{\disc},\Ab]$ shows.
 
 - id: algebraic_implies_lfp
   assumptions:

--- a/database/data/category-implications/additive.yaml
+++ b/database/data/category-implications/additive.yaml
@@ -64,9 +64,13 @@
 - id: grothendieck_abelian_cogenerator
   assumptions:
     - Grothendieck abelian
+    - locally essentially small
   conclusions:
     - cogenerator
-  proof: See <a href="https://ncatlab.org/nlab/show/Categories+and+Sheaves" target="_blank">Kashiwara-Schapira</a>, Thm. 9.6.3.
+  proof: >-
+    See <a href="https://ncatlab.org/nlab/show/Categories+and+Sheaves" target="_blank">Kashiwara-Schapira</a>, Thm. 9.6.3.
+
+    Remark: The assumption that the category is locally essentially small is necessary (and is implicit in most of the literature), as the example $[\On,\Ab]$ shows.
 
 - id: grothendieck_abelian_self-dual
   assumptions:

--- a/database/data/category-implications/additive.yaml
+++ b/database/data/category-implications/additive.yaml
@@ -72,13 +72,23 @@
 
     Remark: The assumption that the category is locally essentially small is necessary (and is implicit in most of the literature), as the example $[\On,\Ab]$ shows.
 
-- id: grothendieck_abelian_self-dual
+- id: additive_CIP_CSP
   assumptions:
-    - Grothendieck abelian
-    - self-dual
+    - additive
+    - balanced
+    - CIP
+    - CSP
   conclusions:
     - trivial
-  proof: This follows since the dual of a non-trivial Grothendieck abelian category cannot be Grothendieck abelian. See Peter Freyd, <i>Abelian categories</i>, p. 116.
+  proof: >-
+    We work in a balanced additive category with products and coproducts such that, for every family of objects $(X_i)$, the canonical morphism
+    $$\textstyle \alpha : \coprod_i X_i \to \prod_{i \in I} X_i$$
+    is a monomorphism and an epimorphism, and therefore an isomorphism. In particular, for every object $A$ the canonical morphism
+    $$\textstyle \alpha : \coprod_{n \geq 1} A \to \prod_{n \geq 1} A$$
+    is an isomorphism. By <a href="/content/infinite-products-coproducts-additive-categories">this proposition</a>, this implies that $A = 0$.
+
+
+    Remark: This result strengthens the well-known theorem (and is inspired by it) stating that the dual of a Grothendieck abelian category can only be Grothendieck abelian when it is trivial, which appears as exercise B on p. 116 in Freyd's book <i>Abelian categories</i>. This follows from the result we have just proved since a Grothendieck abelian category with products is additive, balanced, and satisfies CIP (by <a href="/category-implication/CIP_criterion">this result</a>).
 
 - id: split_abelian_condition
   assumptions:

--- a/database/data/category-implications/additive.yaml
+++ b/database/data/category-implications/additive.yaml
@@ -4,7 +4,6 @@
   assumptions:
     - preadditive
   conclusions:
-    - locally essentially small
     - zero morphisms
   proof: This is trivial.
 

--- a/database/data/category-implications/mono-regular.yaml
+++ b/database/data/category-implications/mono-regular.yaml
@@ -27,4 +27,4 @@
     - preadditive
   conclusions:
     - normal
-  proof: The a monomorphism is the equalizer of $f,g$, it is the kernel of $f-g$.
+  proof: If a monomorphism is the equalizer of $f,g$, it is the kernel of $f-g$.

--- a/database/data/category-properties/additive.yaml
+++ b/database/data/category-properties/additive.yaml
@@ -10,6 +10,8 @@ related:
   - finite coproducts
   - finite products
   - preadditive
+  - zero morphisms
+  - abelian
 
 tags:
   - morphism behavior

--- a/database/data/category-properties/preadditive.yaml
+++ b/database/data/category-properties/preadditive.yaml
@@ -9,6 +9,7 @@ invariant_under_equivalences: true
 
 related:
   - additive
+  - zero morphisms
 
 tags:
   - morphism behavior

--- a/database/data/category-properties/preadditive.yaml
+++ b/database/data/category-properties/preadditive.yaml
@@ -1,8 +1,12 @@
 id: preadditive
 relation: is
-description: |-
-  A category is <i>preadditive</i> when it is locally essentially small* and each hom-set carries the structure of an abelian group such that the composition is bilinear. Notice that "preadditive" is an extra structure. The property here just says that some preadditive structure exists.
-  *We demand this instead of the more common "locally small" to ensure that preadditive categories are invariant under equivalences of categories.
+description: >-
+  A category is <i>preadditive</i> if, for every pair of objects $A,B$, the collection of morphisms $\Hom(A,B)$ is equipped with the structure of an abelian group such that composition is bilinear:
+  $$\begin{align*}
+  f \circ (g + h) &= f \circ g + f \circ h \\
+  (f + g) \circ h &= f \circ h + g \circ h.
+  \end{align*}$$
+  Note that being preadditive is an extra structure. The property here merely says that a preadditive structure exists. Furthermore, since categories are not assumed to be locally small (see <a href="/content/foundations">Foundations</a>), the abelian group $\Hom(A,B)$ is not necessarily a set. In contrast, a locally small preadditive category is precisely an $(\Ab,\otimes)$-enriched category.
 nlab_link: https://ncatlab.org/nlab/show/Ab-enriched+category
 dual: preadditive
 invariant_under_equivalences: true

--- a/database/data/category-properties/zero morphisms.yaml
+++ b/database/data/category-properties/zero morphisms.yaml
@@ -7,6 +7,7 @@ invariant_under_equivalences: true
 
 related:
   - pointed
+  - additive
   - preadditive
 
 tags:


### PR DESCRIPTION
Before this PR, preadditive categories were assumed to be locally small, or rather locally essentially small so that the property would be invariant under equivalences. This is not natural, however, since our categories are not locally essentially small by default. It also leads to the awkward situation that a functor category $[C,Ab]$ is not necessarily preadditive (an example I was about to add to the database), let alone abelian, since this may depend on the size of $C$.

Hence, the definition has been changed. A preadditive category now has hom-collections equipped with structures of (possibly large) abelian groups. Of course, if we want to talk about $Ab$-enriched categories, we can simply combine the two properties `locally small` and `preadditive`.

Luckily, this did not remove any of the properties of the recorded categories. This is because preadditivity previously only required local essential smallness, and all recorded preadditive categories already had a manual assignment stating that they are locally small. (The next PR will add examples of abelian categories that are not locally small.)

However, we need to check whether all implications involving preadditive categories and related notions remain valid. Of course, `preadditive ==> locally essentially small` needs to be removed. The implications involving the property `abelian` seem to be OK. However, two implications concerning Grothendieck abelian categories needed to be adjusted:

1. A Grothendieck abelian category (with the new convention that it is not necessarily locally essentially small) need not be locally presentable. A counterexample is $[Set_{\mathrm{disc}}, Ab]$, which will be added in a future PR. However, a locally essentially small Grothendieck abelian category is locally presentable.

2. A Grothendieck abelian category need not have a cogenerator. A counterexample is $[On,Ab]$, which will be added in a future PR. However, a locally essentially small Grothendieck abelian category has a cogenerator.

In this context, the result that a self-dual Grothendieck abelian category is trivial has been double-checked to ensure that its proof does not require local smallness. In fact, the result has been drastically strengthened as follows: an additive balanced category satisfying CSP and CIP is trivial. More precisely, if an object $A$ in an additive category with products and coproducts has the property that the canonical morphism $\bigoplus_n A \to \prod_n A$ is an isomorphism, then $A = 0$. A full proof is given as well. Previously, this was just a reference to an exercise in Freyd's book.

As a nice byproduct, three properties of the category of abelian sheaves $Sh(X,Ab)$ have been proved automatically: CSP is not satisfied, and hence neither exact cofiltered limits nor cofiltered-limit-stable epimorphisms hold. The number of unknown (category, property)-pairs went down from **75** to **72**.

But another number went up, unfortunately – the one I want to reduce in the context of [this milestone](https://github.com/ScriptRaccoon/CatDat/milestone/1). The number of consistent yet unwitnessed property combinations went up from **595** to **631**. The **36** new combinations are:

```
abelian ∧ ¬locally essentially small
additive ∧ ¬locally essentially small
Grothendieck abelian ∧ ¬accessible
Grothendieck abelian ∧ ¬CIP
Grothendieck abelian ∧ ¬cocartesian cofiltered limits
Grothendieck abelian ∧ ¬cofiltered limits
Grothendieck abelian ∧ ¬cogenerating set
Grothendieck abelian ∧ ¬cogenerator
Grothendieck abelian ∧ ¬complete
Grothendieck abelian ∧ ¬concretizable
Grothendieck abelian ∧ ¬connected limits
Grothendieck abelian ∧ ¬cosifted limits
Grothendieck abelian ∧ ¬cototal
Grothendieck abelian ∧ ¬countable powers
Grothendieck abelian ∧ ¬countable products
Grothendieck abelian ∧ ¬directed limits
Grothendieck abelian ∧ ¬disjoint products
Grothendieck abelian ∧ ¬extremal cogenerating set
Grothendieck abelian ∧ ¬extremal cogenerator
Grothendieck abelian ∧ ¬locally essentially small
Grothendieck abelian ∧ ¬locally multi-presentable
Grothendieck abelian ∧ ¬locally poly-presentable
Grothendieck abelian ∧ ¬locally presentable
Grothendieck abelian ∧ ¬multi-complete
Grothendieck abelian ∧ ¬powers
Grothendieck abelian ∧ ¬products
Grothendieck abelian ∧ ¬sequential limits
Grothendieck abelian ∧ ¬total
Grothendieck abelian ∧ ¬well-copowered
Grothendieck abelian ∧ ¬well-powered
Grothendieck abelian ∧ ¬wide pullbacks
Grothendieck abelian ∧ ¬ℵ₁-cofiltered limits
Grothendieck abelian ∧ ¬ℵ₂-small powers
Grothendieck abelian ∧ ¬ℵ₂-small products
preadditive ∧ ¬locally essentially small
split abelian ∧ ¬locally essentially small
```

It is a bit awkward that a Grothendieck abelian category (which is not locally essentially small) does not necessarily have products (I think I know a counterexample). Basically, all non-trivial results about Grothendieck abelian categories seem to require local essential smallness. Still, I do not think that this property should be built into the definition.